### PR TITLE
fix: pass ServerName in tls config to send mails in secure mode

### DIFF
--- a/pkg/mailer/dialer.go
+++ b/pkg/mailer/dialer.go
@@ -35,6 +35,7 @@ func NewDialerImpl(SMTPHost string, SMTPPort int, SMTPUser string, SMTPPass stri
 	d := mail.NewDialer(SMTPHost, SMTPPort, SMTPUser, SMTPPass)
 	d.TLSConfig = &tls.Config{
 		InsecureSkipVerify: SMTPInsecure,
+		ServerName:         SMTPHost,
 	}
 	d.StartTLSPolicy = mail.MandatoryStartTLS
 	return &DialerImpl{


### PR DESCRIPTION
**Bug description**

If `app.mailer.smtp_insecure` is set to `false` in the config, Frontier is unable to send emails, and we get the following error: `tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config`.

When `app.mailer.smtp_insecure` is set to `true`, there is no such error. However, in this mode, TLS is susceptible to main-in-the-middle attacks.

**Expected behaviour**

Clients should be able to configure `app.mailer.smtp_insecure` to `false`, as this is the recommended setting when sending mails in production environments.

**Solution**

- Golang's `tls` module expects a `ServerName` if `InsecureSkipVerify` is set to false [(Reference to source code)](https://cs.opensource.google/go/go/+/master:src/crypto/tls/handshake_client.go;l=44?q=%22ServerName%20or%20InsecureSkipVerify%22&ss=go%2Fgo). 
- The ServerName is used to verify the hostname on the returned certificates.
- More details about `ServerName` and `InsecureSkipVerify` can be found in [the tls documentation](https://pkg.go.dev/crypto/tls).
- This PR fixes the issue by setting `ServerName` in the `tlsConfig`, irrespective of the value of `InsecureSkipVerify`

