### PR TITLE
feat: allow passing token RSA key as base64 config

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -197,6 +198,17 @@ func buildAPIDependencies(
 	var tokenKeySet jwk.Set
 	if len(cfg.App.Authentication.Token.RSAPath) > 0 {
 		if ks, err := jwk.ReadFile(cfg.App.Authentication.Token.RSAPath); err != nil {
+			return api.Deps{}, fmt.Errorf("failed to parse rsa key: %w", err)
+		} else {
+			tokenKeySet = ks
+		}
+	}
+	if len(cfg.App.Authentication.Token.RSABase64) > 0 {
+		rawDecoded, err := base64.StdEncoding.DecodeString(cfg.App.Authentication.Token.RSABase64)
+		if err != nil {
+			return api.Deps{}, fmt.Errorf("failed to decode rsa key as std-base64: %w", err)
+		}
+		if ks, err := jwk.Parse(rawDecoded); err != nil {
 			return api.Deps{}, fmt.Errorf("failed to parse rsa key: %w", err)
 		} else {
 			tokenKeySet = ks

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -88,6 +88,8 @@ app:
       # if not specified, access tokens will be disabled
       # example: /opt/rsa
       rsa_path: ""
+      # if rsa_path is not specified, rsa_base64 can be used to provide the rsa key in base64 encoded format
+      rsa_base64: ""
       # issuer claim to be added to the jwt
       iss: "http://localhost.frontier"
       # validity of the token

--- a/core/authenticate/config.go
+++ b/core/authenticate/config.go
@@ -21,6 +21,8 @@ type TokenConfig struct {
 	// jwt will be signed by first key, but will be tried to be decoded by all matching key ids, this helps in key rotation.
 	// If not provided, access token will not be generated
 	RSAPath string `yaml:"rsa_path" mapstructure:"rsa_path"`
+	// RSABase64 is base64 encoded rsa key, it can contain more than one key as a json array
+	RSABase64 string `yaml:"rsa_base64" mapstructure:"rsa_base64"`
 
 	// Issuer uniquely identifies the service that issued the token
 	// a good example could be fully qualified domain name

--- a/docs/docs/reference/configurations.md
+++ b/docs/docs/reference/configurations.md
@@ -94,6 +94,8 @@ app:
       # if not specified, access tokens will be disabled
       # example: /opt/rsa
       rsa_path: ""
+      # if rsa_path is not specified, rsa_base64 can be used to provide the rsa key in base64 encoded format
+      rsa_base64: ""
       # issuer claim to be added to the jwt
       iss: "http://localhost.frontier"
       # validity of the token


### PR DESCRIPTION
- the config is added under app.authentication.token.rsa_base64