### PR TITLE
fix: update title in project update api

### DIFF
--- a/internal/api/v1beta1/project.go
+++ b/internal/api/v1beta1/project.go
@@ -156,6 +156,7 @@ func (h Handler) UpdateProject(
 	updatedProject, err := h.projectService.Update(ctx, project.Project{
 		ID:           request.GetId(),
 		Name:         request.GetBody().GetName(),
+		Title:        request.GetBody().GetTitle(),
 		Organization: organization.Organization{ID: request.GetBody().GetOrgId()},
 		Metadata:     metaDataMap,
 	})


### PR DESCRIPTION
This PR will fix the issue of project update api setting the project title to empty string.