### PR TITLE
feat: preferences should reflect instantly after update

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: install dependencies
         run: go mod tidy
       - name: run unit tests
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: install dependencies
         run: go mod tidy
       - name: install spicedb binary
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: install dependencies
         run: go mod tidy
       - name: run regression tests

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint-fix:
 test: ## Run tests
 	@go test -race $(shell go list ./... | grep -v /ui | grep -v /vendor/ | grep -v /test/) -coverprofile=coverage.out -count 2 -timeout 150s
 
-test-all: test e2e-smoke-test e2e-regression-test lint ## Run all tests
+test-all: lint test e2e-smoke-test e2e-regression-test ## Run all tests
 
 e2e-test: ## Run all e2e tests
 	## run `docker network prune` if docker fails to find non-overlapping ipv4 address pool

--- a/core/preference/service.go
+++ b/core/preference/service.go
@@ -63,6 +63,8 @@ func (s *Service) Describe(ctx context.Context) []Trait {
 // and returns a map of preference name to value
 // if a preference is not set in the database, the default value is used from DefaultTraits
 func (s *Service) LoadPlatformPreferences(ctx context.Context) (map[string]string, error) {
+	// TODO(kushsharma): we should cache this method as it will not happen that often
+
 	preferences, err := s.List(ctx, Filter{
 		ResourceID:   PlatformID,
 		ResourceType: schema.PlatformNamespace,

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -51,5 +51,6 @@ type YAML struct {
 
 type Check struct {
 	Object     relation.Object
+	Subject    relation.Subject
 	Permission string
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/raystack/frontier
 
-go 1.20
+go 1.21
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
@@ -12,7 +12,6 @@ require (
 	github.com/doug-martin/goqu/v9 v9.18.0
 	github.com/envoyproxy/protoc-gen-validate v1.0.2
 	github.com/ghodss/yaml v1.0.0
-	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -468,6 +468,7 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
+github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -566,6 +567,7 @@ github.com/aws/aws-sdk-go v1.43.31/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4
 github.com/aws/aws-sdk-go v1.44.128/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.151/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go v1.44.314 h1:d/5Jyk/Fb+PBd/4nzQg0JuC2W4A0knrDIzBgK/ggAow=
+github.com/aws/aws-sdk-go v1.44.314/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
@@ -644,6 +646,7 @@ github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd3
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -864,6 +867,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdBA=
 github.com/creasty/defaults v1.7.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -993,6 +997,7 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -1042,6 +1047,7 @@ github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
@@ -1160,6 +1166,7 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.1 h1:jxpi2eWoU84wbX9iIEyAeeoac3FLuifZpY9tcNUD9kw=
+github.com/golang/glog v1.1.1/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1370,7 +1377,9 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
+github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v1.3.4 h1:XSL3NR682X/cVk2IeV0d70N4DZ9ljI885xAEU8IoK3c=
+github.com/hashicorp/go-memdb v1.3.4/go.mod h1:uBTr1oQbtuMgd1SSGoR8YV27eT3sBHbYiNm53bMpgSg=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
@@ -1582,7 +1591,9 @@ github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lestrrat-go/blackmagic v1.0.1 h1:lS5Zts+5HIC/8og6cGHb0uCcNCa3OUt1ygh3Qz2Fe80=
 github.com/lestrrat-go/blackmagic v1.0.1/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
@@ -1986,6 +1997,7 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -2022,6 +2034,7 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
@@ -2233,6 +2246,7 @@ go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9deb
 go.opentelemetry.io/otel/metric v0.28.0/go.mod h1:TrzsfQAmQaB1PDcdhBauLMk7nyyg9hm+GoQq/ekE9Iw=
 go.opentelemetry.io/otel/metric v0.33.0/go.mod h1:QlTYc+EnYNq/M2mNk1qDDMRLpqCOj2f/r5c7Fd5FYaI=
 go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26Q3hqOo=
+go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
 go.opentelemetry.io/otel/oteltest v0.20.0/go.mod h1:L7bgKf9ZB7qCwT9Up7i9/pn0PWIa9FqQ2IQ8LoxiGnw=
 go.opentelemetry.io/otel/sdk v0.20.0/go.mod h1:g/IcepuwNsoiX5Byy2nNV0ySUF1em498m7hBWC279Yc=
 go.opentelemetry.io/otel/sdk v1.3.0/go.mod h1:rIo4suHNhQwBIPg9axF8V9CA72Wz2mKF1teNrup8yzs=
@@ -2267,6 +2281,7 @@ go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ
 go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
@@ -3196,6 +3211,7 @@ gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 gotest.tools/v3 v3.1.0/go.mod h1:fHy7eyTmJFO5bQbUsEGQ1v4m2J3Jz9eWL54TP2/ZuYQ=
 gotest.tools/v3 v3.2.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
+gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -24,27 +24,24 @@ import (
 )
 
 type Deps struct {
-	DisableOrgsListing  bool
-	DisableUsersListing bool
-	DisableOrgOnCreate  bool
-	OrgService          *organization.Service
-	ProjectService      *project.Service
-	GroupService        *group.Service
-	RoleService         *role.Service
-	PolicyService       *policy.Service
-	UserService         *user.Service
-	NamespaceService    *namespace.Service
-	PermissionService   *permission.Service
-	RelationService     *relation.Service
-	ResourceService     *resource.Service
-	SessionService      *session.Service
-	AuthnService        *authenticate.Service
-	DeleterService      *deleter.Service
-	MetaSchemaService   *metaschema.Service
-	BootstrapService    *bootstrap.Service
-	InvitationService   *invitation.Service
-	ServiceUserService  *serviceuser.Service
-	AuditService        *audit.Service
-	DomainService       *domain.Service
-	PreferenceService   *preference.Service
+	OrgService         *organization.Service
+	ProjectService     *project.Service
+	GroupService       *group.Service
+	RoleService        *role.Service
+	PolicyService      *policy.Service
+	UserService        *user.Service
+	NamespaceService   *namespace.Service
+	PermissionService  *permission.Service
+	RelationService    *relation.Service
+	ResourceService    *resource.Service
+	SessionService     *session.Service
+	AuthnService       *authenticate.Service
+	DeleterService     *deleter.Service
+	MetaSchemaService  *metaschema.Service
+	BootstrapService   *bootstrap.Service
+	InvitationService  *invitation.Service
+	ServiceUserService *serviceuser.Service
+	AuditService       *audit.Service
+	DomainService      *domain.Service
+	PreferenceService  *preference.Service
 }

--- a/internal/api/v1beta1/authenticate.go
+++ b/internal/api/v1beta1/authenticate.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/raystack/frontier/core/relation"
+
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 	"go.uber.org/zap"
 
@@ -271,7 +273,10 @@ func (h Handler) getAccessToken(ctx context.Context, principalID string) ([]byte
 			if err != nil {
 				logger.Error("error getting project", zap.Error(err), zap.String("project", projectKey[0]))
 			} else {
-				if err := h.IsAuthorized(ctx, schema.ProjectNamespace, proj.ID, schema.GetPermission); err == nil {
+				if err := h.IsAuthorized(ctx, relation.Object{
+					Namespace: schema.ProjectNamespace,
+					ID:        proj.ID,
+				}, schema.GetPermission); err == nil {
 					customClaims["project_id"] = proj.ID
 				} else {
 					logger.Warn("error checking project access", zap.Error(err), zap.String("project", proj.ID), zap.String("principal", principalID))

--- a/internal/api/v1beta1/invitations_test.go
+++ b/internal/api/v1beta1/invitations_test.go
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func TestHandler_ListOrganizationInvations(t *testing.T) {
+func TestHandler_ListOrganizationInvitations(t *testing.T) {
 	tests := []struct {
 		name    string
 		setup   func(is *mocks.InvitationService, os *mocks.OrganizationService)
@@ -66,8 +66,9 @@ func TestHandler_ListOrganizationInvations(t *testing.T) {
 		{
 			name: "should return an error if listing invitation returns an error",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), invitation.Filter{
+				context.Background()
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), invitation.Filter{
 					OrgID: testOrgID,
 				}).Return(nil, errors.New("new-error"))
 			},
@@ -80,14 +81,14 @@ func TestHandler_ListOrganizationInvations(t *testing.T) {
 		{
 			name: "should return the list of invitations belonging to an org on success",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				var testInvitationList []invitation.Invitation
 				for _, u := range testInvitationMap {
 					if u.OrgID == testOrgID {
 						testInvitationList = append(testInvitationList, u)
 					}
 				}
-				is.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), invitation.Filter{
+				is.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), invitation.Filter{
 					OrgID: testOrgID,
 				}).Return(testInvitationList, nil)
 			},
@@ -142,7 +143,7 @@ func TestHandler_ListUserInvitations(t *testing.T) {
 		{
 			name: "should return an error if listing user invitation returns an error",
 			setup: func(is *mocks.InvitationService) {
-				is.EXPECT().ListByUser(mock.AnythingOfType("*context.emptyCtx"), testUserEmail).Return(nil, errors.New("new-error"))
+				is.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), testUserEmail).Return(nil, errors.New("new-error"))
 			},
 			request: &frontierv1beta1.ListUserInvitationsRequest{
 				Id: testUserEmail,
@@ -159,7 +160,7 @@ func TestHandler_ListUserInvitations(t *testing.T) {
 						testInvitationList = append(testInvitationList, u)
 					}
 				}
-				is.EXPECT().ListByUser(mock.AnythingOfType("*context.emptyCtx"), testUserEmail).Return(testInvitationList, nil)
+				is.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), testUserEmail).Return(testInvitationList, nil)
 			},
 			request: &frontierv1beta1.ListUserInvitationsRequest{
 				Id: testUserEmail,
@@ -212,8 +213,8 @@ func TestHandler_CreateOrganizationInvitation(t *testing.T) {
 		{
 			name: "should create an invitation on success and return the invitation",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), invitation.Invitation{
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), invitation.Invitation{
 					OrgID:     testOrgID,
 					UserID:    testUserEmail,
 					GroupIDs:  []string{randomGroupID},
@@ -248,7 +249,7 @@ func TestHandler_CreateOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an error if user email is not provided",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), randomOrgID).Return(testOrgMap[randomOrgID], nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), randomOrgID).Return(testOrgMap[randomOrgID], nil)
 			},
 			request: &frontierv1beta1.CreateOrganizationInvitationRequest{
 				OrgId:    randomOrgID,
@@ -261,8 +262,8 @@ func TestHandler_CreateOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an error if the invitation service fails",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), invitation.Invitation{
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), invitation.Invitation{
 					OrgID:     testOrgID,
 					UserID:    testUserEmail,
 					GroupIDs:  []string{randomGroupID},
@@ -281,8 +282,8 @@ func TestHandler_CreateOrganizationInvitation(t *testing.T) {
 		{
 			name: "should create a new invitation with the default expiration date",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), invitation.Invitation{
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), invitation.Invitation{
 					OrgID:     testOrgID,
 					UserID:    testUserEmail,
 					GroupIDs:  []string{randomGroupID},
@@ -349,8 +350,8 @@ func TestHandler_GetOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an invitation",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(testInvitationMap[testInvitation1ID.String()], nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(testInvitationMap[testInvitation1ID.String()], nil)
 			},
 			request: &frontierv1beta1.GetOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -376,8 +377,8 @@ func TestHandler_GetOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an error if the invitation service fails",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(invitation.Invitation{}, errors.New("test error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(invitation.Invitation{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -389,8 +390,8 @@ func TestHandler_GetOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an error if the invitation is not found",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(invitation.Invitation{}, invitation.ErrNotFound)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(invitation.Invitation{}, invitation.ErrNotFound)
 			},
 			request: &frontierv1beta1.GetOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -434,8 +435,8 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an error if invite not found",
 			setup: func(is *mocks.InvitationService, us *mocks.UserService, gs *mocks.GroupService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Accept(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(invitation.ErrNotFound)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Accept(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(invitation.ErrNotFound)
 			},
 			request: &frontierv1beta1.AcceptOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -447,8 +448,8 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an error if unable to get user by id",
 			setup: func(is *mocks.InvitationService, us *mocks.UserService, gs *mocks.GroupService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Accept(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(user.ErrNotExist)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Accept(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(user.ErrNotExist)
 			},
 			request: &frontierv1beta1.AcceptOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -460,8 +461,8 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an internal error if unable to accept invitation",
 			setup: func(is *mocks.InvitationService, us *mocks.UserService, gs *mocks.GroupService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Accept(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(errors.New("test error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Accept(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(errors.New("test error"))
 			},
 			request: &frontierv1beta1.AcceptOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -473,8 +474,8 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 		{
 			name: "should accept an invitation on success",
 			setup: func(is *mocks.InvitationService, us *mocks.UserService, gs *mocks.GroupService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				is.EXPECT().Accept(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Accept(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(nil)
 			},
 			request: &frontierv1beta1.AcceptOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -524,8 +525,8 @@ func TestHandler_DeleteOrganizationInvitation(t *testing.T) {
 		{
 			name: "should return an internal server error if invitation service fails to delete the invite",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), randomOrgID).Return(testOrgMap[randomOrgID], nil)
-				is.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(errors.New("test error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), randomOrgID).Return(testOrgMap[randomOrgID], nil)
+				is.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(errors.New("test error"))
 			},
 			request: &frontierv1beta1.DeleteOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),
@@ -537,8 +538,8 @@ func TestHandler_DeleteOrganizationInvitation(t *testing.T) {
 		{
 			name: "should delete an invitation on success",
 			setup: func(is *mocks.InvitationService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), randomOrgID).Return(testOrgMap[randomOrgID], nil)
-				is.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testInvitation1ID).Return(nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), randomOrgID).Return(testOrgMap[randomOrgID], nil)
+				is.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testInvitation1ID).Return(nil)
 			},
 			request: &frontierv1beta1.DeleteOrganizationInvitationRequest{
 				Id:    testInvitation1ID.String(),

--- a/internal/api/v1beta1/metaschema_test.go
+++ b/internal/api/v1beta1/metaschema_test.go
@@ -25,7 +25,7 @@ func TestHandler_ListMetaSchemas(t *testing.T) {
 		{
 			name: "Should list meta schemas on success",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().List(mock.AnythingOfType("*context.emptyCtx")).Return([]metaschema.MetaSchema{
+				m.EXPECT().List(mock.AnythingOfType("context.backgroundCtx")).Return([]metaschema.MetaSchema{
 					{
 						ID:     "some_id",
 						Name:   "domain_name",
@@ -48,7 +48,7 @@ func TestHandler_ListMetaSchemas(t *testing.T) {
 		{
 			name: "should return an error if Meta schema service return some error",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().List(mock.AnythingOfType("*context.emptyCtx")).Return([]metaschema.MetaSchema{}, errors.New("some_err"))
+				m.EXPECT().List(mock.AnythingOfType("context.backgroundCtx")).Return([]metaschema.MetaSchema{}, errors.New("some_err"))
 			},
 			req:     &frontierv1beta1.ListMetaSchemasRequest{},
 			want:    nil,
@@ -80,7 +80,7 @@ func Test_CreateMetaSchema(t *testing.T) {
 		{
 			name: "should successfully create  Meta Schema",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), metaschema.MetaSchema{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{
@@ -117,7 +117,7 @@ func Test_CreateMetaSchema(t *testing.T) {
 		{
 			name: "should return bad body error if meta scheme does not exist ",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), metaschema.MetaSchema{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, metaschema.ErrNotExist)
@@ -134,7 +134,7 @@ func Test_CreateMetaSchema(t *testing.T) {
 		{
 			name: "should return conflict error if metaschema already exist",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), metaschema.MetaSchema{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, metaschema.ErrConflict)
@@ -151,7 +151,7 @@ func Test_CreateMetaSchema(t *testing.T) {
 		{
 			name: "should return an error if meta scheme service return some error",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), metaschema.MetaSchema{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, errors.New("some_err"))
@@ -191,7 +191,7 @@ func Test_GetMetaSchema(t *testing.T) {
 		{
 			name: "should get meta schema on success",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some_id").Return(metaschema.MetaSchema{
+				m.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(metaschema.MetaSchema{
 					ID:     "some_id",
 					Name:   "some_name",
 					Schema: "some_schema",
@@ -214,7 +214,7 @@ func Test_GetMetaSchema(t *testing.T) {
 		{
 			name: "should return err if id is empty",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(metaschema.MetaSchema{}, grpcMetaSchemaNotFoundErr)
+				m.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(metaschema.MetaSchema{}, grpcMetaSchemaNotFoundErr)
 			},
 			req: &frontierv1beta1.GetMetaSchemaRequest{
 				Id: "",
@@ -225,7 +225,7 @@ func Test_GetMetaSchema(t *testing.T) {
 		{
 			name: "should return error if ID is Invalid",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some_id").Return(metaschema.MetaSchema{}, metaschema.ErrInvalidID)
+				m.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(metaschema.MetaSchema{}, metaschema.ErrInvalidID)
 			},
 			req: &frontierv1beta1.GetMetaSchemaRequest{
 				Id: "some_id",
@@ -236,7 +236,7 @@ func Test_GetMetaSchema(t *testing.T) {
 		{
 			name: "should return an error if meta schema service return some error",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some_id").Return(metaschema.MetaSchema{}, errors.New("some_error"))
+				m.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(metaschema.MetaSchema{}, errors.New("some_error"))
 			},
 			req: &frontierv1beta1.GetMetaSchemaRequest{
 				Id: "some_id",
@@ -270,7 +270,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 		{
 			name: "should update meta schema on  success",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), "some_id", metaschema.MetaSchema{
+				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "some_id", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{
@@ -300,7 +300,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 		{
 			name: "should return errorif meta schema doesn't exist",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), "", metaschema.MetaSchema{
+				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, nil)
@@ -327,7 +327,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 		{
 			name: "should return error if invalid metadata detail",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), "some_id", metaschema.MetaSchema{
+				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "some_id", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, metaschema.ErrInvalidDetail)
@@ -345,7 +345,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 		{
 			name: "should return error if metaschema doesn't exist",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), "some_id", metaschema.MetaSchema{
+				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "some_id", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, metaschema.ErrNotExist)
@@ -363,7 +363,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 		{
 			name: "should return error if metaschema already exist",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), "some_id", metaschema.MetaSchema{
+				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "some_id", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, metaschema.ErrConflict)
@@ -381,7 +381,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 		{
 			name: "should return an error if Meta schema service return some error",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), "some_id", metaschema.MetaSchema{
+				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "some_id", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
 				}).Return(metaschema.MetaSchema{}, errors.New("some_err"))
@@ -422,7 +422,7 @@ func Test_DeleteMetaSchema(t *testing.T) {
 		{
 			name: "should delete meta schema on success",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "some_id").Return(nil)
+				m.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(nil)
 			},
 			req: &frontierv1beta1.DeleteMetaSchemaRequest{
 				Id: "some_id",
@@ -433,7 +433,7 @@ func Test_DeleteMetaSchema(t *testing.T) {
 		{
 			name: "should return error if Id is empty",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "").Return(nil)
+				m.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "").Return(nil)
 			},
 			req: &frontierv1beta1.DeleteMetaSchemaRequest{
 				Id: "",
@@ -444,7 +444,7 @@ func Test_DeleteMetaSchema(t *testing.T) {
 		{
 			name: "should return error if metaschema doesn't exist",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "some_id").Return(metaschema.ErrNotExist)
+				m.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(metaschema.ErrNotExist)
 			},
 			req: &frontierv1beta1.DeleteMetaSchemaRequest{
 				Id: "some_id",
@@ -455,7 +455,7 @@ func Test_DeleteMetaSchema(t *testing.T) {
 		{
 			name: "should return an error if Meta schema service return some error ",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "some_id").Return(errors.New("some_error"))
+				m.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(errors.New("some_error"))
 			},
 			req: &frontierv1beta1.DeleteMetaSchemaRequest{
 				Id: "some_id",

--- a/internal/api/v1beta1/mocks/preference_service.go
+++ b/internal/api/v1beta1/mocks/preference_service.go
@@ -174,6 +174,60 @@ func (_c *PreferenceService_List_Call) RunAndReturn(run func(context.Context, pr
 	return _c
 }
 
+// LoadPlatformPreferences provides a mock function with given fields: ctx
+func (_m *PreferenceService) LoadPlatformPreferences(ctx context.Context) (map[string]string, error) {
+	ret := _m.Called(ctx)
+
+	var r0 map[string]string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (map[string]string, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) map[string]string); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PreferenceService_LoadPlatformPreferences_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadPlatformPreferences'
+type PreferenceService_LoadPlatformPreferences_Call struct {
+	*mock.Call
+}
+
+// LoadPlatformPreferences is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *PreferenceService_Expecter) LoadPlatformPreferences(ctx interface{}) *PreferenceService_LoadPlatformPreferences_Call {
+	return &PreferenceService_LoadPlatformPreferences_Call{Call: _e.mock.On("LoadPlatformPreferences", ctx)}
+}
+
+func (_c *PreferenceService_LoadPlatformPreferences_Call) Run(run func(ctx context.Context)) *PreferenceService_LoadPlatformPreferences_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *PreferenceService_LoadPlatformPreferences_Call) Return(_a0 map[string]string, _a1 error) *PreferenceService_LoadPlatformPreferences_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *PreferenceService_LoadPlatformPreferences_Call) RunAndReturn(run func(context.Context) (map[string]string, error)) *PreferenceService_LoadPlatformPreferences_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewPreferenceService creates a new instance of PreferenceService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewPreferenceService(t interface {

--- a/internal/api/v1beta1/namespace_test.go
+++ b/internal/api/v1beta1/namespace_test.go
@@ -118,7 +118,7 @@ func TestHandler_GetNamespace(t *testing.T) {
 		{
 			name: "should return internal error if namespace service return some error",
 			setup: func(ns *mocks.NamespaceService) {
-				ns.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testNSID).Return(namespace.Namespace{}, errors.New("some error"))
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetNamespaceRequest{
 				Id: testNSID,
@@ -129,7 +129,7 @@ func TestHandler_GetNamespace(t *testing.T) {
 		{
 			name: "should return not found error if namespace id is empty",
 			setup: func(ns *mocks.NamespaceService) {
-				ns.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(namespace.Namespace{}, namespace.ErrInvalidID)
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(namespace.Namespace{}, namespace.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetNamespaceRequest{},
 			want:    nil,
@@ -138,7 +138,7 @@ func TestHandler_GetNamespace(t *testing.T) {
 		{
 			name: "should return not found error if namespace id not exist",
 			setup: func(ns *mocks.NamespaceService) {
-				ns.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testNSID).Return(namespace.Namespace{}, namespace.ErrNotExist)
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{}, namespace.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetNamespaceRequest{
 				Id: testNSID,
@@ -149,7 +149,7 @@ func TestHandler_GetNamespace(t *testing.T) {
 		{
 			name: "should return success is namespace service return nil error",
 			setup: func(ns *mocks.NamespaceService) {
-				ns.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testNSID).Return(namespace.Namespace{
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{
 					ID:   testNSMap[testNSID].ID,
 					Name: testNSMap[testNSID].Name,
 				}, nil)

--- a/internal/api/v1beta1/org_test.go
+++ b/internal/api/v1beta1/org_test.go
@@ -56,7 +56,7 @@ func TestHandler_ListOrganization(t *testing.T) {
 		{
 			title: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), organization.Filter{}).Return([]organization.Organization{}, errors.New("some error"))
+				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), organization.Filter{}).Return([]organization.Organization{}, errors.New("some error"))
 			},
 			want: nil,
 			err:  status.Errorf(codes.Internal, ErrInternalServer.Error()),
@@ -68,7 +68,7 @@ func TestHandler_ListOrganization(t *testing.T) {
 				for _, o := range testOrgMap {
 					testOrgList = append(testOrgList, o)
 				}
-				os.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), organization.Filter{}).Return(testOrgList, nil)
+				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), organization.Filter{}).Return(testOrgList, nil)
 			},
 			want: &frontierv1beta1.ListOrganizationsResponse{Organizations: []*frontierv1beta1.Organization{
 				{
@@ -129,7 +129,7 @@ func TestHandler_CreateOrganization(t *testing.T) {
 			title: "should return forbidden error if auth email in context is empty and org service return invalid user email",
 			setup: func(ctx context.Context, os *mocks.OrganizationService, ms *mocks.MetaSchemaService) context.Context {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					Name:     "some-org",
 					Metadata: metadata.Metadata{},
 				}).Return(organization.Organization{}, user.ErrInvalidEmail)
@@ -265,7 +265,7 @@ func TestHandler_GetOrganization(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().GetRaw(mock.AnythingOfType("*context.emptyCtx"), someOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().GetRaw(mock.AnythingOfType("context.backgroundCtx"), someOrgID).Return(organization.Organization{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetOrganizationRequest{
 				Id: someOrgID,
@@ -276,7 +276,7 @@ func TestHandler_GetOrganization(t *testing.T) {
 		{
 			name: "should return not found error if org id is not uuid (slug) and org not exist",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().GetRaw(mock.AnythingOfType("*context.emptyCtx"), someOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+				os.EXPECT().GetRaw(mock.AnythingOfType("context.backgroundCtx"), someOrgID).Return(organization.Organization{}, organization.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetOrganizationRequest{
 				Id: someOrgID,
@@ -287,7 +287,7 @@ func TestHandler_GetOrganization(t *testing.T) {
 		{
 			name: "should return not found error if org id is invalid",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().GetRaw(mock.AnythingOfType("*context.emptyCtx"), "").Return(organization.Organization{}, organization.ErrInvalidID)
+				os.EXPECT().GetRaw(mock.AnythingOfType("context.backgroundCtx"), "").Return(organization.Organization{}, organization.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetOrganizationRequest{},
 			want:    nil,
@@ -296,7 +296,7 @@ func TestHandler_GetOrganization(t *testing.T) {
 		{
 			name: "should return success if org service return nil error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().GetRaw(mock.AnythingOfType("*context.emptyCtx"), "9f256f86-31a3-11ec-8d3d-0242ac130003").Return(testOrgMap["9f256f86-31a3-11ec-8d3d-0242ac130003"], nil)
+				os.EXPECT().GetRaw(mock.AnythingOfType("context.backgroundCtx"), "9f256f86-31a3-11ec-8d3d-0242ac130003").Return(testOrgMap["9f256f86-31a3-11ec-8d3d-0242ac130003"], nil)
 			},
 			request: &frontierv1beta1.GetOrganizationRequest{
 				Id: "9f256f86-31a3-11ec-8d3d-0242ac130003",
@@ -348,7 +348,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					ID: someOrgID,
 					Metadata: metadata.Metadata{
 						"email": "org1@org1.com",
@@ -378,7 +378,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 			name: "should return not found error if org id is not uuid (slug) and not exist",
 			setup: func(os *mocks.OrganizationService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					ID: someOrgID,
 					Metadata: metadata.Metadata{
 						"email": "org1@org1.com",
@@ -408,7 +408,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 			name: "should return not found error if org id is empty",
 			setup: func(os *mocks.OrganizationService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					Name: "new-org",
 					Metadata: metadata.Metadata{
 						"email": "org1@org1.com",
@@ -436,7 +436,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 			name: "should return already exist error if org service return err conflict",
 			setup: func(os *mocks.OrganizationService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					ID: someOrgID,
 					Metadata: metadata.Metadata{
 						"email": "org1@org1.com",
@@ -466,7 +466,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 			name: "should return success if org service is updated by id and return nil error",
 			setup: func(os *mocks.OrganizationService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					ID: someOrgID,
 					Metadata: metadata.Metadata{
 						"email": "org1@org1.com",
@@ -521,7 +521,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 			name: "should return success if org service is updated by name and return nil error",
 			setup: func(os *mocks.OrganizationService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), orgMetaSchema).Return(nil)
-				os.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), organization.Organization{
+				os.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), organization.Organization{
 					Name: "new-org",
 					Metadata: metadata.Metadata{
 						"email": "org1@org1.com",
@@ -597,8 +597,8 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, schema.UpdatePermission).Return([]user.User{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, schema.UpdatePermission).Return([]user.User{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: testOrgID,
@@ -609,7 +609,7 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 		{
 			name: "should return error if org id is not exist",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
 			},
 			request: &frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: testOrgID,
@@ -620,12 +620,12 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 		{
 			name: "should return success if org service return nil error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				var testUserList []user.User
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, schema.UpdatePermission).Return(testUserList, nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, schema.UpdatePermission).Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: testOrgID,
@@ -679,7 +679,7 @@ func TestHandler_ListOrganizationUsers(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-org-id").Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(organization.Organization{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListOrganizationUsersRequest{
 				Id: "some-org-id",
@@ -690,7 +690,7 @@ func TestHandler_ListOrganizationUsers(t *testing.T) {
 		{
 			name: "should return org not found error if org id is not exist",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-org-id").Return(organization.Organization{}, organization.ErrNotExist)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(organization.Organization{}, organization.ErrNotExist)
 			},
 			request: &frontierv1beta1.ListOrganizationUsersRequest{
 				Id: "some-org-id",
@@ -701,12 +701,12 @@ func TestHandler_ListOrganizationUsers(t *testing.T) {
 		{
 			name: "should return success if org service return nil error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				var testUserList []user.User
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, "membership").Return(testUserList, nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "membership").Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListOrganizationUsersRequest{
 				Id: testOrgID,
@@ -761,8 +761,8 @@ func TestHandler_ListOrganizationServiceUsers(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.ServiceUserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return([]serviceuser.ServiceUser{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return([]serviceuser.ServiceUser{}, errors.New("some error"))
 			},
 			req: &frontierv1beta1.ListOrganizationServiceUsersRequest{
 				Id: testOrgID,
@@ -773,7 +773,7 @@ func TestHandler_ListOrganizationServiceUsers(t *testing.T) {
 		{
 			name: "should return org not found error if org doesnt exist",
 			setup: func(us *mocks.ServiceUserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, organization.ErrNotExist)
 			},
 			req: &frontierv1beta1.ListOrganizationServiceUsersRequest{
 				Id: testOrgID,
@@ -784,12 +784,12 @@ func TestHandler_ListOrganizationServiceUsers(t *testing.T) {
 		{
 			name: "should return success if org service return nil error",
 			setup: func(us *mocks.ServiceUserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
 				var testUserList []user.User
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return([]serviceuser.ServiceUser{
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return([]serviceuser.ServiceUser{
 					{
 						ID:    "9f256f86-31a3-11ec-8d3d-0242ac130003",
 						Title: "Sample Service User",
@@ -850,7 +850,7 @@ func TestHandler_ListAllOrganizations(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"),
+				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"),
 					organization.Filter{}).Return([]organization.Organization{}, errors.New("some error"))
 			},
 			req:     &frontierv1beta1.ListAllOrganizationsRequest{},
@@ -860,7 +860,7 @@ func TestHandler_ListAllOrganizations(t *testing.T) {
 		{
 			name: "should return empty list of orgs if org service return nil error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), organization.Filter{}).Return([]organization.Organization{}, nil)
+				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), organization.Filter{}).Return([]organization.Organization{}, nil)
 			},
 			req:     &frontierv1beta1.ListAllOrganizationsRequest{},
 			want:    &frontierv1beta1.ListAllOrganizationsResponse{},
@@ -873,7 +873,7 @@ func TestHandler_ListAllOrganizations(t *testing.T) {
 				for _, o := range testOrgMap {
 					testOrgList = append(testOrgList, o)
 				}
-				os.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), organization.Filter{}).Return(testOrgList, nil)
+				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), organization.Filter{}).Return(testOrgList, nil)
 			},
 			req: &frontierv1beta1.ListAllOrganizationsRequest{},
 			want: &frontierv1beta1.ListAllOrganizationsResponse{
@@ -925,7 +925,7 @@ func TestHandler_EnableOrganization(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(errors.New("some error"))
+				os.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(errors.New("some error"))
 			},
 			req: &frontierv1beta1.EnableOrganizationRequest{
 				Id: testOrgID,
@@ -936,7 +936,7 @@ func TestHandler_EnableOrganization(t *testing.T) {
 		{
 			name: "should enable org successfully",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(nil)
+				os.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(nil)
 			},
 			req: &frontierv1beta1.EnableOrganizationRequest{
 				Id: testOrgID,
@@ -972,7 +972,7 @@ func TestHandler_DisableOrganization(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), "some-org-id").Return(errors.New("some error"))
+				os.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(errors.New("some error"))
 			},
 			req: &frontierv1beta1.DisableOrganizationRequest{
 				Id: "some-org-id",
@@ -983,7 +983,7 @@ func TestHandler_DisableOrganization(t *testing.T) {
 		{
 			name: "should disable org successfully",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), "some-org-id").Return(nil)
+				os.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(nil)
 			},
 			req: &frontierv1beta1.DisableOrganizationRequest{
 				Id: "some-org-id",
@@ -1019,7 +1019,7 @@ func TestHandler_AddOrganizationUser(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
 			},
 			req: &frontierv1beta1.AddOrganizationUsersRequest{
 				Id:      testOrgID,
@@ -1031,8 +1031,8 @@ func TestHandler_AddOrganizationUser(t *testing.T) {
 		{
 			name: "should add user to org successfully",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				os.EXPECT().AddUsers(mock.AnythingOfType("*context.emptyCtx"), testOrgID, []string{"some-user-id"}).Return(nil)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				os.EXPECT().AddUsers(mock.AnythingOfType("context.backgroundCtx"), testOrgID, []string{"some-user-id"}).Return(nil)
 			},
 			req: &frontierv1beta1.AddOrganizationUsersRequest{
 				Id:      testOrgID,
@@ -1069,7 +1069,7 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.CascadeDeleter) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
 			},
 			req: &frontierv1beta1.RemoveOrganizationUserRequest{
 				Id:     testOrgID,
@@ -1081,11 +1081,11 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 		{
 			name: "should return the error and not remove user if it is the last admin user",
 			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.CascadeDeleter) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, "update").Return([]user.User{
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "update").Return([]user.User{
 					testUserMap[testUserID],
 				}, nil)
-				ds.EXPECT().RemoveUsersFromOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, []string{testUserID}).Return(nil)
+				ds.EXPECT().RemoveUsersFromOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, []string{testUserID}).Return(nil)
 			},
 			req: &frontierv1beta1.RemoveOrganizationUserRequest{
 				Id:     testOrgID,
@@ -1097,8 +1097,8 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 		{
 			name: "should remove user from org successfully",
 			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.CascadeDeleter) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, "update").Return([]user.User{
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "update").Return([]user.User{
 					testUserMap[testUserID],
 					{
 						ID:        "some-user-id",
@@ -1110,7 +1110,7 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 						UpdatedAt: time.Time{},
 					},
 				}, nil)
-				ds.EXPECT().RemoveUsersFromOrg(mock.AnythingOfType("*context.emptyCtx"), testOrgID, []string{"some-user-id"}).Return(nil)
+				ds.EXPECT().RemoveUsersFromOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, []string{"some-user-id"}).Return(nil)
 			},
 			req: &frontierv1beta1.RemoveOrganizationUserRequest{
 				Id:     testOrgID,
@@ -1153,8 +1153,8 @@ func TestHandler_ListOrganizationProjects(t *testing.T) {
 		{
 			name: "should return error if organization does not exist ",
 			setup: func(ps *mocks.ProjectService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-org-id").Return(organization.Organization{}, organization.ErrNotExist)
-				ps.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), project.Filter{OrgID: "some-org-id"}).Return([]project.Project{}, organization.ErrNotExist)
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(organization.Organization{}, organization.ErrNotExist)
+				ps.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), project.Filter{OrgID: "some-org-id"}).Return([]project.Project{}, organization.ErrNotExist)
 			},
 			req: &frontierv1beta1.ListOrganizationProjectsRequest{
 				Id: "some-org-id",
@@ -1165,7 +1165,7 @@ func TestHandler_ListOrganizationProjects(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(ps *mocks.ProjectService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
 			},
 			req: &frontierv1beta1.ListOrganizationProjectsRequest{
 				Id: testOrgID,
@@ -1176,8 +1176,8 @@ func TestHandler_ListOrganizationProjects(t *testing.T) {
 		{
 			name: "should return list of projects successfully",
 			setup: func(ps *mocks.ProjectService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testOrgMap[testOrgID].Name).Return(testOrgMap[testOrgID], nil)
-				ps.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), project.Filter{OrgID: testOrgID}).Return([]project.Project{
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgMap[testOrgID].Name).Return(testOrgMap[testOrgID], nil)
+				ps.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), project.Filter{OrgID: testOrgID}).Return([]project.Project{
 					{
 						ID:   "some-project-id",
 						Name: "some-project-name",

--- a/internal/api/v1beta1/permission_test.go
+++ b/internal/api/v1beta1/permission_test.go
@@ -132,7 +132,7 @@ func TestCreatePermission(t *testing.T) {
 		{
 			title: "should return internal error if permission service return some error",
 			setup: func(as *mocks.PermissionService, bs *mocks.BootstrapService) {
-				bs.EXPECT().AppendSchema(mock.AnythingOfType("*context.emptyCtx"), schema.ServiceDefinition{
+				bs.EXPECT().AppendSchema(mock.AnythingOfType("context.backgroundCtx"), schema.ServiceDefinition{
 					Permissions: []schema.ResourcePermission{
 						{
 							Name:        testPermissions[testPermissionIdx].Name,
@@ -183,7 +183,7 @@ func TestCreatePermission(t *testing.T) {
 		{
 			title: "should return success if permission service return nil error",
 			setup: func(as *mocks.PermissionService, bs *mocks.BootstrapService) {
-				bs.EXPECT().AppendSchema(mock.AnythingOfType("*context.emptyCtx"), schema.ServiceDefinition{
+				bs.EXPECT().AppendSchema(mock.AnythingOfType("context.backgroundCtx"), schema.ServiceDefinition{
 					Permissions: []schema.ResourcePermission{
 						{
 							Name:      testPermissions[testPermissionIdx].Name + "0",
@@ -248,7 +248,7 @@ func TestCreatePermission(t *testing.T) {
 		{
 			title: "should return success if permission service return nil error with permission key",
 			setup: func(as *mocks.PermissionService, bs *mocks.BootstrapService) {
-				bs.EXPECT().AppendSchema(mock.AnythingOfType("*context.emptyCtx"), schema.ServiceDefinition{
+				bs.EXPECT().AppendSchema(mock.AnythingOfType("context.backgroundCtx"), schema.ServiceDefinition{
 					Permissions: []schema.ResourcePermission{
 						{
 							Name:      testPermissions[testPermissionIdx].Name + "0",
@@ -315,7 +315,7 @@ func TestHandler_GetPermission(t *testing.T) {
 		{
 			name: "should return internal error if permission service return some error",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testPermissions[testPermissionIdx].ID).Return(permission.Permission{}, errors.New("some error"))
+				as.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPermissions[testPermissionIdx].ID).Return(permission.Permission{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetPermissionRequest{
 				Id: testPermissions[testPermissionIdx].ID,
@@ -326,7 +326,7 @@ func TestHandler_GetPermission(t *testing.T) {
 		{
 			name: "should return not found error if permission id not exist",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testPermissions[testPermissionIdx].ID).Return(permission.Permission{}, permission.ErrNotExist)
+				as.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPermissions[testPermissionIdx].ID).Return(permission.Permission{}, permission.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetPermissionRequest{
 				Id: testPermissions[testPermissionIdx].ID,
@@ -337,7 +337,7 @@ func TestHandler_GetPermission(t *testing.T) {
 		{
 			name: "should return not found error if permission id is empty",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(permission.Permission{}, permission.ErrInvalidID)
+				as.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(permission.Permission{}, permission.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetPermissionRequest{},
 			want:    nil,
@@ -346,7 +346,7 @@ func TestHandler_GetPermission(t *testing.T) {
 		{
 			name: "should return success if permission service return nil error",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"),
+				as.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"),
 					testPermissions[testPermissionIdx].ID).Return(testPermissions[testPermissionIdx], nil)
 			},
 			request: &frontierv1beta1.GetPermissionRequest{
@@ -390,7 +390,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 		{
 			name: "should return internal error if permission service return some error",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), permission.Permission{
+				as.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), permission.Permission{
 					ID:          testPermissions[testPermissionIdx].ID,
 					Name:        testPermissions[testPermissionIdx].Name,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID,
@@ -409,7 +409,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 		{
 			name: "should return not found error if permission id not exist",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), permission.Permission{
+				as.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), permission.Permission{
 					ID:          testPermissions[testPermissionIdx].ID,
 					Name:        testPermissions[testPermissionIdx].Name,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID}).Return(permission.Permission{}, permission.ErrNotExist)
@@ -427,7 +427,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 		{
 			name: "should return not found error if permission id is empty",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), permission.Permission{
+				as.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), permission.Permission{
 					Name:        testPermissions[testPermissionIdx].Name,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID}).Return(permission.Permission{}, permission.ErrInvalidID)
 			},
@@ -443,7 +443,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 		{
 			name: "should return bad request error if namespace id not exist",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), permission.Permission{
+				as.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), permission.Permission{
 					ID:          testPermissions[testPermissionIdx].ID,
 					Name:        testPermissions[testPermissionIdx].Name,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID}).Return(permission.Permission{}, namespace.ErrNotExist)
@@ -461,7 +461,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 		{
 			name: "should return bad request error if name is empty",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), permission.Permission{
+				as.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), permission.Permission{
 					ID:          testPermissions[testPermissionIdx].ID,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID}).Return(permission.Permission{}, permission.ErrInvalidDetail)
 			},
@@ -477,7 +477,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 		{
 			name: "should return success if permission service return nil error",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), permission.Permission{
+				as.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), permission.Permission{
 					ID:          testPermissions[testPermissionIdx].ID,
 					Name:        testPermissions[testPermissionIdx].Name,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID,

--- a/internal/api/v1beta1/policy_test.go
+++ b/internal/api/v1beta1/policy_test.go
@@ -95,7 +95,7 @@ func TestCreatePolicy(t *testing.T) {
 		{
 			title: "should return internal error if policy service return some error",
 			setup: func(ps *mocks.PolicyService) {
-				ps.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), policy.Policy{
+				ps.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), policy.Policy{
 					RoleID:        "Admin",
 					ResourceID:    "id",
 					ResourceType:  "ns",
@@ -114,7 +114,7 @@ func TestCreatePolicy(t *testing.T) {
 		{
 			title: "should return bad request error if foreign reference not exist",
 			setup: func(ps *mocks.PolicyService) {
-				ps.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), policy.Policy{
+				ps.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), policy.Policy{
 					RoleID:        "Admin",
 					ResourceID:    "id",
 					ResourceType:  "ns",
@@ -133,7 +133,7 @@ func TestCreatePolicy(t *testing.T) {
 		{
 			title: "should return success if policy service return nil error",
 			setup: func(ps *mocks.PolicyService) {
-				ps.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), policy.Policy{
+				ps.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), policy.Policy{
 					ResourceType:  testPolicyResourceType,
 					RoleID:        "reader",
 					ResourceID:    "id",
@@ -187,7 +187,7 @@ func TestHandler_GetPolicy(t *testing.T) {
 		{
 			name: "should return internal error if policy service return some error",
 			setup: func(rs *mocks.PolicyService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testPolicyID).Return(policy.Policy{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPolicyID).Return(policy.Policy{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetPolicyRequest{
 				Id: testPolicyID,
@@ -198,7 +198,7 @@ func TestHandler_GetPolicy(t *testing.T) {
 		{
 			name: "should return not found error if id is empty",
 			setup: func(rs *mocks.PolicyService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(policy.Policy{}, policy.ErrInvalidID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(policy.Policy{}, policy.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetPolicyRequest{},
 			want:    nil,
@@ -207,7 +207,7 @@ func TestHandler_GetPolicy(t *testing.T) {
 		{
 			name: "should return not found error if id is not uuid",
 			setup: func(rs *mocks.PolicyService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-id").Return(policy.Policy{}, policy.ErrInvalidUUID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(policy.Policy{}, policy.ErrInvalidUUID)
 			},
 			request: &frontierv1beta1.GetPolicyRequest{
 				Id: "some-id",
@@ -218,7 +218,7 @@ func TestHandler_GetPolicy(t *testing.T) {
 		{
 			name: "should return not found error if id not exist",
 			setup: func(rs *mocks.PolicyService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testPolicyID).Return(policy.Policy{}, policy.ErrNotExist)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPolicyID).Return(policy.Policy{}, policy.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetPolicyRequest{
 				Id: testPolicyID,
@@ -229,7 +229,7 @@ func TestHandler_GetPolicy(t *testing.T) {
 		{
 			name: "should return success if policy service return nil error",
 			setup: func(rs *mocks.PolicyService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testPolicyID).Return(testPolicyMap[testPolicyID], nil)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPolicyID).Return(testPolicyMap[testPolicyID], nil)
 			},
 			request: &frontierv1beta1.GetPolicyRequest{
 				Id: testPolicyID,

--- a/internal/api/v1beta1/preferences.go
+++ b/internal/api/v1beta1/preferences.go
@@ -17,6 +17,7 @@ type PreferenceService interface {
 	Create(ctx context.Context, preference preference.Preference) (preference.Preference, error)
 	Describe(ctx context.Context) []preference.Trait
 	List(ctx context.Context, filter preference.Filter) ([]preference.Preference, error)
+	LoadPlatformPreferences(ctx context.Context) (map[string]string, error)
 }
 
 func (h Handler) ListPreferences(ctx context.Context, in *frontierv1beta1.ListPreferencesRequest) (*frontierv1beta1.ListPreferencesResponse, error) {
@@ -242,6 +243,10 @@ func (h Handler) ListCurrentUserPreferences(ctx context.Context, request *fronti
 	return &frontierv1beta1.ListCurrentUserPreferencesResponse{
 		Preferences: pbPrefs,
 	}, nil
+}
+
+func (h Handler) ListPlatformPreferences(ctx context.Context) (map[string]string, error) {
+	return h.preferenceService.LoadPlatformPreferences(ctx)
 }
 
 func transformPreferenceToPB(pref preference.Preference) *frontierv1beta1.Preference {

--- a/internal/api/v1beta1/preferences_test.go
+++ b/internal/api/v1beta1/preferences_test.go
@@ -29,7 +29,7 @@ func Test_DescribePreferences(t *testing.T) {
 		{
 			name: "should describe preferences on success",
 			setup: func(m *mocks.PreferenceService) {
-				m.EXPECT().Describe(mock.AnythingOfType("*context.emptyCtx")).Return([]preference.Trait{{
+				m.EXPECT().Describe(mock.AnythingOfType("context.backgroundCtx")).Return([]preference.Trait{{
 					ResourceType:    "resource",
 					Name:            "some_name",
 					Title:           "some_title",
@@ -85,7 +85,7 @@ func Test_CreateOrganizationPreferences(t *testing.T) {
 		{
 			name: "should create organization preferences on success",
 			setup: func(m *mocks.PreferenceService) {
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), preference.Preference{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
 					Name:         "some_name",
 					Value:        "some_value",
 					ResourceID:   "some_resource_id",
@@ -148,7 +148,7 @@ func Test_ListOrganizationPreferences(t *testing.T) {
 		{
 			name: "should list Organization Preferences on success",
 			setup: func(m *mocks.PreferenceService) {
-				m.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), preference.Filter{
+				m.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), preference.Filter{
 					OrgID: "some_id",
 				}).Return([]preference.Preference{
 					{
@@ -203,10 +203,10 @@ func Test_CreateUserPreferences(t *testing.T) {
 		{
 			name: "should create user preference on success",
 			setup: func(m *mocks.PreferenceService, a *mocks.AuthnService) {
-				a.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{
+				a.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{
 					ID: "some_resource_id",
 				}, nil)
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), preference.Preference{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
 					Name:         "some_name",
 					Value:        "some_value",
 					ResourceID:   "some_resource_id",
@@ -245,10 +245,10 @@ func Test_CreateUserPreferences(t *testing.T) {
 		{
 			name: "should return preference service return some error",
 			setup: func(m *mocks.PreferenceService, a *mocks.AuthnService) {
-				a.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{
+				a.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{
 					ID: "some_resource_id",
 				}, nil)
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), preference.Preference{
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
 					Name:         "some_name",
 					Value:        "some_value",
 					ResourceID:   "some_resource_id",
@@ -269,8 +269,8 @@ func Test_CreateUserPreferences(t *testing.T) {
 		{
 			name: "should return error if authenServ return some error",
 			setup: func(m *mocks.PreferenceService, a *mocks.AuthnService) {
-				a.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{}, errors.New("some_error_auth"))
-				m.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), preference.Preference{
+				a.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{}, errors.New("some_error_auth"))
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
 					Name:         "some_name",
 					Value:        "some_value",
 					ResourceID:   "",

--- a/internal/api/v1beta1/project_test.go
+++ b/internal/api/v1beta1/project_test.go
@@ -257,7 +257,7 @@ func TestListProjects(t *testing.T) {
 			title: "should return internal error if project service return some error",
 			req:   &frontierv1beta1.ListProjectsRequest{},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), project.Filter{}).Return([]project.Project{}, errors.New("some error"))
+				ps.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), project.Filter{}).Return([]project.Project{}, errors.New("some error"))
 			},
 			want: nil,
 			err:  grpcInternalServerError,
@@ -272,7 +272,7 @@ func TestListProjects(t *testing.T) {
 					prjs = append(prjs, testProjectMap[projectID])
 				}
 
-				ps.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), project.Filter{}).Return(prjs, nil)
+				ps.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), project.Filter{}).Return(prjs, nil)
 			},
 			want: &frontierv1beta1.ListProjectsResponse{Projects: []*frontierv1beta1.Project{
 				{
@@ -334,7 +334,7 @@ func TestGetProject(t *testing.T) {
 				Id: someProjectID,
 			},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), someProjectID).Return(project.Project{}, errors.New("some error"))
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(project.Project{}, errors.New("some error"))
 			},
 			err: grpcInternalServerError,
 		},
@@ -344,7 +344,7 @@ func TestGetProject(t *testing.T) {
 				Id: someProjectID,
 			},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), someProjectID).Return(project.Project{}, project.ErrNotExist)
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(project.Project{}, project.ErrNotExist)
 			},
 			err: grpcProjectNotFoundErr,
 		},
@@ -354,7 +354,7 @@ func TestGetProject(t *testing.T) {
 				Id: "some-id",
 			},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-id").Return(project.Project{}, project.ErrInvalidUUID)
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(project.Project{}, project.ErrInvalidUUID)
 			},
 			err: grpcProjectNotFoundErr,
 		},
@@ -362,7 +362,7 @@ func TestGetProject(t *testing.T) {
 			title: "should return project not found if project id is empty",
 			req:   &frontierv1beta1.GetProjectRequest{},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(project.Project{}, project.ErrInvalidUUID)
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(project.Project{}, project.ErrInvalidUUID)
 			},
 			err: grpcProjectNotFoundErr,
 		},
@@ -372,7 +372,7 @@ func TestGetProject(t *testing.T) {
 				Id: someProjectID,
 			},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), someProjectID).Return(
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(
 					testProjectMap[testProjectID], nil)
 			},
 			want: &frontierv1beta1.GetProjectResponse{Project: &frontierv1beta1.Project{
@@ -416,7 +416,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), testProjectMap[testProjectID]).Return(project.Project{}, errors.New("some error"))
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -436,7 +436,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return not found error if org id is not uuid",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), testProjectMap[testProjectID]).Return(project.Project{}, organization.ErrInvalidUUID)
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, organization.ErrInvalidUUID)
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -456,7 +456,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return not found error if project not exist",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrNotExist)
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrNotExist)
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -476,7 +476,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return not found error if project not exist",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrNotExist)
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrNotExist)
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -496,7 +496,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return already exist error if project service return err conflict",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrConflict)
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrConflict)
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -516,7 +516,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return bad request error if update by id with empty name",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), project.Project{
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), project.Project{
 					ID:           testProjectID,
 					Organization: testProjectMap[testProjectID].Organization,
 					Metadata:     testProjectMap[testProjectID].Metadata,
@@ -539,7 +539,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return bad request error if update by id with empty slug",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), project.Project{
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), project.Project{
 					ID:           testProjectID,
 					Name:         testProjectMap[testProjectID].Name,
 					Organization: testProjectMap[testProjectID].Organization,
@@ -564,7 +564,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return not found error if project id empty",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), project.Project{
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), project.Project{
 					Name:         testProjectMap[testProjectID].Name,
 					Organization: testProjectMap[testProjectID].Organization,
 					Metadata:     testProjectMap[testProjectID].Metadata,
@@ -587,7 +587,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return success if project service return nil",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), testProjectMap[testProjectID]).Return(testProjectMap[testProjectID], nil)
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(testProjectMap[testProjectID], nil)
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -643,7 +643,7 @@ func TestHandler_ListProjectAdmins(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("*context.emptyCtx"), testProjectID, schema.DeletePermission).Return([]user.User{}, errors.New("some error"))
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, schema.DeletePermission).Return([]user.User{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListProjectAdminsRequest{
 				Id: testProjectID,
@@ -654,7 +654,7 @@ func TestHandler_ListProjectAdmins(t *testing.T) {
 		{
 			name: "should return not found error if org id is not exist",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("*context.emptyCtx"), testProjectID, schema.DeletePermission).Return([]user.User{}, project.ErrNotExist)
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, schema.DeletePermission).Return([]user.User{}, project.ErrNotExist)
 			},
 			request: &frontierv1beta1.ListProjectAdminsRequest{
 				Id: testProjectID,
@@ -669,7 +669,7 @@ func TestHandler_ListProjectAdmins(t *testing.T) {
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				ps.EXPECT().ListUsers(mock.AnythingOfType("*context.emptyCtx"), testProjectID, schema.DeletePermission).Return(testUserList, nil)
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, schema.DeletePermission).Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListProjectAdminsRequest{
 				Id: testProjectID,
@@ -721,7 +721,7 @@ func TestHandler_EnableProject(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), testProjectID).Return(errors.New("some error"))
+				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("some error"))
 			},
 			req: &frontierv1beta1.EnableProjectRequest{
 				Id: testProjectID,
@@ -732,7 +732,7 @@ func TestHandler_EnableProject(t *testing.T) {
 		{
 			name: "should return not found error if project id is not exist",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), testProjectID).Return(project.ErrNotExist)
+				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(project.ErrNotExist)
 			},
 			req: &frontierv1beta1.EnableProjectRequest{
 				Id: testProjectID,
@@ -743,7 +743,7 @@ func TestHandler_EnableProject(t *testing.T) {
 		{
 			name: "should return no error if project enabled successfully",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Enable(mock.AnythingOfType("*context.emptyCtx"), testProjectID).Return(nil)
+				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(nil)
 			},
 			req: &frontierv1beta1.EnableProjectRequest{
 				Id: testProjectID,
@@ -778,7 +778,7 @@ func TestHandler_DisableProject(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), testProjectID).Return(errors.New("some error"))
+				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("some error"))
 			},
 			req: &frontierv1beta1.DisableProjectRequest{
 				Id: testProjectID,
@@ -789,7 +789,7 @@ func TestHandler_DisableProject(t *testing.T) {
 		{
 			name: "should return not found error if project id is not exist",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), testProjectID).Return(project.ErrNotExist)
+				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(project.ErrNotExist)
 			},
 			req: &frontierv1beta1.DisableProjectRequest{
 				Id: testProjectID,
@@ -800,7 +800,7 @@ func TestHandler_DisableProject(t *testing.T) {
 		{
 			name: "should return no error if project disabled successfully",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Disable(mock.AnythingOfType("*context.emptyCtx"), testProjectID).Return(nil)
+				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(nil)
 			},
 			req: &frontierv1beta1.DisableProjectRequest{
 				Id: testProjectID,
@@ -835,7 +835,7 @@ func TestHandler_ListProjectUsers(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("*context.emptyCtx"), testProjectID, project.MemberPermission).Return(nil, errors.New("some error"))
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.MemberPermission).Return(nil, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListProjectUsersRequest{
 				Id: testProjectID,
@@ -846,7 +846,7 @@ func TestHandler_ListProjectUsers(t *testing.T) {
 		{
 			name: "should return not found error if project id is not exist",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("*context.emptyCtx"), testProjectID, "get").Return(nil, project.ErrNotExist)
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, "get").Return(nil, project.ErrNotExist)
 			},
 			request: &frontierv1beta1.ListProjectUsersRequest{
 				Id: testProjectID,
@@ -857,7 +857,7 @@ func TestHandler_ListProjectUsers(t *testing.T) {
 		{
 			name: "should return project users list and no error on success",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("*context.emptyCtx"), testProjectID, project.MemberPermission).Return([]user.User{{
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.MemberPermission).Return([]user.User{{
 					ID:        "user1",
 					Name:      "user1",
 					Title:     "user1",

--- a/internal/api/v1beta1/relation_test.go
+++ b/internal/api/v1beta1/relation_test.go
@@ -56,7 +56,7 @@ func TestHandler_ListRelations(t *testing.T) {
 		{
 			name: "should return internal error if relation service return some error",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx")).Return([]relation.Relation{}, errors.New("some error"))
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx")).Return([]relation.Relation{}, errors.New("some error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -64,7 +64,7 @@ func TestHandler_ListRelations(t *testing.T) {
 		{
 			name: "should return relations if relation service return nil error",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx")).Return([]relation.Relation{
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx")).Return([]relation.Relation{
 					testRelationV2,
 				}, nil)
 			},
@@ -136,7 +136,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 				},
 			},
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
-				us.EXPECT().GetByEmail(mock.AnythingOfType("*context.emptyCtx"), "not-a-valid-email").Return(user.User{}, user.ErrNotExist)
+				us.EXPECT().GetByEmail(mock.AnythingOfType("context.backgroundCtx"), "not-a-valid-email").Return(user.User{}, user.ErrNotExist)
 			},
 			want:    nil,
 			wantErr: grpcUserNotFoundError,
@@ -144,10 +144,10 @@ func TestHandler_CreateRelation(t *testing.T) {
 		{
 			name: "should return internal error if relation service return some error",
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
-				us.EXPECT().GetByEmail(mock.AnythingOfType("*context.emptyCtx"), "user@raystack.org").Return(user.User{
+				us.EXPECT().GetByEmail(mock.AnythingOfType("context.backgroundCtx"), "user@raystack.org").Return(user.User{
 					ID: "subject-id",
 				}, nil)
-				rs.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), relation.Relation{
+				rs.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
 					Subject: relation.Subject{
 						ID:              testRelationV2.Subject.ID,
 						Namespace:       "app/user",
@@ -172,7 +172,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 		{
 			name: "should return bad request error if field value not exist in foreign reference",
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
-				res.EXPECT().CheckAuthz(mock.AnythingOfType("*context.emptyCtx"), resource.Check{
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
 					Object: relation.Object{
 						ID:        testRelationV2.Object.ID,
 						Namespace: testRelationV2.Object.Namespace,
@@ -180,7 +180,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 					Permission: schema.UpdatePermission,
 				}).Return(true, nil)
 
-				rs.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), relation.Relation{
+				rs.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
 					Subject: relation.Subject{
 						ID:              testRelationV2.Subject.ID,
 						Namespace:       testRelationV2.Subject.Namespace,
@@ -205,7 +205,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 		{
 			name: "should return success if relation service return nil",
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
-				res.EXPECT().CheckAuthz(mock.AnythingOfType("*context.emptyCtx"), resource.Check{
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
 					Object: relation.Object{
 						ID:        testRelationV2.Object.ID,
 						Namespace: testRelationV2.Object.Namespace,
@@ -213,7 +213,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 					Permission: schema.UpdatePermission,
 				}).Return(true, nil)
 
-				rs.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), relation.Relation{
+				rs.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
 					Subject: relation.Subject{
 						ID:              testRelationV2.Subject.ID,
 						Namespace:       testRelationV2.Subject.Namespace,
@@ -266,7 +266,7 @@ func TestHandler_GetRelation(t *testing.T) {
 		{
 			name: "should return internal error if relation service return some error",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testRelationV2.ID).Return(relation.Relation{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(relation.Relation{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetRelationRequest{
 				Id: testRelationV2.ID,
@@ -277,7 +277,7 @@ func TestHandler_GetRelation(t *testing.T) {
 		{
 			name: "should return not found error if id is empty",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(relation.Relation{}, relation.ErrInvalidID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(relation.Relation{}, relation.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetRelationRequest{},
 			want:    nil,
@@ -286,7 +286,7 @@ func TestHandler_GetRelation(t *testing.T) {
 		{
 			name: "should return not found error if id is not uuid",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-id").Return(relation.Relation{}, relation.ErrInvalidUUID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(relation.Relation{}, relation.ErrInvalidUUID)
 			},
 			request: &frontierv1beta1.GetRelationRequest{
 				Id: "some-id",
@@ -297,7 +297,7 @@ func TestHandler_GetRelation(t *testing.T) {
 		{
 			name: "should return not found error if id not exist",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testRelationV2.ID).Return(relation.Relation{}, relation.ErrNotExist)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(relation.Relation{}, relation.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetRelationRequest{
 				Id: testRelationV2.ID,
@@ -308,7 +308,7 @@ func TestHandler_GetRelation(t *testing.T) {
 		{
 			name: "should return success if relation service return nil error",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testRelationV2.ID).Return(testRelationV2, nil)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(testRelationV2, nil)
 			},
 			request: &frontierv1beta1.GetRelationRequest{
 				Id: testRelationV2.ID,
@@ -361,7 +361,7 @@ func TestHandler_DeleteRelation(t *testing.T) {
 		{
 			name: "should return internal server error when relation service returns some error while deletion",
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), relation.Relation{
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
 					Subject: relation.Subject{
 						Namespace:       testRelationV2.Subject.Namespace,
 						ID:              testRelationV2.Subject.ID,
@@ -384,7 +384,7 @@ func TestHandler_DeleteRelation(t *testing.T) {
 		{
 			name: "should return internal server error when relation service returns some error while deletion",
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), relation.Relation{
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
 					Subject: relation.Subject{
 						Namespace:       testRelationV2.Subject.Namespace,
 						ID:              testRelationV2.Subject.ID,
@@ -407,7 +407,7 @@ func TestHandler_DeleteRelation(t *testing.T) {
 		{
 			name: "should successfully delete when relation exist and user has permission to edit it",
 			setup: func(rs *mocks.RelationService, res *mocks.ResourceService) {
-				res.EXPECT().CheckAuthz(mock.AnythingOfType("*context.emptyCtx"), resource.Check{
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
 					Object: relation.Object{
 						ID:        testRelationV2.Object.ID,
 						Namespace: testRelationV2.Object.Namespace,
@@ -415,7 +415,7 @@ func TestHandler_DeleteRelation(t *testing.T) {
 					Permission: schema.UpdatePermission,
 				}).Return(true, nil)
 
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), relation.Relation{
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
 					Subject: relation.Subject{
 						Namespace:       testRelationV2.Subject.Namespace,
 						ID:              testRelationV2.Subject.ID,

--- a/internal/api/v1beta1/resource_test.go
+++ b/internal/api/v1beta1/resource_test.go
@@ -55,7 +55,7 @@ func TestHandler_ListResources(t *testing.T) {
 		{
 			name: "should return internal error if resource service return some error",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), resource.Filter{}).Return([]resource.Resource{}, errors.New("some error"))
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), resource.Filter{}).Return([]resource.Resource{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListResourcesRequest{},
 			want:    nil,
@@ -64,7 +64,7 @@ func TestHandler_ListResources(t *testing.T) {
 		{
 			name: "should return resources if resource service return nil error",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), resource.Filter{}).Return([]resource.Resource{
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), resource.Filter{}).Return([]resource.Resource{
 					testResource,
 				}, nil)
 			},
@@ -220,7 +220,7 @@ func TestHandler_GetProjectResource(t *testing.T) {
 		{
 			name: "should return internal error if resource service return some error",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ID).Return(resource.Resource{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ID).Return(resource.Resource{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetProjectResourceRequest{
 				Id: testResource.ID,
@@ -231,7 +231,7 @@ func TestHandler_GetProjectResource(t *testing.T) {
 		{
 			name: "should return not found error if id is empty",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(resource.Resource{}, resource.ErrInvalidID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(resource.Resource{}, resource.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetProjectResourceRequest{},
 			want:    nil,
@@ -240,7 +240,7 @@ func TestHandler_GetProjectResource(t *testing.T) {
 		{
 			name: "should return not found error if id is not uuid",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "some-id").Return(resource.Resource{}, resource.ErrInvalidUUID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(resource.Resource{}, resource.ErrInvalidUUID)
 			},
 			request: &frontierv1beta1.GetProjectResourceRequest{
 				Id: "some-id",
@@ -251,7 +251,7 @@ func TestHandler_GetProjectResource(t *testing.T) {
 		{
 			name: "should return not found error if id not exist",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ID).Return(resource.Resource{}, resource.ErrNotExist)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ID).Return(resource.Resource{}, resource.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetProjectResourceRequest{
 				Id: testResource.ID,
@@ -262,7 +262,7 @@ func TestHandler_GetProjectResource(t *testing.T) {
 		{
 			name: "should return success if resource service return nil error",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ID).Return(testResource, nil)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ID).Return(testResource, nil)
 			},
 			request: &frontierv1beta1.GetProjectResourceRequest{
 				Id: testResource.ID,
@@ -307,11 +307,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return internal error if resource service return some error",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            testResourceID,
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -335,11 +335,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return not found error if id is empty",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            "",
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -362,11 +362,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return not found error if id is not exist",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            testResourceID,
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -390,11 +390,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return not found error if id is not uuid",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            "some-id",
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -418,11 +418,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return bad request error if field value not exist in foreign reference",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            testResourceID,
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -446,11 +446,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return already exist error if resource service return err conflict",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            testResourceID,
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -474,11 +474,11 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 		{
 			name: "should return success if resource service return nil",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testResource.ProjectID).Return(project.Project{
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ProjectID).Return(project.Project{
 					ID: testResourceID,
 				}, nil)
 
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), resource.Resource{
 					ID:            testResourceID,
 					Name:          testResource.Name,
 					ProjectID:     testResource.ProjectID,
@@ -528,7 +528,7 @@ func TestHandler_ListProjectResources(t *testing.T) {
 		{
 			name: "should return internal error if resource service return error",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"),
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"),
 					resource.Filter{ProjectID: testProjectID}).Return(nil, errors.New("error"))
 			},
 			request: &frontierv1beta1.ListProjectResourcesRequest{
@@ -540,7 +540,7 @@ func TestHandler_ListProjectResources(t *testing.T) {
 		{
 			name: "should return success if resource service return nil",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), resource.Filter{ProjectID: testProjectID}).Return([]resource.Resource{}, nil)
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), resource.Filter{ProjectID: testProjectID}).Return([]resource.Resource{}, nil)
 			},
 			request: &frontierv1beta1.ListProjectResourcesRequest{
 				ProjectId: testProjectID,
@@ -553,7 +553,7 @@ func TestHandler_ListProjectResources(t *testing.T) {
 		{
 			name: "should return success if resource service return resources",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), resource.Filter{ProjectID: testProjectID}).Return([]resource.Resource{testResource}, nil)
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), resource.Filter{ProjectID: testProjectID}).Return([]resource.Resource{testResource}, nil)
 			},
 			request: &frontierv1beta1.ListProjectResourcesRequest{
 				ProjectId: testProjectID,

--- a/internal/api/v1beta1/role.go
+++ b/internal/api/v1beta1/role.go
@@ -155,6 +155,7 @@ func (h Handler) UpdateRole(ctx context.Context, request *frontierv1beta1.Update
 	updatedRole, err := h.roleService.Update(ctx, role.Role{
 		ID:          request.GetId(),
 		OrgID:       schema.PlatformOrgID.String(), // to create a platform wide role
+		Title:       request.GetBody().GetTitle(),
 		Name:        request.GetBody().GetName(),
 		Scopes:      request.GetBody().GetScopes(),
 		Permissions: request.GetBody().GetPermissions(),

--- a/internal/api/v1beta1/role_test.go
+++ b/internal/api/v1beta1/role_test.go
@@ -97,7 +97,7 @@ func TestHandler_ListOrganizationRoles(t *testing.T) {
 		{
 			name: "should return internal error if role service return some error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), role.Filter{}).Return([]role.Role{}, errors.New("some error"))
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), role.Filter{}).Return([]role.Role{}, errors.New("some error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -112,7 +112,7 @@ func TestHandler_ListOrganizationRoles(t *testing.T) {
 					}
 					testRolesList = append(testRolesList, rl)
 				}
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), role.Filter{}).Return(testRolesList, nil)
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), role.Filter{}).Return(testRolesList, nil)
 			},
 			want: &frontierv1beta1.ListOrganizationRolesResponse{
 				Roles: []*frontierv1beta1.Role{
@@ -187,7 +187,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 			name: "should return internal error if role service return some error",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Upsert(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Upsert(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
@@ -213,7 +213,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 			name: "should return bad request error if namespace id not exist",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Upsert(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Upsert(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
@@ -239,7 +239,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 			name: "should return bad request error if name empty",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Upsert(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Upsert(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
 					Metadata:    testRoleMap[testRoleID].Metadata,
@@ -263,7 +263,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 			name: "should return bad request error if id empty",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Upsert(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Upsert(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
@@ -288,7 +288,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 			name: "should return success if role service return nil error",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Upsert(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Upsert(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
@@ -355,7 +355,7 @@ func TestHandler_GetOrganizationRole(t *testing.T) {
 		{
 			name: "should return internal error if role service return some error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testRoleID).Return(role.Role{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRoleID).Return(role.Role{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.GetOrganizationRoleRequest{
 				Id: testRoleID,
@@ -366,7 +366,7 @@ func TestHandler_GetOrganizationRole(t *testing.T) {
 		{
 			name: "should return not found error if id not exist",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testRoleID).Return(role.Role{}, role.ErrNotExist)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRoleID).Return(role.Role{}, role.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetOrganizationRoleRequest{
 				Id: testRoleID,
@@ -377,7 +377,7 @@ func TestHandler_GetOrganizationRole(t *testing.T) {
 		{
 			name: "should return not found error if id empty",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "").Return(role.Role{}, role.ErrInvalidID)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(role.Role{}, role.ErrInvalidID)
 			},
 			request: &frontierv1beta1.GetOrganizationRoleRequest{},
 			want:    nil,
@@ -386,7 +386,7 @@ func TestHandler_GetOrganizationRole(t *testing.T) {
 		{
 			name: "should return success if role service return nil error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), testRoleID).Return(testRoleMap[testRoleID], nil)
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRoleID).Return(testRoleMap[testRoleID], nil)
 			},
 			request: &frontierv1beta1.GetOrganizationRoleRequest{
 				Id: testRoleID,
@@ -456,7 +456,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should return internal error if role service return some error",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
@@ -484,7 +484,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should return not found error if id not exist",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
@@ -512,7 +512,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should return not found error if id is empty",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
@@ -540,7 +540,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should return bad request error if name is empty",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
@@ -566,7 +566,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should return bad request error if namespace id not exist",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
@@ -594,7 +594,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should return already exist error if role service return err conflict",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Name:        testRoleMap[testRoleID].Name,
 					Permissions: testRoleMap[testRoleID].Permissions,
@@ -622,7 +622,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 			name: "should update role successfully",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(nil)
-				rs.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), role.Role{
+				rs.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), role.Role{
 					ID:          testRoleMap[testRoleID].ID,
 					Title:       testRoleMap[testRoleID].Title,
 					Name:        testRoleMap[testRoleID].Name,
@@ -686,7 +686,7 @@ func TestHandler_DeleteOrganizationRole(t *testing.T) {
 		{
 			name: "should return not found error if role service return err not found",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testRoleMap[testRoleID].ID).Return(role.ErrNotExist)
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(role.ErrNotExist)
 			},
 			request: &frontierv1beta1.DeleteOrganizationRoleRequest{
 				Id:    testRoleMap[testRoleID].ID,
@@ -698,7 +698,7 @@ func TestHandler_DeleteOrganizationRole(t *testing.T) {
 		{
 			name: "should return internal error if role service gives unknown error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testRoleMap[testRoleID].ID).Return(errors.New("unknown error"))
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(errors.New("unknown error"))
 			},
 			request: &frontierv1beta1.DeleteOrganizationRoleRequest{
 				Id:    testRoleMap[testRoleID].ID,
@@ -710,7 +710,7 @@ func TestHandler_DeleteOrganizationRole(t *testing.T) {
 		{
 			name: "should return nil if role service return nil",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testRoleMap[testRoleID].ID).Return(nil)
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(nil)
 			},
 			request: &frontierv1beta1.DeleteOrganizationRoleRequest{
 				Id:    testRoleMap[testRoleID].ID,
@@ -754,7 +754,7 @@ func TestHandler_DeleteRole(t *testing.T) {
 		{
 			name: "should return not found error if role service return err not found",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testRoleMap[testRoleID].ID).Return(role.ErrNotExist)
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(role.ErrNotExist)
 			},
 			request: &frontierv1beta1.DeleteRoleRequest{
 				Id: testRoleMap[testRoleID].ID,
@@ -765,7 +765,7 @@ func TestHandler_DeleteRole(t *testing.T) {
 		{
 			name: "should return internal error if role service gives unknown error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testRoleMap[testRoleID].ID).Return(errors.New("unknown error"))
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(errors.New("unknown error"))
 			},
 			request: &frontierv1beta1.DeleteRoleRequest{
 				Id: testRoleMap[testRoleID].ID,
@@ -776,7 +776,7 @@ func TestHandler_DeleteRole(t *testing.T) {
 		{
 			name: "should return nil if role service return nil",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), testRoleMap[testRoleID].ID).Return(nil)
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(nil)
 			},
 			request: &frontierv1beta1.DeleteRoleRequest{
 				Id: testRoleMap[testRoleID].ID,
@@ -817,7 +817,7 @@ func TestHandler_ListRoles(t *testing.T) {
 						testRolesList = append(testRolesList, rl)
 					}
 				}
-				rs.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), role.Filter{OrgID: testRoleMap[instanceLevelRoleID].OrgID}).Return(testRolesList, nil)
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), role.Filter{OrgID: testRoleMap[instanceLevelRoleID].OrgID}).Return(testRolesList, nil)
 			},
 			request: &frontierv1beta1.ListRolesRequest{},
 			want: &frontierv1beta1.ListRolesResponse{
@@ -875,7 +875,7 @@ func TestHandler_CreateRole(t *testing.T) {
 				expectedResp := testRoleMap[instanceLevelRoleID]
 				expectedResp.ID = ""
 				ms.EXPECT().Validate(testRoleMap[testRoleID].Metadata, roleMetaSchema).Return(nil)
-				rs.EXPECT().Upsert(mock.AnythingOfType("*context.emptyCtx"), expectedResp).Return(testRoleMap[instanceLevelRoleID], nil)
+				rs.EXPECT().Upsert(mock.AnythingOfType("context.backgroundCtx"), expectedResp).Return(testRoleMap[instanceLevelRoleID], nil)
 			},
 			request: &frontierv1beta1.CreateRoleRequest{
 				Body: &frontierv1beta1.RoleRequestBody{

--- a/internal/api/v1beta1/serviceuser_test.go
+++ b/internal/api/v1beta1/serviceuser_test.go
@@ -81,7 +81,7 @@ func TestHandler_ListServiveUsers(t *testing.T) {
 			name:    "should return internal server error when list service user service returns error",
 			request: &frontierv1beta1.ListServiceUsersRequest{},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Filter{
+				su.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Filter{
 					OrgID: "",
 					State: "",
 				}).Return(nil, errors.New("error"))
@@ -92,7 +92,7 @@ func TestHandler_ListServiveUsers(t *testing.T) {
 		{
 			name: "Test List Service Users",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().List(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Filter{
+				su.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Filter{
 					OrgID: "",
 					State: "",
 				}).Return([]serviceuser.ServiceUser{su1, su2}, nil)
@@ -138,7 +138,7 @@ func TestHandler_GetServiceUser(t *testing.T) {
 				Id: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "1").Return(serviceuser.ServiceUser{}, errors.New("error"))
+				su.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.ServiceUser{}, errors.New("error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -146,7 +146,7 @@ func TestHandler_GetServiceUser(t *testing.T) {
 		{
 			name: "should return not found error when service user is not found",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "1").Return(serviceuser.ServiceUser{}, serviceuser.ErrNotExist)
+				su.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.ServiceUser{}, serviceuser.ErrNotExist)
 			},
 			request: &frontierv1beta1.GetServiceUserRequest{
 				Id: "1",
@@ -157,7 +157,7 @@ func TestHandler_GetServiceUser(t *testing.T) {
 		{
 			name: "should return service user",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Get(mock.AnythingOfType("*context.emptyCtx"), "1").Return(su1, nil)
+				su.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "1").Return(su1, nil)
 			},
 			request: &frontierv1beta1.GetServiceUserRequest{
 				Id: "1",
@@ -203,7 +203,7 @@ func TestHandler_CreateServiceUser(t *testing.T) {
 				OrgId: su1PB.OrgId,
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), serviceuser.ServiceUser{
+				su.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), serviceuser.ServiceUser{
 					Title:    su1.Title,
 					Metadata: su1.Metadata,
 					OrgID:    su1.OrgID,
@@ -215,7 +215,7 @@ func TestHandler_CreateServiceUser(t *testing.T) {
 		{
 			name: "should return service user",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Create(mock.AnythingOfType("*context.emptyCtx"), serviceuser.ServiceUser{
+				su.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), serviceuser.ServiceUser{
 					Title:    su1.Title,
 					Metadata: su1.Metadata,
 					OrgID:    su1.OrgID,
@@ -265,7 +265,7 @@ func TestHandler_DeleteServiceUser(t *testing.T) {
 				Id: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "1").Return(errors.New("error"))
+				su.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -273,7 +273,7 @@ func TestHandler_DeleteServiceUser(t *testing.T) {
 		{
 			name: "should return not found error when service user is not found",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "1").Return(serviceuser.ErrNotExist)
+				su.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.ErrNotExist)
 			},
 			request: &frontierv1beta1.DeleteServiceUserRequest{
 				Id: "1",
@@ -284,7 +284,7 @@ func TestHandler_DeleteServiceUser(t *testing.T) {
 		{
 			name: "should return service user",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Delete(mock.AnythingOfType("*context.emptyCtx"), "1").Return(nil)
+				su.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil)
 			},
 			request: &frontierv1beta1.DeleteServiceUserRequest{
 				Id: "1",
@@ -325,7 +325,7 @@ func TestHandler_CreateServiceUserKey(t *testing.T) {
 				Title: "title",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().CreateKey(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Credential{
+				su.EXPECT().CreateKey(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Credential{
 					Title:         "title",
 					ServiceUserID: "1",
 				}).Return(serviceuser.Credential{}, errors.New("error"))
@@ -336,7 +336,7 @@ func TestHandler_CreateServiceUserKey(t *testing.T) {
 		{
 			name: "should return not found error when service user is not found",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().CreateKey(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Credential{
+				su.EXPECT().CreateKey(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Credential{
 					Title:         "title",
 					ServiceUserID: "1",
 				}).Return(serviceuser.Credential{}, serviceuser.ErrNotExist)
@@ -351,7 +351,7 @@ func TestHandler_CreateServiceUserKey(t *testing.T) {
 		{
 			name: "should return service user key",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().CreateKey(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Credential{
+				su.EXPECT().CreateKey(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Credential{
 					ServiceUserID: "1",
 					Title:         "title",
 				}).Return(suKey1PB, nil)
@@ -413,7 +413,7 @@ func TestHandler_ListServiceUserKeys(t *testing.T) {
 				Id: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().ListKeys(mock.AnythingOfType("*context.emptyCtx"), "1").Return(nil, errors.New("error"))
+				su.EXPECT().ListKeys(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil, errors.New("error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -421,7 +421,7 @@ func TestHandler_ListServiceUserKeys(t *testing.T) {
 		{
 			name: "should return not found error when service user is not found",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().ListKeys(mock.AnythingOfType("*context.emptyCtx"), "1").Return(nil, serviceuser.ErrNotExist)
+				su.EXPECT().ListKeys(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil, serviceuser.ErrNotExist)
 			},
 			request: &frontierv1beta1.ListServiceUserKeysRequest{
 				Id: "1",
@@ -432,7 +432,7 @@ func TestHandler_ListServiceUserKeys(t *testing.T) {
 		{
 			name: "should return service user keys",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().ListKeys(mock.AnythingOfType("*context.emptyCtx"), "1").Return([]serviceuser.Credential{suKey1PB}, nil)
+				su.EXPECT().ListKeys(mock.AnythingOfType("context.backgroundCtx"), "1").Return([]serviceuser.Credential{suKey1PB}, nil)
 			},
 			request: &frontierv1beta1.ListServiceUserKeysRequest{
 				Id: "1",
@@ -483,7 +483,7 @@ func TestHandler_GetServiceUserKey(t *testing.T) {
 				KeyId: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().GetKey(mock.AnythingOfType("*context.emptyCtx"), "1").Return(serviceuser.Credential{}, errors.New("error"))
+				su.EXPECT().GetKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.Credential{}, errors.New("error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -491,7 +491,7 @@ func TestHandler_GetServiceUserKey(t *testing.T) {
 		{
 			name: "should return not found error when service user is not found",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().GetKey(mock.AnythingOfType("*context.emptyCtx"), "1").Return(serviceuser.Credential{}, serviceuser.ErrCredNotExist)
+				su.EXPECT().GetKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.Credential{}, serviceuser.ErrCredNotExist)
 			},
 			request: &frontierv1beta1.GetServiceUserKeyRequest{
 				Id:    "1",
@@ -503,7 +503,7 @@ func TestHandler_GetServiceUserKey(t *testing.T) {
 		{
 			name: "should return service user key",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().GetKey(mock.AnythingOfType("*context.emptyCtx"), "1").Return(suKey1PB, nil)
+				su.EXPECT().GetKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(suKey1PB, nil)
 			},
 			request: &frontierv1beta1.GetServiceUserKeyRequest{
 				Id:    "1",
@@ -555,7 +555,7 @@ func TestHandler_DeleteServiceUserKey(t *testing.T) {
 				KeyId: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteKey(mock.AnythingOfType("*context.emptyCtx"), "1").Return(errors.New("error"))
+				su.EXPECT().DeleteKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -563,7 +563,7 @@ func TestHandler_DeleteServiceUserKey(t *testing.T) {
 		{
 			name: "should return not found error when service user is not found",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteKey(mock.AnythingOfType("*context.emptyCtx"), "1").Return(serviceuser.ErrCredNotExist)
+				su.EXPECT().DeleteKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.ErrCredNotExist)
 			},
 			request: &frontierv1beta1.DeleteServiceUserKeyRequest{
 				Id:    "1",
@@ -575,7 +575,7 @@ func TestHandler_DeleteServiceUserKey(t *testing.T) {
 		{
 			name: "should return service user key",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteKey(mock.AnythingOfType("*context.emptyCtx"), "1").Return(nil)
+				su.EXPECT().DeleteKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil)
 			},
 			request: &frontierv1beta1.DeleteServiceUserKeyRequest{
 				Id:    "1",
@@ -617,7 +617,7 @@ func TestHandler_DeleteServiceUserSecret(t *testing.T) {
 				SecretId: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteSecret(mock.AnythingOfType("*context.emptyCtx"), "1").Return(errors.New("error"))
+				su.EXPECT().DeleteSecret(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("error"))
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
@@ -625,7 +625,7 @@ func TestHandler_DeleteServiceUserSecret(t *testing.T) {
 		{
 			name: "should return service user secret",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteSecret(mock.AnythingOfType("*context.emptyCtx"), "1").Return(nil)
+				su.EXPECT().DeleteSecret(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil)
 			},
 			request: &frontierv1beta1.DeleteServiceUserSecretRequest{
 				Id:       "1",
@@ -667,7 +667,7 @@ func TestHandler_CreateServiceUserSecret(t *testing.T) {
 				Title: "title",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().CreateSecret(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Credential{
+				su.EXPECT().CreateSecret(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Credential{
 					// ID:            "1",
 					Title:         "title",
 					ServiceUserID: "1",
@@ -683,7 +683,7 @@ func TestHandler_CreateServiceUserSecret(t *testing.T) {
 		{
 			name: "should return service user secret",
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().CreateSecret(mock.AnythingOfType("*context.emptyCtx"), serviceuser.Credential{
+				su.EXPECT().CreateSecret(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Credential{
 					Title:         "title",
 					ServiceUserID: "1",
 				}).Return(serviceuser.Secret{

--- a/internal/api/v1beta1/user_test.go
+++ b/internal/api/v1beta1/user_test.go
@@ -294,7 +294,7 @@ func TestGetUser(t *testing.T) {
 		{
 			title: "should return not found error if user does not exist",
 			setup: func(us *mocks.UserService) {
-				us.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), randomID).Return(user.User{}, user.ErrNotExist)
+				us.EXPECT().GetByID(mock.AnythingOfType("context.backgroundCtx"), randomID).Return(user.User{}, user.ErrNotExist)
 			},
 			req: &frontierv1beta1.GetUserRequest{
 				Id: randomID,
@@ -305,7 +305,7 @@ func TestGetUser(t *testing.T) {
 		{
 			title: "should return not found error if user id is not uuid",
 			setup: func(us *mocks.UserService) {
-				us.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), "some-id").Return(user.User{}, user.ErrInvalidUUID)
+				us.EXPECT().GetByID(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(user.User{}, user.ErrInvalidUUID)
 			},
 			req: &frontierv1beta1.GetUserRequest{
 				Id: "some-id",
@@ -316,7 +316,7 @@ func TestGetUser(t *testing.T) {
 		{
 			title: "should return not found error if user id is invalid",
 			setup: func(us *mocks.UserService) {
-				us.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), "").Return(user.User{}, user.ErrInvalidID)
+				us.EXPECT().GetByID(mock.AnythingOfType("context.backgroundCtx"), "").Return(user.User{}, user.ErrInvalidID)
 			},
 			req:  &frontierv1beta1.GetUserRequest{},
 			want: nil,
@@ -325,7 +325,7 @@ func TestGetUser(t *testing.T) {
 		{
 			title: "should return user if user service return nil error",
 			setup: func(us *mocks.UserService) {
-				us.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), randomID).Return(
+				us.EXPECT().GetByID(mock.AnythingOfType("context.backgroundCtx"), randomID).Return(
 					user.User{
 						ID:    randomID,
 						Title: "some user",
@@ -384,7 +384,7 @@ func TestGetCurrentUser(t *testing.T) {
 			want:  nil,
 			err:   grpcUnauthenticated,
 			setup: func(ctx context.Context, us *mocks.AuthnService, ss *mocks.SessionService) context.Context {
-				us.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{}, errors.ErrUnauthenticated)
+				us.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{}, errors.ErrUnauthenticated)
 				return ctx
 			},
 		},
@@ -479,7 +479,7 @@ func TestUpdateUser(t *testing.T) {
 			title: "should return internal error if user service return some error",
 			setup: func(us *mocks.UserService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					ID:    someID,
 					Title: "abc user",
 					Email: "user@raystack.org",
@@ -506,7 +506,7 @@ func TestUpdateUser(t *testing.T) {
 			title: "should return not found error if id is invalid",
 			setup: func(us *mocks.UserService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					Title: "abc user",
 					Email: "user@raystack.org",
 					Metadata: metadata.Metadata{
@@ -550,7 +550,7 @@ func TestUpdateUser(t *testing.T) {
 			title: "should return already exist error if user service return error conflict",
 			setup: func(us *mocks.UserService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					ID:    someID,
 					Title: "abc user",
 					Email: "user@raystack.org",
@@ -577,7 +577,7 @@ func TestUpdateUser(t *testing.T) {
 			title: "should return bad request error if email in request empty",
 			setup: func(us *mocks.UserService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					ID:    someID,
 					Title: "abc user",
 					Metadata: metadata.Metadata{
@@ -609,7 +609,7 @@ func TestUpdateUser(t *testing.T) {
 			title: "should return success if user service return nil error",
 			setup: func(us *mocks.UserService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					ID:    someID,
 					Title: "abc user",
 					Email: "user@raystack.org",
@@ -657,7 +657,7 @@ func TestUpdateUser(t *testing.T) {
 			title: "should return success even though name is empty",
 			setup: func(us *mocks.UserService, ms *mocks.MetaSchemaService) {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					ID:    someID,
 					Email: "user@raystack.org",
 					Metadata: metadata.Metadata{
@@ -728,7 +728,7 @@ func TestUpdateCurrentUser(t *testing.T) {
 		{
 			title: "should return unauthenticated error if auth email header not exist",
 			setup: func(ctx context.Context, us *mocks.UserService, ms *mocks.MetaSchemaService, as *mocks.AuthnService) context.Context {
-				as.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{}, errors.ErrUnauthenticated)
+				as.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{}, errors.ErrUnauthenticated)
 				return ctx
 			},
 			req: &frontierv1beta1.UpdateCurrentUserRequest{Body: &frontierv1beta1.UserRequestBody{
@@ -747,14 +747,14 @@ func TestUpdateCurrentUser(t *testing.T) {
 			title: "should return internal error if user service return some error",
 			setup: func(ctx context.Context, us *mocks.UserService, ms *mocks.MetaSchemaService, as *mocks.AuthnService) context.Context {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				us.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), user.User{
+				us.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), user.User{
 					ID:    userID,
 					Title: "abc user",
 					Metadata: metadata.Metadata{
 						"foo": "bar",
 					},
 				}).Return(user.User{}, errors.New("some error"))
-				as.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{ID: userID}, nil)
+				as.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{ID: userID}, nil)
 				return ctx
 			},
 			req: &frontierv1beta1.UpdateCurrentUserRequest{Body: &frontierv1beta1.UserRequestBody{
@@ -773,7 +773,7 @@ func TestUpdateCurrentUser(t *testing.T) {
 			title: "should return bad request error if empty request body",
 			setup: func(ctx context.Context, us *mocks.UserService, ms *mocks.MetaSchemaService, as *mocks.AuthnService) context.Context {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				as.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{ID: userID}, nil)
+				as.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{ID: userID}, nil)
 				return ctx
 			},
 			req:  &frontierv1beta1.UpdateCurrentUserRequest{Body: nil},
@@ -784,7 +784,7 @@ func TestUpdateCurrentUser(t *testing.T) {
 			title: "should return success if user service return nil error",
 			setup: func(ctx context.Context, us *mocks.UserService, ms *mocks.MetaSchemaService, as *mocks.AuthnService) context.Context {
 				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), userMetaSchema).Return(nil)
-				as.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{ID: userID}, nil)
+				as.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{ID: userID}, nil)
 				us.EXPECT().Update(mock.Anything, mock.Anything).Return(
 					user.User{
 						ID:    "user-id-1",
@@ -852,7 +852,7 @@ func TestHandler_ListUserGroups(t *testing.T) {
 		{
 			name: "should return internal error if group service return some error",
 			setup: func(gs *mocks.GroupService) {
-				gs.EXPECT().ListByUser(mock.AnythingOfType("*context.emptyCtx"), someUserID, group.Filter{}).Return([]group.Group{}, errors.New("some error"))
+				gs.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), someUserID, group.Filter{}).Return([]group.Group{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListUserGroupsRequest{
 				Id: someUserID,
@@ -863,7 +863,7 @@ func TestHandler_ListUserGroups(t *testing.T) {
 		{
 			name: "should return empty list if user does not exist",
 			setup: func(gs *mocks.GroupService) {
-				gs.EXPECT().ListByUser(mock.AnythingOfType("*context.emptyCtx"), someUserID, group.Filter{}).Return([]group.Group{}, nil)
+				gs.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), someUserID, group.Filter{}).Return([]group.Group{}, nil)
 			},
 			request: &frontierv1beta1.ListUserGroupsRequest{
 				Id: someUserID,
@@ -879,7 +879,7 @@ func TestHandler_ListUserGroups(t *testing.T) {
 				for _, g := range testGroupMap {
 					testGroupList = append(testGroupList, g)
 				}
-				gs.EXPECT().ListByUser(mock.AnythingOfType("*context.emptyCtx"), someUserID, group.Filter{}).Return(testGroupList, nil)
+				gs.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), someUserID, group.Filter{}).Return(testGroupList, nil)
 			},
 			request: &frontierv1beta1.ListUserGroupsRequest{
 				Id: someUserID,
@@ -1005,11 +1005,11 @@ func Test_ListCurrentUserGroups(t *testing.T) {
 		{
 			name: "should list current user groups on success",
 			setup: func(g *mocks.GroupService, a *mocks.AuthnService, r *mocks.ResourceService) {
-				a.EXPECT().GetPrincipal(mock.AnythingOfType("*context.emptyCtx")).Return(authenticate.Principal{
+				a.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{
 					ID:   "some_id",
 					Type: "some_type",
 				}, nil)
-				g.EXPECT().ListByUser(mock.AnythingOfType("*context.emptyCtx"), "some_id", group.Filter{}).
+				g.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), "some_id", group.Filter{}).
 					Return([]group.Group{
 						{
 							ID:             "some_id",
@@ -1018,7 +1018,7 @@ func Test_ListCurrentUserGroups(t *testing.T) {
 							OrganizationID: "some_org_id",
 						},
 					}, nil)
-				r.EXPECT().BatchCheck(mock.AnythingOfType("*context.emptyCtx"), []resource.Check{}).Return(nil, nil)
+				r.EXPECT().BatchCheck(mock.AnythingOfType("context.backgroundCtx"), []resource.Check{}).Return(nil, nil)
 			},
 			request: &frontierv1beta1.ListCurrentUserGroupsRequest{},
 			want: &frontierv1beta1.ListCurrentUserGroupsResponse{

--- a/internal/api/v1beta1/v1beta1.go
+++ b/internal/api/v1beta1/v1beta1.go
@@ -10,56 +10,50 @@ type Handler struct {
 	frontierv1beta1.UnimplementedFrontierServiceServer
 	frontierv1beta1.UnimplementedAdminServiceServer
 
-	DisableOrgsListing  bool
-	DisableUsersListing bool
-	DisableOrgOnCreate  bool
-	orgService          OrganizationService
-	projectService      ProjectService
-	groupService        GroupService
-	roleService         RoleService
-	policyService       PolicyService
-	userService         UserService
-	namespaceService    NamespaceService
-	permissionService   PermissionService
-	relationService     RelationService
-	resourceService     ResourceService
-	sessionService      SessionService
-	authnService        AuthnService
-	deleterService      CascadeDeleter
-	metaSchemaService   MetaSchemaService
-	bootstrapService    BootstrapService
-	invitationService   InvitationService
-	serviceUserService  ServiceUserService
-	auditService        AuditService
-	domainService       DomainService
-	preferenceService   PreferenceService
+	orgService         OrganizationService
+	projectService     ProjectService
+	groupService       GroupService
+	roleService        RoleService
+	policyService      PolicyService
+	userService        UserService
+	namespaceService   NamespaceService
+	permissionService  PermissionService
+	relationService    RelationService
+	resourceService    ResourceService
+	sessionService     SessionService
+	authnService       AuthnService
+	deleterService     CascadeDeleter
+	metaSchemaService  MetaSchemaService
+	bootstrapService   BootstrapService
+	invitationService  InvitationService
+	serviceUserService ServiceUserService
+	auditService       AuditService
+	domainService      DomainService
+	preferenceService  PreferenceService
 }
 
 func Register(s *grpc.Server, deps api.Deps) error {
 	handler := &Handler{
-		DisableOrgsListing:  deps.DisableOrgsListing,
-		DisableUsersListing: deps.DisableUsersListing,
-		DisableOrgOnCreate:  deps.DisableOrgOnCreate,
-		orgService:          deps.OrgService,
-		projectService:      deps.ProjectService,
-		groupService:        deps.GroupService,
-		roleService:         deps.RoleService,
-		policyService:       deps.PolicyService,
-		userService:         deps.UserService,
-		namespaceService:    deps.NamespaceService,
-		permissionService:   deps.PermissionService,
-		relationService:     deps.RelationService,
-		resourceService:     deps.ResourceService,
-		sessionService:      deps.SessionService,
-		authnService:        deps.AuthnService,
-		deleterService:      deps.DeleterService,
-		metaSchemaService:   deps.MetaSchemaService,
-		bootstrapService:    deps.BootstrapService,
-		invitationService:   deps.InvitationService,
-		serviceUserService:  deps.ServiceUserService,
-		auditService:        deps.AuditService,
-		domainService:       deps.DomainService,
-		preferenceService:   deps.PreferenceService,
+		orgService:         deps.OrgService,
+		projectService:     deps.ProjectService,
+		groupService:       deps.GroupService,
+		roleService:        deps.RoleService,
+		policyService:      deps.PolicyService,
+		userService:        deps.UserService,
+		namespaceService:   deps.NamespaceService,
+		permissionService:  deps.PermissionService,
+		relationService:    deps.RelationService,
+		resourceService:    deps.ResourceService,
+		sessionService:     deps.SessionService,
+		authnService:       deps.AuthnService,
+		deleterService:     deps.DeleterService,
+		metaSchemaService:  deps.MetaSchemaService,
+		bootstrapService:   deps.BootstrapService,
+		invitationService:  deps.InvitationService,
+		serviceUserService: deps.ServiceUserService,
+		auditService:       deps.AuditService,
+		domainService:      deps.DomainService,
+		preferenceService:  deps.PreferenceService,
 	}
 	s.RegisterService(&frontierv1beta1.FrontierService_ServiceDesc, handler)
 	s.RegisterService(&frontierv1beta1.AdminService_ServiceDesc, handler)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,7 +1,10 @@
 package logger
 
 import (
+	"context"
 	"os"
+
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 
 	"github.com/raystack/salt/log"
 	"go.uber.org/zap"
@@ -22,6 +25,10 @@ func InitLogger(cfg Config) *log.Zap {
 
 	logger := log.NewZap(opt)
 	return logger
+}
+
+func Ctx(ctx context.Context) *zap.Logger {
+	return grpczap.Extract(ctx)
 }
 
 func atomicLevel(level string) zapcore.Level {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -10,8 +10,6 @@ import (
 	"github.com/raystack/frontier/internal/bootstrap"
 
 	"github.com/raystack/frontier/core/authenticate"
-	"github.com/raystack/frontier/core/invitation"
-
 	"github.com/raystack/frontier/pkg/telemetry"
 )
 
@@ -54,14 +52,6 @@ type Config struct {
 	TelemetryConfig telemetry.Config `yaml:"telemetry_config" mapstructure:"telemetry_config"`
 
 	Authentication authenticate.Config `yaml:"authentication" mapstructure:"authentication"`
-	// DisableOrgsOnCreate if set to true will turn the default state of new orgs as disabled. Default is false
-	DisableOrgsOnCreate bool `yaml:"disable_orgs_on_create" mapstructure:"disable_orgs_on_create" default:"false"`
-	// DisableOrgsListing if set to true will disallow non-admin APIs to list all organizations
-	DisableOrgsListing bool `yaml:"disable_orgs_listing" mapstructure:"disable_orgs_listing" default:"false"`
-	// DisableUsersListing if set to true will disallow non-admin APIs to list all users
-	DisableUsersListing bool `yaml:"disable_users_listing" mapstructure:"disable_users_listing" default:"false"`
-	// Invite is config for user invitation to join an organization
-	Invite invitation.Config `yaml:"invite" mapstructure:"invite"`
 
 	// Deprecated: use Cors instead
 	CorsOrigin []string `yaml:"cors_origin" mapstructure:"cors_origin"`

--- a/pkg/server/interceptors/authorization.go
+++ b/pkg/server/interceptors/authorization.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/raystack/frontier/core/relation"
+
+	"github.com/raystack/frontier/core/preference"
+
 	"github.com/raystack/frontier/core/group"
 
 	"github.com/raystack/frontier/pkg/server/health"
@@ -103,7 +107,11 @@ var authorizationSkipList = map[string]bool{
 var authorizationValidationMap = map[string]func(ctx context.Context, handler *v1beta1.Handler, req any) error{
 	// user
 	"/raystack.frontier.v1beta1.FrontierService/ListUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
-		if handler.DisableUsersListing {
+		prefs, err := handler.ListPlatformPreferences(ctx)
+		if err != nil {
+			return status.Error(codes.Unavailable, err.Error())
+		}
+		if prefs[preference.PlatformDisableUsersListing] == "true" {
 			return status.Error(codes.Unavailable, ErrNotAvailable.Error())
 		}
 		return nil
@@ -172,222 +180,230 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 	// serviceuser
 	"/raystack.frontier.v1beta1.FrontierService/ListServiceUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListServiceUsersRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateServiceUser": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateServiceUserRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.ServiceUserManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.ServiceUserManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetServiceUser": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetServiceUserRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteServiceUser": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteServiceUserRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.ServiceUserManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.ServiceUserManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListServiceUserKeys": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListServiceUserKeysRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateServiceUserKey": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateServiceUserKeyRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteServiceUserKey": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteServiceUserKeyRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateServiceUserSecret": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateServiceUserSecretRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListServiceUserSecrets": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListServiceUserSecretsRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteServiceUserSecret": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteServiceUserSecretRequest)
-		return handler.IsAuthorized(ctx, schema.ServiceUserPrincipal, pbreq.GetId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ServiceUserPrincipal, ID: pbreq.GetId()}, schema.ManagePermission)
 	},
 
 	// org
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizations": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		// check if true or not
-		if handler.DisableOrgsListing {
+		prefs, err := handler.ListPlatformPreferences(ctx)
+		if err != nil {
+			return status.Error(codes.Unavailable, err.Error())
+		}
+		if prefs[preference.PlatformDisableOrgsListing] == "true" {
 			return status.Error(codes.Unavailable, ErrNotAvailable.Error())
 		}
 		return nil
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetOrganization": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetOrganizationRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/UpdateOrganization": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.UpdateOrganizationRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationUsersRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationServiceUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationServiceUsersRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationProjects": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationProjectsRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.ProjectListPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.ProjectListPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/AddOrganizationUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.AddOrganizationUsersRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/RemoveOrganizationUser": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.RemoveOrganizationUserRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationInvitations": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationInvitationsRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.InvitationListPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.InvitationListPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateOrganizationInvitation": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateOrganizationInvitationRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.InvitationCreatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.InvitationCreatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetOrganizationInvitation": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetOrganizationInvitationRequest)
-		return handler.IsAuthorized(ctx, schema.InvitationNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.InvitationNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/AcceptOrganizationInvitation": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.AcceptOrganizationInvitationRequest)
-		return handler.IsAuthorized(ctx, schema.InvitationNamespace, pbreq.GetId(), schema.AcceptPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.InvitationNamespace, ID: pbreq.GetId()}, schema.AcceptPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteOrganizationInvitation": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteOrganizationInvitationRequest)
-		return handler.IsAuthorized(ctx, schema.InvitationNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.InvitationNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateOrganizationDomain": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateOrganizationDomainRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteOrganizationDomain": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteOrganizationDomainRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationDomains": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationDomainsRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationsByDomain": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		return nil
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetOrganizationDomain": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetOrganizationDomainRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/VerifyOrganizationDomain": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.VerifyOrganizationDomainRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/EnableOrganization": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
-		if handler.DisableOrgOnCreate {
+		prefs, err := handler.ListPlatformPreferences(ctx)
+		if err != nil {
+			return status.Error(codes.Unavailable, err.Error())
+		}
+		if prefs[preference.PlatformDisableOrgsOnCreate] == "true" {
 			return handler.IsSuperUser(ctx)
 		}
 		pbreq := req.(*frontierv1beta1.EnableOrganizationRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DisableOrganization": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DisableOrganizationRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteOrganization": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteOrganizationRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 
 	// group
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationGroups": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationGroupsRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GroupListPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GroupListPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateGroup": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateGroupRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GroupCreatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GroupCreatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetGroup": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetGroupRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/UpdateGroup": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.UpdateGroupRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListGroupUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListGroupUsersRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/AddGroupUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.AddGroupUsersRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/RemoveGroupUser": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.RemoveGroupUserRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/EnableGroup": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.EnableGroupRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DisableGroup": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DisableGroupRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteGroup": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteGroupRequest)
-		return handler.IsAuthorized(ctx, schema.GroupNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 
 	// project
 	"/raystack.frontier.v1beta1.FrontierService/CreateProject": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateProjectRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetBody().GetOrgId(), schema.ProjectCreatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetBody().GetOrgId()}, schema.ProjectCreatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetProject": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetProjectRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/UpdateProject": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.UpdateProjectRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListProjectAdmins": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListProjectAdminsRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListProjectUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListProjectUsersRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListProjectServiceUsers": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListProjectServiceUsersRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListProjectGroups": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListProjectGroupsRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/EnableProject": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.EnableProjectRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DisableProject": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DisableProjectRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteProject": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteProjectRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.DeletePermission)
 	},
 
 	// roles
@@ -396,23 +412,23 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationRoles": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationRolesRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateOrganizationRole": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateOrganizationRoleRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.RoleManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.RoleManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetOrganizationRole": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetOrganizationRoleRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/UpdateOrganizationRole": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.UpdateOrganizationRoleRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.RoleManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.RoleManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteOrganizationRole": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteOrganizationRoleRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.RoleManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.RoleManagePermission)
 	},
 
 	// policies
@@ -425,11 +441,11 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 
 		switch ns {
 		case schema.OrganizationNamespace, schema.ProjectNamespace:
-			return handler.IsAuthorized(ctx, ns, id, schema.PolicyManagePermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: ns, ID: id}, schema.PolicyManagePermission)
 		case schema.GroupNamespace:
-			return handler.IsAuthorized(ctx, ns, id, group.AdminPermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: ns, ID: id}, group.AdminPermission)
 		}
-		return handler.IsAuthorized(ctx, ns, id, schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: ns, ID: id}, schema.DeletePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetPolicy": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		return nil
@@ -450,11 +466,11 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 
 		switch ns {
 		case schema.OrganizationNamespace, schema.ProjectNamespace:
-			return handler.IsAuthorized(ctx, ns, id, schema.PolicyManagePermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: ns, ID: id}, schema.PolicyManagePermission)
 		case schema.GroupNamespace:
-			return handler.IsAuthorized(ctx, ns, id, group.AdminPermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: ns, ID: id}, group.AdminPermission)
 		}
-		return handler.IsAuthorized(ctx, ns, id, schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: ns, ID: id}, schema.DeletePermission)
 	},
 
 	// relations
@@ -477,16 +493,16 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 		}
 
 		if objNS == schema.OrganizationNamespace {
-			return handler.IsAuthorized(ctx, schema.OrganizationNamespace, objID, schema.UpdatePermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: objID}, schema.UpdatePermission)
 		}
 		if subNS == schema.OrganizationNamespace {
-			return handler.IsAuthorized(ctx, schema.OrganizationNamespace, subID, schema.UpdatePermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: subID}, schema.UpdatePermission)
 		}
 		if objNS == schema.ProjectNamespace {
-			return handler.IsAuthorized(ctx, schema.ProjectNamespace, objID, schema.UpdatePermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: objID}, schema.UpdatePermission)
 		}
 		if subNS == schema.ProjectNamespace {
-			return handler.IsAuthorized(ctx, schema.ProjectNamespace, subID, schema.UpdatePermission)
+			return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: subID}, schema.UpdatePermission)
 		}
 		return status.Error(codes.Unavailable, ErrNotAvailable.Error())
 	},
@@ -494,11 +510,11 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 	// resources
 	"/raystack.frontier.v1beta1.FrontierService/ListProjectResources": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListProjectResourcesRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetProjectId(), schema.ResourceListPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetProjectId()}, schema.ResourceListPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateProjectResource": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateProjectResourceRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetProjectId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetProjectId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetProjectResource": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetProjectResourceRequest)
@@ -506,11 +522,11 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 		if err != nil {
 			return err
 		}
-		return handler.IsAuthorized(ctx, resp.GetResource().GetNamespace(), resp.GetResource().GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: resp.GetResource().GetNamespace(), ID: resp.GetResource().GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/UpdateProjectResource": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.UpdateProjectResourceRequest)
-		return handler.IsAuthorized(ctx, pbreq.GetBody().GetNamespace(), pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: pbreq.GetBody().GetNamespace(), ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeleteProjectResource": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.DeleteProjectResourceRequest)
@@ -518,47 +534,47 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 		if err != nil {
 			return err
 		}
-		return handler.IsAuthorized(ctx, resp.GetResource().GetNamespace(), resp.GetResource().GetId(), schema.DeletePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: resp.GetResource().GetNamespace(), ID: resp.GetResource().GetId()}, schema.DeletePermission)
 	},
 
 	// audit logs
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationAuditLogs": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationAuditLogsRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.ManagePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateOrganizationAuditLogs": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateOrganizationAuditLogsRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetOrganizationAuditLog": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.GetOrganizationAuditLogRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetOrgId(), schema.ManagePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetOrgId()}, schema.ManagePermission)
 	},
 
 	// preferences
 	"/raystack.frontier.v1beta1.FrontierService/CreateOrganizationPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateOrganizationPreferencesRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListOrganizationPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListOrganizationPreferencesRequest)
-		return handler.IsAuthorized(ctx, schema.OrganizationNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateProjectPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateProjectPreferencesRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListProjectPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListProjectPreferencesRequest)
-		return handler.IsAuthorized(ctx, schema.ProjectNamespace, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.ProjectNamespace, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateGroupPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.CreateGroupPreferencesRequest)
-		return handler.IsAuthorized(ctx, schema.GroupPrincipal, pbreq.GetId(), schema.UpdatePermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupPrincipal, ID: pbreq.GetId()}, schema.UpdatePermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/ListGroupPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		pbreq := req.(*frontierv1beta1.ListGroupPreferencesRequest)
-		return handler.IsAuthorized(ctx, schema.GroupPrincipal, pbreq.GetId(), schema.GetPermission)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.GroupPrincipal, ID: pbreq.GetId()}, schema.GetPermission)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/CreateUserPreferences": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
 		return handler.IsSuperUser(ctx)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -117,7 +117,6 @@ func Serve(
 		}),
 	)
 	grpcGateway := runtime.NewServeMux(grpcGatewayServerInterceptors...)
-
 	var rootHandler http.Handler = grpcGateway
 	if len(cfg.Cors.AllowedOrigins) > 0 {
 		rootHandler = interceptors.WithCors(rootHandler, cfg.Cors)
@@ -208,9 +207,9 @@ func getGRPCMiddleware(logger log.Logger, identityProxyHeader string, nrApp newr
 	return grpc.UnaryInterceptor(
 		grpc_middleware.ChainUnaryServer(
 			grpc_recovery.UnaryServerInterceptor(grpcRecoveryOpts...),
+			grpc_zap.UnaryServerInterceptor(grpcZapLogger.Desugar()),
 			nrgrpc.UnaryServerInterceptor(nrApp),
 			interceptors.EnrichCtxWithPassthroughEmail(identityProxyHeader),
-			grpc_zap.UnaryServerInterceptor(grpcZapLogger.Desugar()),
 			grpc_ctxtags.UnaryServerInterceptor(),
 			grpc_validator.UnaryServerInterceptor(),
 			sessionMiddleware.UnaryGRPCRequestHeadersAnnotator(),


### PR DESCRIPTION
- currently after modifying a preference(like a platform configuration) application restart is required, this will no longer be a requirement
- updated go version to 1.21
- fixed org owner not having permission to delete invitation
- fixed role title not getting updated on update call