### PR TITLE
feat: add disable org on creation flag and disallow removing of last admin from the org/group

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -260,7 +260,7 @@ func buildAPIDependencies(
 	)
 
 	organizationRepository := postgres.NewOrganizationRepository(dbc)
-	organizationService := organization.NewService(organizationRepository, relationService, userService, authnService)
+	organizationService := organization.NewService(organizationRepository, relationService, userService, authnService, cfg.App.OrgDisableOnCreation)
 
 	domainRepository := postgres.NewDomainRepository(logger, dbc)
 	domainService := domain.NewService(logger, domainRepository, userService, organizationService)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -260,7 +260,7 @@ func buildAPIDependencies(
 	)
 
 	organizationRepository := postgres.NewOrganizationRepository(dbc)
-	organizationService := organization.NewService(organizationRepository, relationService, userService, authnService, cfg.App.DisableOrgsOnCreation)
+	organizationService := organization.NewService(organizationRepository, relationService, userService, authnService, cfg.App.DisableOrgsOnCreate)
 
 	domainRepository := postgres.NewDomainRepository(logger, dbc)
 	domainService := domain.NewService(logger, domainRepository, userService, organizationService)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -260,7 +260,7 @@ func buildAPIDependencies(
 	)
 
 	organizationRepository := postgres.NewOrganizationRepository(dbc)
-	organizationService := organization.NewService(organizationRepository, relationService, userService, authnService, cfg.App.OrgDisableOnCreation)
+	organizationService := organization.NewService(organizationRepository, relationService, userService, authnService, cfg.App.DisableOrgsOnCreation)
 
 	domainRepository := postgres.NewDomainRepository(logger, dbc)
 	domainService := domain.NewService(logger, domainRepository, userService, organizationService)

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -29,6 +29,9 @@ app:
   # secret string "val://user:password"
   # optional
   resources_config_path_secret: env://TEST_RESOURCE_CONFIG_SECRET
+  # org_disable_on_creation if set to true will set the org status to disabled on creation. This can be used to
+  # prevent users from accessing the org until they contact the admin and get it enabled. Default is false
+  org_disable_on_creation: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all organizations
   disable_orgs_listing: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all users

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -29,9 +29,9 @@ app:
   # secret string "val://user:password"
   # optional
   resources_config_path_secret: env://TEST_RESOURCE_CONFIG_SECRET
-  # org_disable_on_creation if set to true will set the org status to disabled on creation. This can be used to
+  # disable_orgs_on_create if set to true will set the org status to disabled on creation. This can be used to
   # prevent users from accessing the org until they contact the admin and get it enabled. Default is false
-  org_disable_on_creation: false
+  disable_orgs_on_create: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all organizations
   disable_orgs_listing: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all users

--- a/core/organization/errors.go
+++ b/core/organization/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrInvalidID     = errors.New("org id is invalid")
 	ErrConflict      = errors.New("org already exist")
 	ErrInvalidDetail = errors.New("invalid org detail")
+	ErrDisabled      = errors.New("org is disabled")
 )

--- a/core/organization/service.go
+++ b/core/organization/service.go
@@ -37,9 +37,9 @@ type Service struct {
 }
 
 func NewService(repository Repository, relationService RelationService,
-	userService UserService, authnService AuthnService, orgDisableOnCreation bool) *Service {
+	userService UserService, authnService AuthnService, disableOrgsOnCreate bool) *Service {
 	defaultState := Enabled
-	if orgDisableOnCreation {
+	if disableOrgsOnCreate {
 		defaultState = Disabled
 	}
 	return &Service{

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -68,6 +68,9 @@ app:
   # secret string "val://user:password"
   # optional
   resources_config_path_secret: env://TEST_RESOURCE_CONFIG_SECRET
+  # org_disable_on_creation if set to true will set the org status to disabled on creation. This can be used to
+  # prevent users from accessing the org until they contact the admin and get it enabled. Default is false
+  org_disable_on_creation: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all organizations
   disable_orgs_listing: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all users

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -68,9 +68,9 @@ app:
   # secret string "val://user:password"
   # optional
   resources_config_path_secret: env://TEST_RESOURCE_CONFIG_SECRET
-  # org_disable_on_creation if set to true will set the org status to disabled on creation. This can be used to
+  # disable_orgs_on_create if set to true will set the org status to disabled on creation. This can be used to
   # prevent users from accessing the org until they contact the admin and get it enabled. Default is false
-  org_disable_on_creation: false
+  disable_orgs_on_create: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all organizations
   disable_orgs_listing: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all users

--- a/docs/docs/reference/configurations.md
+++ b/docs/docs/reference/configurations.md
@@ -35,6 +35,9 @@ app:
   # secret string "val://user:password"
   # optional
   resources_config_path_secret: env://TEST_RESOURCE_CONFIG_SECRET
+  # org_disable_on_creation if set to true will set the org status to disabled on creation. This can be used to
+  # prevent users from accessing the org until they contact the admin and get it enabled. Default is false
+  org_disable_on_creation: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all organizations
   disable_orgs_listing: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all users

--- a/docs/docs/reference/configurations.md
+++ b/docs/docs/reference/configurations.md
@@ -35,9 +35,9 @@ app:
   # secret string "val://user:password"
   # optional
   resources_config_path_secret: env://TEST_RESOURCE_CONFIG_SECRET
-  # org_disable_on_creation if set to true will set the org status to disabled on creation. This can be used to
+  # disable_orgs_on_create if set to true will set the org status to disabled on creation. This can be used to
   # prevent users from accessing the org until they contact the admin and get it enabled. Default is false
-  org_disable_on_creation: false
+  disable_orgs_on_create: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all organizations
   disable_orgs_listing: false
   # disable_orgs_listing if set to true will disallow non-admin APIs to list all users

--- a/internal/api/v1beta1/domain.go
+++ b/internal/api/v1beta1/domain.go
@@ -6,6 +6,7 @@ import (
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/raystack/frontier/core/domain"
 	"github.com/raystack/frontier/core/organization"
+	"github.com/raystack/frontier/pkg/errors"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -32,20 +33,27 @@ type DomainService interface {
 
 func (h Handler) CreateOrganizationDomain(ctx context.Context, request *frontierv1beta1.CreateOrganizationDomainRequest) (*frontierv1beta1.CreateOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-
-	if request.GetOrgId() == "" || request.GetDomain() == "" {
-		return nil, grpcBadBodyError
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+	if orgResp.State == organization.Disabled {
+		return nil, grpcOrgDisabledErr
 	}
 
 	dmn, err := h.domainService.Create(ctx, domain.Domain{
-		OrgID: request.GetOrgId(),
+		OrgID: orgResp.ID,
 		Name:  request.GetDomain(),
 	})
 	if err != nil {
 		logger.Error(err.Error())
 		switch err {
-		case organization.ErrNotExist:
-			return nil, grpcOrgNotFoundErr
 		case domain.ErrDuplicateKey:
 			return nil, grpcDomainAlreadyExistsErr
 		default:
@@ -59,16 +67,23 @@ func (h Handler) CreateOrganizationDomain(ctx context.Context, request *frontier
 
 func (h Handler) DeleteOrganizationDomain(ctx context.Context, request *frontierv1beta1.DeleteOrganizationDomainRequest) (*frontierv1beta1.DeleteOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-
-	if request.GetId() == "" || request.GetOrgId() == "" {
-		return nil, grpcBadBodyError
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+	if orgResp.State == organization.Disabled {
+		return nil, grpcOrgDisabledErr
 	}
 
 	if err := h.domainService.Delete(ctx, request.GetId()); err != nil {
 		logger.Error(err.Error())
 		switch err {
-		case organization.ErrNotExist:
-			return nil, grpcOrgNotFoundErr
 		case domain.ErrNotExist:
 			return nil, grpcDomainNotFoundErr
 		default:
@@ -81,9 +96,18 @@ func (h Handler) DeleteOrganizationDomain(ctx context.Context, request *frontier
 
 func (h Handler) GetOrganizationDomain(ctx context.Context, request *frontierv1beta1.GetOrganizationDomainRequest) (*frontierv1beta1.GetOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-
-	if request.GetId() == "" || request.GetOrgId() == "" {
-		return nil, grpcBadBodyError
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+	if orgResp.State == organization.Disabled {
+		return nil, grpcOrgDisabledErr
 	}
 
 	domainResp, err := h.domainService.Get(ctx, request.GetId())
@@ -103,9 +127,18 @@ func (h Handler) GetOrganizationDomain(ctx context.Context, request *frontierv1b
 
 func (h Handler) JoinOrganization(ctx context.Context, request *frontierv1beta1.JoinOrganizationRequest) (*frontierv1beta1.JoinOrganizationResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgId := request.GetOrgId()
-	if orgId == "" {
-		return nil, grpcBadBodyError
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+	if orgResp.State == organization.Disabled {
+		return nil, grpcOrgDisabledErr
 	}
 
 	// get current user
@@ -115,11 +148,9 @@ func (h Handler) JoinOrganization(ctx context.Context, request *frontierv1beta1.
 		return nil, grpcInternalServerError
 	}
 
-	if err := h.domainService.Join(ctx, orgId, principal.ID); err != nil {
+	if err := h.domainService.Join(ctx, orgResp.ID, principal.ID); err != nil {
 		logger.Error(err.Error())
 		switch err {
-		case organization.ErrNotExist:
-			return nil, grpcOrgNotFoundErr
 		case domain.ErrDomainsMisMatch:
 			return nil, grpcDomainMisMatchErr
 		default:
@@ -132,9 +163,18 @@ func (h Handler) JoinOrganization(ctx context.Context, request *frontierv1beta1.
 
 func (h Handler) VerifyOrganizationDomain(ctx context.Context, request *frontierv1beta1.VerifyOrganizationDomainRequest) (*frontierv1beta1.VerifyOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-
-	if request.GetId() == "" || request.GetOrgId() == "" {
-		return nil, grpcBadBodyError
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+	if orgResp.State == organization.Disabled {
+		return nil, grpcOrgDisabledErr
 	}
 
 	domainResp, err := h.domainService.VerifyDomain(ctx, request.GetId())
@@ -157,12 +197,21 @@ func (h Handler) VerifyOrganizationDomain(ctx context.Context, request *frontier
 
 func (h Handler) ListOrganizationDomains(ctx context.Context, request *frontierv1beta1.ListOrganizationDomainsRequest) (*frontierv1beta1.ListOrganizationDomainsResponse, error) {
 	logger := grpczap.Extract(ctx)
-
-	if request.GetOrgId() == "" {
-		return nil, grpcBadBodyError
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+	if orgResp.State == organization.Disabled {
+		return nil, grpcOrgDisabledErr
 	}
 
-	domains, err := h.domainService.List(ctx, domain.Filter{OrgID: request.GetOrgId(), State: domain.Status(request.GetState())})
+	domains, err := h.domainService.List(ctx, domain.Filter{OrgID: orgResp.ID, State: domain.Status(request.GetState())})
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError

--- a/internal/api/v1beta1/domain.go
+++ b/internal/api/v1beta1/domain.go
@@ -37,14 +37,13 @@ func (h Handler) CreateOrganizationDomain(ctx context.Context, request *frontier
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	dmn, err := h.domainService.Create(ctx, domain.Domain{
@@ -67,18 +66,17 @@ func (h Handler) CreateOrganizationDomain(ctx context.Context, request *frontier
 
 func (h Handler) DeleteOrganizationDomain(ctx context.Context, request *frontierv1beta1.DeleteOrganizationDomainRequest) (*frontierv1beta1.DeleteOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	if err := h.domainService.Delete(ctx, request.GetId()); err != nil {
@@ -96,18 +94,17 @@ func (h Handler) DeleteOrganizationDomain(ctx context.Context, request *frontier
 
 func (h Handler) GetOrganizationDomain(ctx context.Context, request *frontierv1beta1.GetOrganizationDomainRequest) (*frontierv1beta1.GetOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	domainResp, err := h.domainService.Get(ctx, request.GetId())
@@ -131,14 +128,13 @@ func (h Handler) JoinOrganization(ctx context.Context, request *frontierv1beta1.
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	// get current user
@@ -163,18 +159,17 @@ func (h Handler) JoinOrganization(ctx context.Context, request *frontierv1beta1.
 
 func (h Handler) VerifyOrganizationDomain(ctx context.Context, request *frontierv1beta1.VerifyOrganizationDomainRequest) (*frontierv1beta1.VerifyOrganizationDomainResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	domainResp, err := h.domainService.VerifyDomain(ctx, request.GetId())
@@ -201,14 +196,13 @@ func (h Handler) ListOrganizationDomains(ctx context.Context, request *frontierv
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	domains, err := h.domainService.List(ctx, domain.Filter{OrgID: orgResp.ID, State: domain.Status(request.GetState())})

--- a/internal/api/v1beta1/domain_test.go
+++ b/internal/api/v1beta1/domain_test.go
@@ -74,7 +74,7 @@ func TestHandler_CreateOrganizationDomain(t *testing.T) {
 		{
 			name: "should return error when org is disabled",
 			setup: func(os *mocks.OrganizationService, ds *mocks.DomainService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{State: organization.Disabled}, nil)
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.CreateOrganizationDomainRequest{
 				OrgId:  testOrgID,
@@ -160,7 +160,7 @@ func TestHandler_DeleteOrganizationDomain(t *testing.T) {
 		{
 			name: "should return error when org is disabled",
 			setup: func(os *mocks.OrganizationService, ds *mocks.DomainService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{State: organization.Disabled}, nil)
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.DeleteOrganizationDomainRequest{
 				OrgId: testOrgID,
@@ -237,7 +237,7 @@ func TestHandler_GetOrganizationDomain(t *testing.T) {
 		{
 			name: "should return error when org is disabled",
 			setup: func(os *mocks.OrganizationService, ds *mocks.DomainService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{State: organization.Disabled}, nil)
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.GetOrganizationDomainRequest{
 				OrgId: testOrgID,
@@ -315,7 +315,7 @@ func TestHandler_JoinOrganization(t *testing.T) {
 		{
 			name: "should return error when org is disabled",
 			setup: func(os *mocks.OrganizationService, ds *mocks.DomainService, us *mocks.AuthnService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{State: organization.Disabled}, nil)
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.JoinOrganizationRequest{
 				OrgId: testOrgID,
@@ -404,7 +404,7 @@ func TestHandler_ListOrganizationDomains(t *testing.T) {
 		{
 			name: "should return error when org is disabled",
 			setup: func(os *mocks.OrganizationService, ds *mocks.DomainService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{State: organization.Disabled}, nil)
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.ListOrganizationDomainsRequest{
 				OrgId: testOrgID,
@@ -470,7 +470,7 @@ func TestHandler_VerifyOrganizationDomain(t *testing.T) {
 		{
 			name: "should return error when org is disabled",
 			setup: func(os *mocks.OrganizationService, ds *mocks.DomainService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{State: organization.Disabled}, nil)
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.VerifyOrganizationDomainRequest{
 				OrgId: testOrgID,

--- a/internal/api/v1beta1/group.go
+++ b/internal/api/v1beta1/group.go
@@ -39,7 +39,7 @@ type GroupService interface {
 
 var (
 	grpcGroupNotFoundErr = status.Errorf(codes.NotFound, "group doesn't exist")
-	grpcMinOwnerCounrErr = status.Errorf(codes.InvalidArgument, "group must have at least one owner. Please add another owner before removing this one")
+	grpcMinOwnerCounrErr = status.Errorf(codes.InvalidArgument, "group must have at least one owner, consider adding another owner before removing")
 )
 
 func (h Handler) ListGroups(ctx context.Context, request *frontierv1beta1.ListGroupsRequest) (*frontierv1beta1.ListGroupsResponse, error) {

--- a/internal/api/v1beta1/group.go
+++ b/internal/api/v1beta1/group.go
@@ -340,12 +340,12 @@ func (h Handler) RemoveGroupUser(ctx context.Context, request *frontierv1beta1.R
 		}
 	}
 
-	owners, err := h.userService.ListByGroup(ctx, request.GetId(), schema.OwnerRelationName)
+	owners, err := h.userService.ListByGroup(ctx, request.GetId(), schema.DeletePermission)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
 	}
-	if len(owners) == 1 {
+	if len(owners) == 1 && owners[0].ID == request.GetUserId() {
 		return nil, grpcMinOwnerCounrErr
 	}
 

--- a/internal/api/v1beta1/group.go
+++ b/internal/api/v1beta1/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/raystack/frontier/core/audit"
+	"github.com/raystack/frontier/internal/bootstrap/schema"
 
 	"github.com/raystack/frontier/pkg/str"
 
@@ -38,6 +39,7 @@ type GroupService interface {
 
 var (
 	grpcGroupNotFoundErr = status.Errorf(codes.NotFound, "group doesn't exist")
+	grpcMinOwnerCounrErr = status.Errorf(codes.InvalidArgument, "group must have at least one owner. Please add another owner before removing this one")
 )
 
 func (h Handler) ListGroups(ctx context.Context, request *frontierv1beta1.ListGroupsRequest) (*frontierv1beta1.ListGroupsResponse, error) {
@@ -68,10 +70,22 @@ func (h Handler) ListGroups(ctx context.Context, request *frontierv1beta1.ListGr
 
 func (h Handler) ListOrganizationGroups(ctx context.Context, request *frontierv1beta1.ListOrganizationGroupsRequest) (*frontierv1beta1.ListOrganizationGroupsResponse, error) {
 	logger := grpczap.Extract(ctx)
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
 
 	var groups []*frontierv1beta1.Group
 	groupList, err := h.groupService.List(ctx, group.Filter{
-		OrganizationID: request.GetOrgId(),
+		OrganizationID: orgResp.ID,
 		State:          group.State(request.GetState()),
 	})
 	if err != nil {
@@ -97,6 +111,18 @@ func (h Handler) CreateGroup(ctx context.Context, request *frontierv1beta1.Creat
 	if request.GetBody() == nil {
 		return nil, grpcBadBodyError
 	}
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
 
 	metaDataMap := metadata.Build(request.GetBody().GetMetadata().AsMap())
 
@@ -112,7 +138,7 @@ func (h Handler) CreateGroup(ctx context.Context, request *frontierv1beta1.Creat
 	newGroup, err := h.groupService.Create(ctx, group.Group{
 		Name:           request.GetBody().GetName(),
 		Title:          request.GetBody().GetTitle(),
-		OrganizationID: request.GetOrgId(),
+		OrganizationID: orgResp.ID,
 		Metadata:       metaDataMap,
 	})
 	if err != nil {
@@ -148,6 +174,18 @@ func (h Handler) CreateGroup(ctx context.Context, request *frontierv1beta1.Creat
 
 func (h Handler) GetGroup(ctx context.Context, request *frontierv1beta1.GetGroupRequest) (*frontierv1beta1.GetGroupResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
 
 	fetchedGroup, err := h.groupService.Get(ctx, request.GetId())
 	if err != nil {
@@ -175,6 +213,18 @@ func (h Handler) UpdateGroup(ctx context.Context, request *frontierv1beta1.Updat
 	if request.GetBody() == nil {
 		return nil, grpcBadBodyError
 	}
+	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
 
 	metaDataMap := metadata.Build(request.GetBody().GetMetadata().AsMap())
 
@@ -187,7 +237,7 @@ func (h Handler) UpdateGroup(ctx context.Context, request *frontierv1beta1.Updat
 		ID:             request.GetId(),
 		Name:           request.GetBody().GetName(),
 		Title:          request.GetBody().GetTitle(),
-		OrganizationID: request.GetOrgId(),
+		OrganizationID: orgResp.ID,
 		Metadata:       metaDataMap,
 	})
 	if err != nil {
@@ -213,12 +263,24 @@ func (h Handler) UpdateGroup(ctx context.Context, request *frontierv1beta1.Updat
 		return nil, grpcInternalServerError
 	}
 
-	audit.GetAuditor(ctx, request.GetOrgId()).Log(audit.GroupUpdatedEvent, audit.GroupTarget(updatedGroup.ID))
+	audit.GetAuditor(ctx, orgResp.ID).Log(audit.GroupUpdatedEvent, audit.GroupTarget(updatedGroup.ID))
 	return &frontierv1beta1.UpdateGroupResponse{Group: &groupPB}, nil
 }
 
 func (h Handler) ListGroupUsers(ctx context.Context, request *frontierv1beta1.ListGroupUsersRequest) (*frontierv1beta1.ListGroupUsersResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
 
 	users, err := h.userService.ListByGroup(ctx, request.Id, group.MemberPermission)
 	if err != nil {
@@ -243,6 +305,19 @@ func (h Handler) ListGroupUsers(ctx context.Context, request *frontierv1beta1.Li
 
 func (h Handler) AddGroupUsers(ctx context.Context, request *frontierv1beta1.AddGroupUsersRequest) (*frontierv1beta1.AddGroupUsersResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+
 	if err := h.groupService.AddUsers(ctx, request.GetId(), request.GetUserIds()); err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
@@ -252,6 +327,28 @@ func (h Handler) AddGroupUsers(ctx context.Context, request *frontierv1beta1.Add
 
 func (h Handler) RemoveGroupUser(ctx context.Context, request *frontierv1beta1.RemoveGroupUserRequest) (*frontierv1beta1.RemoveGroupUserResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+
+	owners, err := h.userService.ListByGroup(ctx, request.GetId(), schema.OwnerRelationName)
+	if err != nil {
+		logger.Error(err.Error())
+		return nil, grpcInternalServerError
+	}
+	if len(owners) == 1 {
+		return nil, grpcMinOwnerCounrErr
+	}
+
 	if err := h.groupService.RemoveUsers(ctx, request.GetId(), []string{request.GetUserId()}); err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
@@ -261,6 +358,19 @@ func (h Handler) RemoveGroupUser(ctx context.Context, request *frontierv1beta1.R
 
 func (h Handler) EnableGroup(ctx context.Context, request *frontierv1beta1.EnableGroupRequest) (*frontierv1beta1.EnableGroupResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+
 	if err := h.groupService.Enable(ctx, request.GetId()); err != nil {
 		logger.Error(err.Error())
 		switch {
@@ -275,6 +385,19 @@ func (h Handler) EnableGroup(ctx context.Context, request *frontierv1beta1.Enabl
 
 func (h Handler) DisableGroup(ctx context.Context, request *frontierv1beta1.DisableGroupRequest) (*frontierv1beta1.DisableGroupResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+
 	if err := h.groupService.Disable(ctx, request.GetId()); err != nil {
 		logger.Error(err.Error())
 		switch {
@@ -289,6 +412,19 @@ func (h Handler) DisableGroup(ctx context.Context, request *frontierv1beta1.Disa
 
 func (h Handler) DeleteGroup(ctx context.Context, request *frontierv1beta1.DeleteGroupRequest) (*frontierv1beta1.DeleteGroupResponse, error) {
 	logger := grpczap.Extract(ctx)
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
+	if err != nil {
+		logger.Error(err.Error())
+		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
+		case errors.Is(err, organization.ErrNotExist):
+			return nil, grpcOrgNotFoundErr
+		default:
+			return nil, grpcInternalServerError
+		}
+	}
+
 	if err := h.groupService.Delete(ctx, request.GetId()); err != nil {
 		logger.Error(err.Error())
 		switch {

--- a/internal/api/v1beta1/group_test.go
+++ b/internal/api/v1beta1/group_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	"github.com/raystack/frontier/internal/bootstrap/schema"
 	"github.com/raystack/frontier/pkg/errors"
 	"github.com/raystack/frontier/pkg/metadata"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -202,18 +203,17 @@ func TestHandler_ListGroups(t *testing.T) {
 
 func TestHandler_CreateGroup(t *testing.T) {
 	email := "user@raystack.org"
-	someOrgID := utils.NewString()
 	someGroupID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context
+		setup   func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context
 		request *frontierv1beta1.CreateGroupRequest
 		want    *frontierv1beta1.CreateGroupResponse
 		wantErr error
 	}{
 		{
 			name: "should return error if request body is nil",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
 				return ctx
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
@@ -224,13 +224,13 @@ func TestHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name: "should return error if error in metadata validation",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(errors.New("some-error"))
-
 				return ctx
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Metadata: &structpb.Struct{},
 				}},
@@ -239,10 +239,11 @@ func TestHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name: "should return unauthenticated error if auth email in context is empty and group service return invalid user email",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), group.Group{
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Title:          "Test Group",
 					Name:           "Test-Group",
 					Metadata:       metadata.Metadata{},
@@ -251,7 +252,7 @@ func TestHandler_CreateGroup(t *testing.T) {
 				return ctx
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Title:    "Test Group",
 					Metadata: &structpb.Struct{},
@@ -261,17 +262,18 @@ func TestHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name: "should return internal error if group service return some error",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), group.Group{
 					Name:           "some-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{}, errors.New("some error"))
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name:     "some-group",
 					Metadata: &structpb.Struct{},
@@ -281,18 +283,19 @@ func TestHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name: "should return already exist error if group service return error conflict",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), group.Group{
 					Name: "some-group",
 
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrConflict)
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name:     "some-group",
 					Metadata: &structpb.Struct{},
@@ -302,37 +305,18 @@ func TestHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name: "should return bad request error if name empty",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), group.Group{
 					Name:           "some-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrInvalidDetail)
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
-				Body: &frontierv1beta1.GroupRequestBody{
-					Name:     "some-group",
-					Metadata: &structpb.Struct{},
-				}},
-			want:    nil,
-			wantErr: grpcBadBodyError,
-		},
-		{
-			name: "should return bad request error if org id is not uuid",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
-				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
-				gs.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), group.Group{
-					Name:           "some-group",
-					OrganizationID: "some-org-id",
-					Metadata:       metadata.Metadata{},
-				}).Return(group.Group{}, organization.ErrInvalidUUID)
-				return authenticate.SetContextWithEmail(ctx, email)
-			},
-			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: "some-org-id",
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name:     "some-group",
 					Metadata: &structpb.Struct{},
@@ -342,49 +326,45 @@ func TestHandler_CreateGroup(t *testing.T) {
 		},
 		{
 			name: "should return bad request error if org id not exist",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), group.Group{
 					Name: "some-group",
 
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{}, organization.ErrNotExist)
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name:     "some-group",
 					Metadata: &structpb.Struct{},
 				}},
 			want:    nil,
-			wantErr: grpcBadBodyError,
-		},
-		{
-			name:    "should return bad request error if body is empty",
-			request: &frontierv1beta1.CreateGroupRequest{Body: nil},
-			want:    nil,
-			wantErr: grpcBadBodyError,
+			wantErr: grpcOrgNotFoundErr,
 		},
 		{
 			name: "should return success if group service return nil",
-			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService) context.Context {
+			setup: func(ctx context.Context, gs *mocks.GroupService, us *mocks.UserService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) context.Context {
+				os.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), group.Group{
 					Name:           "some-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{
 					ID:             someGroupID,
 					Name:           "some-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}, nil)
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			request: &frontierv1beta1.CreateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name:     "some-group",
 					Metadata: &structpb.Struct{},
@@ -393,7 +373,7 @@ func TestHandler_CreateGroup(t *testing.T) {
 				Group: &frontierv1beta1.Group{
 					Id:    someGroupID,
 					Name:  "some-group",
-					OrgId: someOrgID,
+					OrgId: testOrgID,
 					Metadata: &structpb.Struct{
 						Fields: make(map[string]*structpb.Value),
 					},
@@ -408,15 +388,17 @@ func TestHandler_CreateGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGroupSvc := new(mocks.GroupService)
 			mockUserSvc := new(mocks.UserService)
+			mockOrgSvc := new(mocks.OrganizationService)
 			mockMetaSchemaSvc := new(mocks.MetaSchemaService)
 			ctx := context.Background()
 			if tt.setup != nil {
-				ctx = tt.setup(ctx, mockGroupSvc, mockUserSvc, mockMetaSchemaSvc)
+				ctx = tt.setup(ctx, mockGroupSvc, mockUserSvc, mockMetaSchemaSvc, mockOrgSvc)
 			}
 			h := Handler{
 				userService:       mockUserSvc,
 				groupService:      mockGroupSvc,
 				metaSchemaService: mockMetaSchemaSvc,
+				orgService:        mockOrgSvc,
 			}
 			got, err := h.CreateGroup(ctx, tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -429,54 +411,78 @@ func TestHandler_GetGroup(t *testing.T) {
 	someGroupID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, os *mocks.OrganizationService)
 		request *frontierv1beta1.GetGroupRequest
 		want    *frontierv1beta1.GetGroupResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.GetGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.GetGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return internal error if group service return some error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(group.Group{}, errors.New("some error"))
 			},
-			request: &frontierv1beta1.GetGroupRequest{Id: someGroupID},
+			request: &frontierv1beta1.GetGroupRequest{Id: someGroupID, OrgId: testOrgID},
 			want:    nil,
 			wantErr: grpcInternalServerError,
 		},
 		{
 			name: "should return not found error if id is invalid",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(group.Group{}, group.ErrInvalidID)
 			},
-			request: &frontierv1beta1.GetGroupRequest{},
+			request: &frontierv1beta1.GetGroupRequest{
+				Id:    "",
+				OrgId: testOrgID,
+			},
 			want:    nil,
 			wantErr: grpcGroupNotFoundErr,
 		},
 		{
 			name: "should return not found error if group not exist",
-			setup: func(gs *mocks.GroupService) {
-				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(group.Group{}, group.ErrNotExist)
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(group.Group{}, group.ErrNotExist)
 			},
-			request: &frontierv1beta1.GetGroupRequest{},
+			request: &frontierv1beta1.GetGroupRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
 			want:    nil,
 			wantErr: grpcGroupNotFoundErr,
 		},
-		{
-			name: "should return not found error if uuid is invalid",
-			setup: func(gs *mocks.GroupService) {
-				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(group.Group{}, group.ErrInvalidUUID)
-			},
-			request: &frontierv1beta1.GetGroupRequest{},
-			want:    nil,
-			wantErr: grpcGroupNotFoundErr,
-		},
-
 		{
 			name: "should return success if group service return nil",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testGroupID).Return(testGroupMap[testGroupID], nil)
 			},
-			request: &frontierv1beta1.GetGroupRequest{Id: testGroupID},
+			request: &frontierv1beta1.GetGroupRequest{Id: testGroupID, OrgId: testOrgID},
 			want: &frontierv1beta1.GetGroupResponse{
 				Group: &frontierv1beta1.Group{
 					Id:    testGroupID,
@@ -495,7 +501,8 @@ func TestHandler_GetGroup(t *testing.T) {
 		},
 		{
 			name: "should return internal error if group service return key as integer typpe",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testGroupID).Return(group.Group{
 					Metadata: metadata.Metadata{
 						"key": map[int]any{},
@@ -503,19 +510,21 @@ func TestHandler_GetGroup(t *testing.T) {
 				}, nil)
 			},
 
-			request: &frontierv1beta1.GetGroupRequest{Id: testGroupID},
+			request: &frontierv1beta1.GetGroupRequest{Id: testGroupID, OrgId: testOrgID},
 			want:    nil,
 			wantErr: grpcInternalServerError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mockOrgSvc := new(mocks.OrganizationService)
 			mockGroupSvc := new(mocks.GroupService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.GetGroup(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -526,30 +535,29 @@ func TestHandler_GetGroup(t *testing.T) {
 
 func TestHandler_UpdateGroup(t *testing.T) {
 	someGroupID := utils.NewString()
-	someOrgID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService, ms *mocks.MetaSchemaService)
+		setup   func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService)
 		request *frontierv1beta1.UpdateGroupRequest
 		want    *frontierv1beta1.UpdateGroupResponse
 		wantErr error
 	}{
-
 		{
 			name: "should return internal error if group service return some error",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
 					ID:             someGroupID,
 					Name:           "new-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 
 					Metadata: metadata.Metadata{},
 				}).Return(group.Group{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
@@ -567,32 +575,20 @@ func TestHandler_UpdateGroup(t *testing.T) {
 			wantErr: grpcBadBodyError,
 		},
 		{
-			name: "should return bad body error if body is empty",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
-				ms.EXPECT().Validate(metadata.Metadata{}, groupMetaSchema).Return(errors.New("some_error"))
-			},
-			request: &frontierv1beta1.UpdateGroupRequest{
-				Id:   someGroupID,
-				Body: nil,
-			},
-			want:    nil,
-			wantErr: grpcBadBodyError,
-		},
-
-		{
 			name: "should return not found error if group id is not uuid (slug) and does not exist",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
 					ID:             "some-id",
 					Name:           "some-id",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrNotExist)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    "some-id",
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "some-id",
 				},
@@ -602,38 +598,20 @@ func TestHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name: "should return not found error if group id is uuid and does not exist",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
 					ID:             someGroupID,
 					Name:           "new-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 
 					Metadata: metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrNotExist)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
-				Body: &frontierv1beta1.GroupRequestBody{
-					Name: "new-group",
-				},
-			},
-			want:    nil,
-			wantErr: grpcGroupNotFoundErr,
-		},
-		{
-			name: "should return not found error if group id is empty",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
-				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
-				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
-					Name:           "new-group",
-					OrganizationID: someOrgID,
-					Metadata:       metadata.Metadata{},
-				}).Return(group.Group{}, group.ErrInvalidID)
-			},
-			request: &frontierv1beta1.UpdateGroupRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
@@ -643,19 +621,20 @@ func TestHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name: "should return already exist error if group service return error conflict",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
 					ID:             someGroupID,
 					Name:           "new-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 
 					Metadata: metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrConflict)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
@@ -664,64 +643,51 @@ func TestHandler_UpdateGroup(t *testing.T) {
 			wantErr: grpcConflictError,
 		},
 		{
-			name: "should return bad request error if org id does not exist",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
-				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
-				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
-					ID:             someGroupID,
-					Name:           "new-group",
-					OrganizationID: someOrgID,
-
-					Metadata: metadata.Metadata{},
-				}).Return(group.Group{}, organization.ErrNotExist)
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
 			},
 			want:    nil,
-			wantErr: grpcBadBodyError,
+			wantErr: grpcOrgNotFoundErr,
 		},
 		{
-			name: "should return bad request error if org id is not uuid",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
-				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
-				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
-					ID:             someGroupID,
-					Name:           "new-group",
-					OrganizationID: someOrgID,
-
-					Metadata: metadata.Metadata{},
-				}).Return(group.Group{}, organization.ErrInvalidUUID)
+			name: "should return org is disabled",
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
 			},
 			want:    nil,
-			wantErr: grpcBadBodyError,
+			wantErr: grpcOrgDisabledErr,
 		},
 		{
 			name: "should return bad request error if name is empty",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
 					ID:             someGroupID,
 					Name:           "new-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 
 					Metadata: metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrInvalidDetail)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
@@ -731,19 +697,21 @@ func TestHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name: "should return bad request error if slug is empty",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
-					ID:   someGroupID,
-					Name: someOrgID,
-
-					Metadata: metadata.Metadata{},
+					ID:             someGroupID,
+					Name:           testOrgID,
+					OrganizationID: testOrgID,
+					Metadata:       metadata.Metadata{},
 				}).Return(group.Group{}, group.ErrInvalidDetail)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
-				Id: someGroupID,
+				Id:    someGroupID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
-					Name: someOrgID,
+					Name: testOrgID,
 				},
 			},
 			want:    nil,
@@ -751,25 +719,26 @@ func TestHandler_UpdateGroup(t *testing.T) {
 		},
 		{
 			name: "should return success if updated by id and group service return nil error",
-			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService) {
+			setup: func(gs *mocks.GroupService, ms *mocks.MetaSchemaService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), groupMetaSchema).Return(nil)
 				gs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), group.Group{
 					ID:             someGroupID,
 					Name:           "new-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 
 					Metadata: metadata.Metadata{},
 				}).Return(group.Group{
 					ID:             someGroupID,
 					Name:           "new-group",
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 
 					Metadata: metadata.Metadata{},
 				}, nil)
 			},
 			request: &frontierv1beta1.UpdateGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 				Body: &frontierv1beta1.GroupRequestBody{
 					Name: "new-group",
 				},
@@ -778,7 +747,7 @@ func TestHandler_UpdateGroup(t *testing.T) {
 				Group: &frontierv1beta1.Group{
 					Id:    someGroupID,
 					Name:  "new-group",
-					OrgId: someOrgID,
+					OrgId: testOrgID,
 					Metadata: &structpb.Struct{
 						Fields: make(map[string]*structpb.Value),
 					},
@@ -792,13 +761,15 @@ func TestHandler_UpdateGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGroupSvc := new(mocks.GroupService)
+			mockOrgSvc := new(mocks.OrganizationService)
 			mockMetaSchemaSvc := new(mocks.MetaSchemaService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc, mockMetaSchemaSvc)
+				tt.setup(mockGroupSvc, mockMetaSchemaSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService:      mockGroupSvc,
 				metaSchemaService: mockMetaSchemaSvc,
+				orgService:        mockOrgSvc,
 			}
 			got, err := h.UpdateGroup(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -809,34 +780,59 @@ func TestHandler_UpdateGroup(t *testing.T) {
 
 func TestHandler_DeleteGroup(t *testing.T) {
 	someGroupID := utils.NewString()
-	someOrgID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, os *mocks.OrganizationService)
 		request *frontierv1beta1.DeleteGroupRequest
 		want    *frontierv1beta1.DeleteGroupResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.DeleteGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.DeleteGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return not found error if group service return not found error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(group.ErrNotExist)
 			},
 			request: &frontierv1beta1.DeleteGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    nil,
 			wantErr: grpcGroupNotFoundErr,
 		},
 		{
 			name: "should return success if deleted by id and group service return nil error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(nil)
 			},
 			request: &frontierv1beta1.DeleteGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    &frontierv1beta1.DeleteGroupResponse{},
 			wantErr: nil,
@@ -844,12 +840,14 @@ func TestHandler_DeleteGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mockOrgSvc := new(mocks.OrganizationService)
 			mockGroupSvc := new(mocks.GroupService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.DeleteGroup(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -860,34 +858,59 @@ func TestHandler_DeleteGroup(t *testing.T) {
 
 func TestHandler_DisableGroup(t *testing.T) {
 	someGroupID := utils.NewString()
-	someOrgID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, os *mocks.OrganizationService)
 		request *frontierv1beta1.DisableGroupRequest
 		want    *frontierv1beta1.DisableGroupResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.DisableGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.DisableGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return not found error if group service return not found error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(group.ErrNotExist)
 			},
 			request: &frontierv1beta1.DisableGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    nil,
 			wantErr: grpcGroupNotFoundErr,
 		},
 		{
 			name: "should return success if disabled by id and group service return nil error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(nil)
 			},
 			request: &frontierv1beta1.DisableGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    &frontierv1beta1.DisableGroupResponse{},
 			wantErr: nil,
@@ -895,12 +918,14 @@ func TestHandler_DisableGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mockOrgSvc := new(mocks.OrganizationService)
 			mockGroupSvc := new(mocks.GroupService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.DisableGroup(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -911,34 +936,59 @@ func TestHandler_DisableGroup(t *testing.T) {
 
 func TestHandler_EnableGroup(t *testing.T) {
 	someGroupID := utils.NewString()
-	someOrgID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, os *mocks.OrganizationService)
 		request *frontierv1beta1.EnableGroupRequest
 		want    *frontierv1beta1.EnableGroupResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.EnableGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.EnableGroupRequest{
+				OrgId: testOrgID,
+				Id:    someGroupID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return not found error if group service return not found error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(group.ErrNotExist)
 			},
 			request: &frontierv1beta1.EnableGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    nil,
 			wantErr: grpcGroupNotFoundErr,
 		},
 		{
 			name: "should return success if enabled by id and group service return nil error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), someGroupID).Return(nil)
 			},
 			request: &frontierv1beta1.EnableGroupRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    &frontierv1beta1.EnableGroupResponse{},
 			wantErr: nil,
@@ -947,11 +997,13 @@ func TestHandler_EnableGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGroupSvc := new(mocks.GroupService)
+			mockOrgSvc := new(mocks.OrganizationService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.EnableGroup(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -961,23 +1013,45 @@ func TestHandler_EnableGroup(t *testing.T) {
 }
 
 func TestHandler_ListOrganizationGroups(t *testing.T) {
-	someOrgID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, os *mocks.OrganizationService)
 		request *frontierv1beta1.ListOrganizationGroupsRequest
 		want    *frontierv1beta1.ListOrganizationGroupsResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.ListOrganizationGroupsRequest{
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.ListOrganizationGroupsRequest{
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return empty groups list if organization with valid uuid is not found",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), group.Filter{
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 				}).Return([]group.Group{}, nil)
 			},
 			request: &frontierv1beta1.ListOrganizationGroupsRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want: &frontierv1beta1.ListOrganizationGroupsResponse{
 				Groups: nil,
@@ -986,17 +1060,18 @@ func TestHandler_ListOrganizationGroups(t *testing.T) {
 		},
 		{
 			name: "should return success if list organization groups and group service return nil error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				var testGroupList []group.Group
 				for _, u := range testGroupMap {
 					testGroupList = append(testGroupList, u)
 				}
 				gs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), group.Filter{
-					OrganizationID: someOrgID,
+					OrganizationID: testOrgID,
 				}).Return(testGroupList, nil)
 			},
 			request: &frontierv1beta1.ListOrganizationGroupsRequest{
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want: &frontierv1beta1.ListOrganizationGroupsResponse{
 				Groups: []*frontierv1beta1.Group{
@@ -1008,12 +1083,14 @@ func TestHandler_ListOrganizationGroups(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mockOrgSvc := new(mocks.OrganizationService)
 			mockGroupSvc := new(mocks.GroupService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.ListOrganizationGroups(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -1023,24 +1100,48 @@ func TestHandler_ListOrganizationGroups(t *testing.T) {
 }
 
 func TestHandler_AddGroupUsers(t *testing.T) {
-	someOrgID := utils.NewString()
 	someGroupID := utils.NewString()
 	someUserID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, os *mocks.OrganizationService)
 		request *frontierv1beta1.AddGroupUsersRequest
 		want    *frontierv1beta1.AddGroupUsersResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.AddGroupUsersRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.AddGroupUsersRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return internal server error if error in adding group users",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().AddUsers(mock.AnythingOfType("*context.emptyCtx"), someGroupID, []string{someUserID}).Return(errors.New("some error"))
 			},
 			request: &frontierv1beta1.AddGroupUsersRequest{
 				Id:      someGroupID,
-				OrgId:   someOrgID,
+				OrgId:   testOrgID,
 				UserIds: []string{someUserID},
 			},
 			want:    nil,
@@ -1048,12 +1149,13 @@ func TestHandler_AddGroupUsers(t *testing.T) {
 		},
 		{
 			name: "should return success if add group users and group service return nil error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				gs.EXPECT().AddUsers(mock.AnythingOfType("*context.emptyCtx"), someGroupID, []string{someUserID}).Return(nil)
 			},
 			request: &frontierv1beta1.AddGroupUsersRequest{
 				Id:      someGroupID,
-				OrgId:   someOrgID,
+				OrgId:   testOrgID,
 				UserIds: []string{someUserID},
 			},
 			want:    &frontierv1beta1.AddGroupUsersResponse{},
@@ -1063,11 +1165,13 @@ func TestHandler_AddGroupUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGroupSvc := new(mocks.GroupService)
+			mockOrgSvc := new(mocks.OrganizationService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.AddGroupUsers(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -1077,24 +1181,61 @@ func TestHandler_AddGroupUsers(t *testing.T) {
 }
 
 func TestHandler_RemoveGroupUsers(t *testing.T) {
-	someOrgID := utils.NewString()
 	someGroupID := utils.NewString()
 	someUserID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService)
+		setup   func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService)
 		request *frontierv1beta1.RemoveGroupUserRequest
 		want    *frontierv1beta1.RemoveGroupUserResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.RemoveGroupUserRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should return error if org is disabled",
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.RemoveGroupUserRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return internal server error if error in removing group users",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, schema.OwnerRelationName).Return(
+					[]user.User{
+						testUserMap[testUserID],
+						{
+							ID:        "9f256f86-31a3-11ec-8d3d-0242ac130003",
+							Title:     "User 2",
+							Name:      "user2",
+							Email:     "test@raystack.org",
+							Metadata:  metadata.Metadata{},
+							CreatedAt: time.Time{},
+							UpdatedAt: time.Time{},
+						},
+					}, nil)
 				gs.EXPECT().RemoveUsers(mock.AnythingOfType("*context.emptyCtx"), someGroupID, []string{someUserID}).Return(errors.New("some error"))
 			},
 			request: &frontierv1beta1.RemoveGroupUserRequest{
 				Id:     someGroupID,
-				OrgId:  someOrgID,
+				OrgId:  testOrgID,
 				UserId: someUserID,
 			},
 			want:    nil,
@@ -1102,12 +1243,26 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 		},
 		{
 			name: "should return success if remove group users and group service return nil error",
-			setup: func(gs *mocks.GroupService) {
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, schema.OwnerRelationName).Return(
+					[]user.User{
+						testUserMap[testUserID],
+						{
+							ID:        "9f256f86-31a3-11ec-8d3d-0242ac130003",
+							Title:     "User 2",
+							Name:      "user2",
+							Email:     "test@raystack.org",
+							Metadata:  metadata.Metadata{},
+							CreatedAt: time.Time{},
+							UpdatedAt: time.Time{},
+						},
+					}, nil)
 				gs.EXPECT().RemoveUsers(mock.AnythingOfType("*context.emptyCtx"), someGroupID, []string{someUserID}).Return(nil)
 			},
 			request: &frontierv1beta1.RemoveGroupUserRequest{
 				Id:     someGroupID,
-				OrgId:  someOrgID,
+				OrgId:  testOrgID,
 				UserId: someUserID,
 			},
 			want:    &frontierv1beta1.RemoveGroupUserResponse{},
@@ -1117,11 +1272,15 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGroupSvc := new(mocks.GroupService)
+			mockUserSvc := new(mocks.UserService)
+			mockOrgSvc := new(mocks.OrganizationService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc)
+				tt.setup(mockGroupSvc, mockUserSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
+				userService:  mockUserSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.RemoveGroupUser(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)
@@ -1131,30 +1290,55 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 }
 
 func TestHandler_ListGroupUsers(t *testing.T) {
-	someOrgID := utils.NewString()
 	someGroupID := utils.NewString()
 	tests := []struct {
 		name    string
-		setup   func(gs *mocks.GroupService, us *mocks.UserService)
+		setup   func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService)
 		request *frontierv1beta1.ListGroupUsersRequest
 		want    *frontierv1beta1.ListGroupUsersResponse
 		wantErr error
 	}{
 		{
+			name: "should return error if org does not exist",
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+			},
+			request: &frontierv1beta1.ListGroupUsersRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgNotFoundErr,
+		},
+		{
+			name: "should error if org is disabled",
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
+			},
+			request: &frontierv1beta1.ListGroupUsersRequest{
+				Id:    someGroupID,
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcOrgDisabledErr,
+		},
+		{
 			name: "should return internal server error if error in listing group users",
-			setup: func(gs *mocks.GroupService, us *mocks.UserService) {
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, group.MemberPermission).Return(nil, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListGroupUsersRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
 		},
 		{
 			name: "should return error if metadata has int as key in list of group users",
-			setup: func(gs *mocks.GroupService, us *mocks.UserService) {
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				testUserList := []user.User{
 					{
 						Metadata: metadata.Metadata{
@@ -1167,14 +1351,15 @@ func TestHandler_ListGroupUsers(t *testing.T) {
 			},
 			request: &frontierv1beta1.ListGroupUsersRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
 		},
 		{
 			name: "should return success if list group users and group service return nil error",
-			setup: func(gs *mocks.GroupService, us *mocks.UserService) {
+			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				var testUserList []user.User
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
@@ -1183,7 +1368,7 @@ func TestHandler_ListGroupUsers(t *testing.T) {
 			},
 			request: &frontierv1beta1.ListGroupUsersRequest{
 				Id:    someGroupID,
-				OrgId: someOrgID,
+				OrgId: testOrgID,
 			},
 			want: &frontierv1beta1.ListGroupUsersResponse{
 				Users: []*frontierv1beta1.User{
@@ -1211,12 +1396,14 @@ func TestHandler_ListGroupUsers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockGroupSvc := new(mocks.GroupService)
 			mockUserSvc := new(mocks.UserService)
+			mockOrgSvc := new(mocks.OrganizationService)
 			if tt.setup != nil {
-				tt.setup(mockGroupSvc, mockUserSvc)
+				tt.setup(mockGroupSvc, mockUserSvc, mockOrgSvc)
 			}
 			h := Handler{
 				groupService: mockGroupSvc,
 				userService:  mockUserSvc,
+				orgService:   mockOrgSvc,
 			}
 			got, err := h.ListGroupUsers(context.Background(), tt.request)
 			assert.EqualValues(t, got, tt.want)

--- a/internal/api/v1beta1/group_test.go
+++ b/internal/api/v1beta1/group_test.go
@@ -1218,7 +1218,7 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 			name: "should return internal server error if error in removing group users",
 			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, schema.OwnerRelationName).Return(
+				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, schema.DeletePermission).Return(
 					[]user.User{
 						testUserMap[testUserID],
 						{
@@ -1245,7 +1245,7 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 			name: "should return success if remove group users and group service return nil error",
 			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, schema.OwnerRelationName).Return(
+				us.EXPECT().ListByGroup(mock.AnythingOfType("*context.emptyCtx"), someGroupID, schema.DeletePermission).Return(
 					[]user.User{
 						testUserMap[testUserID],
 						{

--- a/internal/api/v1beta1/invitations.go
+++ b/internal/api/v1beta1/invitations.go
@@ -33,14 +33,13 @@ func (h Handler) ListOrganizationInvitations(ctx context.Context, request *front
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	invite, err := h.invitationService.List(ctx, invitation.Filter{
@@ -92,14 +91,13 @@ func (h Handler) CreateOrganizationInvitation(ctx context.Context, request *fron
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	for _, userID := range request.GetUserIds() {
@@ -140,18 +138,17 @@ func (h Handler) CreateOrganizationInvitation(ctx context.Context, request *fron
 
 func (h Handler) GetOrganizationInvitation(ctx context.Context, request *frontierv1beta1.GetOrganizationInvitationRequest) (*frontierv1beta1.GetOrganizationInvitationResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	inviteID, err := uuid.Parse(request.GetId())
@@ -178,18 +175,17 @@ func (h Handler) GetOrganizationInvitation(ctx context.Context, request *frontie
 
 func (h Handler) AcceptOrganizationInvitation(ctx context.Context, request *frontierv1beta1.AcceptOrganizationInvitationRequest) (*frontierv1beta1.AcceptOrganizationInvitationResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	inviteID, err := uuid.Parse(request.GetId())
@@ -214,18 +210,17 @@ func (h Handler) AcceptOrganizationInvitation(ctx context.Context, request *fron
 
 func (h Handler) DeleteOrganizationInvitation(ctx context.Context, request *frontierv1beta1.DeleteOrganizationInvitationRequest) (*frontierv1beta1.DeleteOrganizationInvitationResponse, error) {
 	logger := grpczap.Extract(ctx)
-	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
+	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, organization.ErrDisabled):
+			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
 			return nil, grpcInternalServerError
 		}
-	}
-	if orgResp.State == organization.Disabled {
-		return nil, grpcOrgDisabledErr
 	}
 
 	inviteID, err := uuid.Parse(request.GetId())

--- a/internal/api/v1beta1/mocks/organization_service.go
+++ b/internal/api/v1beta1/mocks/organization_service.go
@@ -258,6 +258,59 @@ func (_c *OrganizationService_Get_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// GetRaw provides a mock function with given fields: ctx, idOrSlug
+func (_m *OrganizationService) GetRaw(ctx context.Context, idOrSlug string) (organization.Organization, error) {
+	ret := _m.Called(ctx, idOrSlug)
+
+	var r0 organization.Organization
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (organization.Organization, error)); ok {
+		return rf(ctx, idOrSlug)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) organization.Organization); ok {
+		r0 = rf(ctx, idOrSlug)
+	} else {
+		r0 = ret.Get(0).(organization.Organization)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, idOrSlug)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// OrganizationService_GetRaw_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRaw'
+type OrganizationService_GetRaw_Call struct {
+	*mock.Call
+}
+
+// GetRaw is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idOrSlug string
+func (_e *OrganizationService_Expecter) GetRaw(ctx interface{}, idOrSlug interface{}) *OrganizationService_GetRaw_Call {
+	return &OrganizationService_GetRaw_Call{Call: _e.mock.On("GetRaw", ctx, idOrSlug)}
+}
+
+func (_c *OrganizationService_GetRaw_Call) Run(run func(ctx context.Context, idOrSlug string)) *OrganizationService_GetRaw_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *OrganizationService_GetRaw_Call) Return(_a0 organization.Organization, _a1 error) *OrganizationService_GetRaw_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *OrganizationService_GetRaw_Call) RunAndReturn(run func(context.Context, string) (organization.Organization, error)) *OrganizationService_GetRaw_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // List provides a mock function with given fields: ctx, f
 func (_m *OrganizationService) List(ctx context.Context, f organization.Filter) ([]organization.Organization, error) {
 	ret := _m.Called(ctx, f)

--- a/internal/api/v1beta1/org.go
+++ b/internal/api/v1beta1/org.go
@@ -411,7 +411,7 @@ func (h Handler) RemoveOrganizationUser(ctx context.Context, request *frontierv1
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
 	}
-	if len(admins) == 1 {
+	if len(admins) == 1 && admins[0].ID == request.GetUserId() {
 		return nil, grpcMinAdminCountErr
 	}
 

--- a/internal/api/v1beta1/org.go
+++ b/internal/api/v1beta1/org.go
@@ -28,7 +28,7 @@ import (
 var (
 	grpcOrgNotFoundErr   = status.Errorf(codes.NotFound, "org doesn't exist")
 	grpcOrgDisabledErr   = status.Errorf(codes.NotFound, "org is disabled. Please contact your administrator to enable it")
-	grpcMinAdminCountErr = status.Errorf(codes.PermissionDenied, "org must have at least one admin. Please add another admin before removing this user from the org")
+	grpcMinAdminCountErr = status.Errorf(codes.PermissionDenied, "org must have at least one admin, consider adding another admin before removing")
 )
 
 type OrganizationService interface {

--- a/internal/api/v1beta1/org_test.go
+++ b/internal/api/v1beta1/org_test.go
@@ -81,6 +81,7 @@ func TestHandler_ListOrganization(t *testing.T) {
 							"intern": structpb.NewBoolValue(true),
 						},
 					},
+					State:     "enabled",
 					CreatedAt: timestamppb.New(time.Time{}),
 					UpdatedAt: timestamppb.New(time.Time{}),
 				},
@@ -207,6 +208,7 @@ func TestHandler_CreateOrganization(t *testing.T) {
 					Metadata: metadata.Metadata{
 						"email": "a",
 					},
+					State: organization.Enabled,
 				}, nil)
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
@@ -227,6 +229,8 @@ func TestHandler_CreateOrganization(t *testing.T) {
 					}},
 				CreatedAt: timestamppb.New(time.Time{}),
 				UpdatedAt: timestamppb.New(time.Time{}),
+				State:     "enabled",
+				Avatar:    "",
 			}},
 			err: nil,
 		},
@@ -308,6 +312,7 @@ func TestHandler_GetOrganization(t *testing.T) {
 							"intern": structpb.NewBoolValue(true),
 						},
 					},
+					State:     "enabled",
 					CreatedAt: timestamppb.New(time.Time{}),
 					UpdatedAt: timestamppb.New(time.Time{}),
 				},
@@ -476,7 +481,8 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 						"age":   float64(21),
 						"valid": true,
 					},
-					Name: "new-org",
+					Name:  "new-org",
+					State: organization.Enabled,
 				}, nil)
 			},
 			request: &frontierv1beta1.UpdateOrganizationRequest{
@@ -503,6 +509,8 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 							"valid": structpb.NewBoolValue(true),
 						},
 					},
+					State:     "enabled",
+					Avatar:    "",
 					CreatedAt: timestamppb.New(time.Time{}),
 					UpdatedAt: timestamppb.New(time.Time{}),
 				},
@@ -528,6 +536,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 						"age":   float64(21),
 						"valid": true,
 					},
+					State: organization.Enabled,
 				}, nil)
 			},
 			request: &frontierv1beta1.UpdateOrganizationRequest{
@@ -553,6 +562,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 							"valid": structpb.NewBoolValue(true),
 						},
 					},
+					State:     "enabled",
 					CreatedAt: timestamppb.New(time.Time{}),
 					UpdatedAt: timestamppb.New(time.Time{}),
 				},
@@ -879,6 +889,7 @@ func TestHandler_ListAllOrganizations(t *testing.T) {
 								"email":  structpb.NewStringValue("org1@org1.com"),
 							},
 						},
+						State:     "enabled",
 						CreatedAt: timestamppb.New(time.Time{}),
 						UpdatedAt: timestamppb.New(time.Time{}),
 					},
@@ -1074,11 +1085,11 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, "update").Return([]user.User{
 					testUserMap[testUserID],
 				}, nil)
-				os.EXPECT().RemoveUsers(mock.AnythingOfType("*context.emptyCtx"), testOrgID, []string{"some-user-id"}).Return(nil)
+				os.EXPECT().RemoveUsers(mock.AnythingOfType("*context.emptyCtx"), testOrgID, []string{testUserID}).Return(nil)
 			},
 			req: &frontierv1beta1.RemoveOrganizationUserRequest{
 				Id:     testOrgID,
-				UserId: "some-user-id",
+				UserId: testUserID,
 			},
 			want:    nil,
 			wantErr: grpcMinAdminCountErr,

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -39,7 +39,7 @@ func (r OrganizationRepository) GetByID(ctx context.Context, id string) (organiz
 
 	query, params, err := dialect.From(TABLE_ORGANIZATIONS).Where(goqu.Ex{
 		"id": id,
-	}).Where(notDisabledOrgExp).ToSQL()
+	}).ToSQL()
 	if err != nil {
 		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
 	}
@@ -114,7 +114,7 @@ func (r OrganizationRepository) GetByName(ctx context.Context, name string) (org
 
 	query, params, err := dialect.From(TABLE_ORGANIZATIONS).Where(goqu.Ex{
 		"name": name,
-	}).Where(notDisabledOrgExp).ToSQL()
+	}).ToSQL()
 	if err != nil {
 		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -57,8 +57,8 @@ type Config struct {
 	TelemetryConfig telemetry.Config `yaml:"telemetry_config" mapstructure:"telemetry_config"`
 
 	Authentication authenticate.Config `yaml:"authentication" mapstructure:"authentication"`
-	// DisableOrgsOnCreation if set to true will turn the default state of new orgs as disabled. Default is false
-	DisableOrgsOnCreation bool `yaml:"disable_orgs_on_create" mapstructure:"disable_orgs_on_create" default:"false"`
+	// DisableOrgsOnCreate if set to true will turn the default state of new orgs as disabled. Default is false
+	DisableOrgsOnCreate bool `yaml:"disable_orgs_on_create" mapstructure:"disable_orgs_on_create" default:"false"`
 	// DisableOrgsListing if set to true will disallow non-admin APIs to list all organizations
 	DisableOrgsListing bool `yaml:"disable_orgs_listing" mapstructure:"disable_orgs_listing" default:"false"`
 	// DisableUsersListing if set to true will disallow non-admin APIs to list all users

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -57,8 +57,8 @@ type Config struct {
 	TelemetryConfig telemetry.Config `yaml:"telemetry_config" mapstructure:"telemetry_config"`
 
 	Authentication authenticate.Config `yaml:"authentication" mapstructure:"authentication"`
-	// OrgDisableOnCreation if set to true will turn the default state of new orgs as disabled. Default is false
-	OrgDisableOnCreation bool `yaml:"org_disable_on_creation" mapstructure:"org_disable_on_creation" default:"false"`
+	// DisableOrgsOnCreation if set to true will turn the default state of new orgs as disabled. Default is false
+	DisableOrgsOnCreation bool `yaml:"disable_orgs_on_create" mapstructure:"disable_orgs_on_create" default:"false"`
 	// DisableOrgsListing if set to true will disallow non-admin APIs to list all organizations
 	DisableOrgsListing bool `yaml:"disable_orgs_listing" mapstructure:"disable_orgs_listing" default:"false"`
 	// DisableUsersListing if set to true will disallow non-admin APIs to list all users

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -57,7 +57,8 @@ type Config struct {
 	TelemetryConfig telemetry.Config `yaml:"telemetry_config" mapstructure:"telemetry_config"`
 
 	Authentication authenticate.Config `yaml:"authentication" mapstructure:"authentication"`
-
+	// OrgDisableOnCreation if set to true will turn the default state of new orgs as disabled. Default is false
+	OrgDisableOnCreation bool `yaml:"org_disable_on_creation" mapstructure:"org_disable_on_creation" default:"false"`
 	// DisableOrgsListing if set to true will disallow non-admin APIs to list all organizations
 	DisableOrgsListing bool `yaml:"disable_orgs_listing" mapstructure:"disable_orgs_listing" default:"false"`
 	// DisableUsersListing if set to true will disallow non-admin APIs to list all users

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -1159,7 +1159,8 @@ func (s *APIRegressionTestSuite) TestInvitationAPI() {
 
 		// accept invite should add user to org and delete it
 		_, err = s.testBench.Client.AcceptOrganizationInvitation(ctxOrgAdminAuth, &frontierv1beta1.AcceptOrganizationInvitationRequest{
-			Id: createdInvite.GetId(),
+			Id:    createdInvite.GetId(),
+			OrgId: existingOrg.GetOrganization().GetId(),
 		})
 		s.Assert().NoError(err)
 

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -412,14 +412,14 @@ func (s *APIRegressionTestSuite) TestGroupAPI() {
 		s.Assert().Equal(codes.InvalidArgument, status.Convert(err).Code())
 	})
 
-	s.Run("3. org admin create a new team with wrong org id should return invalid argument", func() {
+	s.Run("3. org admin create a new team with wrong org id should return not found", func() {
 		_, err := s.testBench.Client.CreateGroup(ctxOrgAdminAuth, &frontierv1beta1.CreateGroupRequest{
 			OrgId: "not-uuid",
 			Body: &frontierv1beta1.GroupRequestBody{
 				Name: "new-group",
 			},
 		})
-		s.Assert().Equal(codes.InvalidArgument, status.Convert(err).Code())
+		s.Assert().Equal(codes.NotFound, status.Convert(err).Code())
 	})
 
 	s.Run("4. org admin create a new team with same name and org-id should conflict", func() {


### PR DESCRIPTION
-  Disable org on creation flag added. 
- Org APIs now accepts both org name and uuid. Have added checks to prevent actions on disabled orgs
- Additionally a check to prevent the last org admin and project owner to be removed. Another user must be given these permissions before removing that user