### PR TITLE
fix: group users listing should only have members

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -213,7 +213,7 @@ func buildAPIDependencies(
 	policyService := policy.NewService(policyPGRepository, relationService, roleService)
 
 	userRepository := postgres.NewUserRepository(dbc)
-	userService := user.NewService(userRepository, relationService)
+	userService := user.NewService(userRepository, relationService, policyService)
 
 	svUserRepo := postgres.NewServiceUserRepository(dbc)
 	scUserCredRepo := postgres.NewServiceUserCredentialRepository(dbc)

--- a/internal/bootstrap/schema/schema.go
+++ b/internal/bootstrap/schema/schema.go
@@ -69,8 +69,9 @@ const (
 	SuperUserPrincipal   = "app/superuser"
 
 	// Roles
-	RoleOrganizationViewer = "app_organization_viewer"
-	RoleOrganizationOwner  = "app_organization_owner"
+	RoleOrganizationViewer  = "app_organization_viewer"
+	RoleOrganizationManager = "app_organization_manager"
+	RoleOrganizationOwner   = "app_organization_owner"
 
 	RoleProjectOwner   = "app_project_owner"
 	RoleProjectManager = "app_project_manager"
@@ -271,7 +272,7 @@ var PredefinedRoles = []RoleDefinition{
 	},
 	{
 		Title: "Organization Manager",
-		Name:  "app_organization_manager",
+		Name:  RoleOrganizationManager,
 		Permissions: []string{
 			"app_organization_update",
 			"app_organization_get",
@@ -296,6 +297,14 @@ var PredefinedRoles = []RoleDefinition{
 	},
 	{
 		Title: "Organization Viewer",
+		Name:  RoleOrganizationViewer,
+		Permissions: []string{
+			"app_organization_get",
+		},
+		Scopes: []string{OrganizationNamespace},
+	},
+	{
+		Title: "Organization Group Viewer",
 		Name:  RoleOrganizationViewer,
 		Permissions: []string{
 			"app_organization_get",

--- a/internal/store/postgres/metaschemas/group.json
+++ b/internal/store/postgres/metaschemas/group.json
@@ -14,5 +14,5 @@
       "type": "string"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/internal/store/postgres/metaschemas/org.json
+++ b/internal/store/postgres/metaschemas/org.json
@@ -14,5 +14,5 @@
       "type": "string"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/internal/store/postgres/metaschemas/role.json
+++ b/internal/store/postgres/metaschemas/role.json
@@ -14,5 +14,5 @@
       "type": "string"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/internal/store/postgres/metaschemas/user.json
+++ b/internal/store/postgres/metaschemas/user.json
@@ -14,5 +14,5 @@
       "type": "string"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/test/e2e/testbench/testdata/mocks/mock-organization.json
+++ b/test/e2e/testbench/testdata/mocks/mock-organization.json
@@ -8,6 +8,14 @@
         }
     },
     {
+        "name": "org-2",
+        "title": "org 2",
+        "metadata": {
+            "label": {},
+            "description": "description"
+        }
+    },
+    {
         "title": "org user 1",
         "name": "org-user-1"
     },


### PR DESCRIPTION
- currently listing group users returns all the users who have access to the group
- ideally it should only return users who were explicitly added as owner or member of the group
- same goes for listing project users