### PR TITLE
Fix(sdk): styling and rerendring issues

### DIFF
--- a/sdks/js/packages/core/package.json
+++ b/sdks/js/packages/core/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.1",
-    "@raystack/apsara": "^0.11.5",
+    "@raystack/apsara": "^0.11.7",
     "@tanstack/react-router": "0.0.1-beta.174",
     "axios": "^1.5.0",
     "class-variance-authority": "^0.7.0",

--- a/sdks/js/packages/core/react/components/organization/create.tsx
+++ b/sdks/js/packages/core/react/components/organization/create.tsx
@@ -11,7 +11,6 @@ import { Container } from '../Container';
 // @ts-ignore
 import styles from './organization.module.css';
 
-
 type CreateOrganizationProps = ComponentPropsWithRef<typeof Container> & {
   title?: string;
   description?: string;
@@ -88,7 +87,6 @@ export const CreateOrganization = ({
                     {...field}
                     // @ts-ignore
                     size="medium"
-                    label="Workspace URL"
                     placeholder="raystack.org/"
                   />
                 )}

--- a/sdks/js/packages/core/react/components/organization/members/invite.tsx
+++ b/sdks/js/packages/core/react/components/organization/members/invite.tsx
@@ -194,7 +194,7 @@ export const InviteMember = () => {
                 <Controller
                   render={({ field }) => (
                     <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger className="w-[180px]">
+                      <Select.Trigger>
                         <Select.Value placeholder="Select a role" />
                       </Select.Trigger>
                       <Select.Content
@@ -237,7 +237,7 @@ export const InviteMember = () => {
                 <Controller
                   render={({ field }) => (
                     <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger className="w-[180px]" op>
+                      <Select.Trigger>
                         <Select.Value placeholder="Select a team" />
                       </Select.Trigger>
                       <Select.Content

--- a/sdks/js/packages/core/react/components/organization/members/invite.tsx
+++ b/sdks/js/packages/core/react/components/organization/members/invite.tsx
@@ -192,35 +192,38 @@ export const InviteMember = () => {
                 <Skeleton height={'25px'} />
               ) : (
                 <Controller
-                  render={({ field }) => (
-                    <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger>
-                        <Select.Value placeholder="Select a role" />
-                      </Select.Trigger>
-                      <Select.Content
-                        style={{
-                          width: '100% !important',
-                          minWidth: '180px',
-                          zIndex: 65
-                        }}
-                      >
-                        <Select.Group>
-                          {!roles.length && (
-                            <Select.Label
-                              style={{ color: 'var(--foreground-base)' }}
-                            >
-                              No roles available
-                            </Select.Label>
-                          )}
-                          {roles.map(role => (
-                            <Select.Item value={role.id} key={role.id}>
-                              {role.title || role.name}
-                            </Select.Item>
-                          ))}
-                        </Select.Group>
-                      </Select.Content>
-                    </Select>
-                  )}
+                  render={({ field }) => {
+                    const { ref, onChange, ...rest } = field;
+                    return (
+                      <Select {...rest} onValueChange={onChange}>
+                        <Select.Trigger className="w-[180px]" ref={ref}>
+                          <Select.Value placeholder="Select a role" />
+                        </Select.Trigger>
+                        <Select.Content
+                          style={{
+                            width: '100% !important',
+                            minWidth: '180px',
+                            zIndex: 65
+                          }}
+                        >
+                          <Select.Group>
+                            {!roles.length && (
+                              <Select.Label
+                                style={{ color: 'var(--foreground-base)' }}
+                              >
+                                No roles available
+                              </Select.Label>
+                            )}
+                            {roles.map(role => (
+                              <Select.Item value={role.id} key={role.id}>
+                                {role.title || role.name}
+                              </Select.Item>
+                            ))}
+                          </Select.Group>
+                        </Select.Content>
+                      </Select>
+                    );
+                  }}
                   control={control}
                   name="type"
                 />
@@ -235,35 +238,38 @@ export const InviteMember = () => {
                 <Skeleton height={'25px'} />
               ) : (
                 <Controller
-                  render={({ field }) => (
-                    <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger>
-                        <Select.Value placeholder="Select a team" />
-                      </Select.Trigger>
-                      <Select.Content
-                        style={{
-                          width: '100% !important',
-                          minWidth: '180px',
-                          zIndex: 65
-                        }}
-                      >
-                        <Select.Group>
-                          {!teams.length && (
-                            <Select.Label
-                              style={{ color: 'var(--foreground-base)' }}
-                            >
-                              No teams available
-                            </Select.Label>
-                          )}
-                          {teams.map(t => (
-                            <Select.Item value={t.id} key={t.id}>
-                              {t.title}
-                            </Select.Item>
-                          ))}
-                        </Select.Group>
-                      </Select.Content>
-                    </Select>
-                  )}
+                  render={({ field }) => {
+                    const { ref, onChange, ...rest } = field;
+                    return (
+                      <Select {...rest} onValueChange={onChange}>
+                        <Select.Trigger className="w-[180px]" ref={ref}>
+                          <Select.Value placeholder="Select a team" />
+                        </Select.Trigger>
+                        <Select.Content
+                          style={{
+                            width: '100% !important',
+                            minWidth: '180px',
+                            zIndex: 65
+                          }}
+                        >
+                          <Select.Group>
+                            {!teams.length && (
+                              <Select.Label
+                                style={{ color: 'var(--foreground-base)' }}
+                              >
+                                No teams available
+                              </Select.Label>
+                            )}
+                            {teams.map(t => (
+                              <Select.Item value={t.id} key={t.id}>
+                                {t.title}
+                              </Select.Item>
+                            ))}
+                          </Select.Group>
+                        </Select.Content>
+                      </Select>
+                    );
+                  }}
                   control={control}
                   name="team"
                 />

--- a/sdks/js/packages/core/react/components/organization/preferences/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/preferences/index.tsx
@@ -122,7 +122,7 @@ export const PreferencesSelection = ({
         </Text>
       </Flex>
       <Select onValueChange={onSelection} defaultValue={defaultValue}>
-        <Select.Trigger className="w-[180px]">
+        <Select.Trigger>
           <Select.Value placeholder={label} />
         </Select.Trigger>
         <Select.Content style={{ minWidth: '120px' }}>

--- a/sdks/js/packages/core/react/components/organization/profile.tsx
+++ b/sdks/js/packages/core/react/components/organization/profile.tsx
@@ -5,9 +5,9 @@ import {
   RouterProvider,
   Router,
   Route,
-  RouterContext,
   createMemoryHistory,
-  useRouterContext
+  useRouterContext,
+  RouterContext
 } from '@tanstack/react-router';
 import { Toaster } from 'sonner';
 import { useFrontier } from '~/react/contexts/FrontierContext';

--- a/sdks/js/packages/core/react/components/organization/profile.tsx
+++ b/sdks/js/packages/core/react/components/organization/profile.tsx
@@ -5,8 +5,9 @@ import {
   RouterProvider,
   Router,
   Route,
-  RootRoute,
-  createMemoryHistory
+  RouterContext,
+  createMemoryHistory,
+  useRouterContext
 } from '@tanstack/react-router';
 import { Toaster } from 'sonner';
 import { useFrontier } from '~/react/contexts/FrontierContext';
@@ -41,25 +42,60 @@ interface OrganizationProfileProps {
   defaultRoute?: string;
 }
 
-const rootRoute = new RootRoute({
-  component: () => {
-    return (
-      <ThemeProvider>
-        <SkeletonTheme
-          highlightColor="var(--background-base)"
-          baseColor="var(--background-base-hover)"
-        >
-          <Toaster richColors />
-          <Flex style={{ width: '100%', height: '100%' }}>
-            <Sidebar />
-            <Outlet />
-          </Flex>
-        </SkeletonTheme>
-      </ThemeProvider>
-    );
-  }
-});
+const RootRouter = () => {
+  const { organizationId } = useRouterContext({ from: '__root__' });
+  const { client, setActiveOrganization, setIsActiveOrganizationLoading } =
+    useFrontier();
 
+  const fetchOrganization = useCallback(async () => {
+    try {
+      setIsActiveOrganizationLoading(true);
+      const {
+        // @ts-ignore
+        data: { organization }
+      } = await client?.frontierServiceGetOrganization(organizationId);
+      setActiveOrganization(organization);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsActiveOrganizationLoading(false);
+    }
+  }, [
+    client,
+    organizationId,
+    setActiveOrganization,
+    setIsActiveOrganizationLoading
+  ]);
+
+  useEffect(() => {
+    if (organizationId) {
+      fetchOrganization();
+    } else {
+      setActiveOrganization(undefined);
+    }
+  }, [organizationId, fetchOrganization, setActiveOrganization]);
+
+  return (
+    <ThemeProvider>
+      <SkeletonTheme
+        highlightColor="var(--background-base)"
+        baseColor="var(--background-base-hover)"
+      >
+        <Toaster richColors />
+        <Flex style={{ width: '100%', height: '100%' }}>
+          <Sidebar />
+          <Outlet />
+        </Flex>
+      </SkeletonTheme>
+    </ThemeProvider>
+  );
+};
+
+const routerContext = new RouterContext<{ organizationId: string }>();
+
+const rootRoute = routerContext.createRootRoute({
+  component: RootRouter
+});
 const indexRoute = new Route({
   getParentRoute: () => rootRoute,
   path: '/',
@@ -203,48 +239,21 @@ const routeTree = rootRoute.addChildren([
   preferencesRoute
 ]);
 
-const router = new Router({ routeTree });
+const router = new Router({ routeTree, context: { organizationId: '' } });
 
 export const OrganizationProfile = ({
   organizationId,
   defaultRoute = '/'
 }: OrganizationProfileProps) => {
-  const { client, setActiveOrganization, setIsActiveOrganizationLoading } =
-    useFrontier();
-
-  const fetchOrganization = useCallback(async () => {
-    try {
-      setIsActiveOrganizationLoading(true);
-      const {
-        // @ts-ignore
-        data: { organization }
-      } = await client?.frontierServiceGetOrganization(organizationId);
-      setActiveOrganization(organization);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsActiveOrganizationLoading(false);
-    }
-  }, [
-    client,
-    organizationId,
-    setActiveOrganization,
-    setIsActiveOrganizationLoading
-  ]);
-
-  useEffect(() => {
-    if (organizationId) {
-      fetchOrganization();
-    } else {
-      setActiveOrganization(undefined);
-    }
-  }, [organizationId, fetchOrganization, setActiveOrganization]);
-
   const memoryHistory = createMemoryHistory({
     initialEntries: [defaultRoute]
   });
 
-  const memoryRouter = new Router({ routeTree, history: memoryHistory });
+  const memoryRouter = new Router({
+    routeTree,
+    history: memoryHistory,
+    context: { organizationId }
+  });
 
   return <RouterProvider router={memoryRouter} />;
 };

--- a/sdks/js/packages/core/react/components/organization/project/add.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/add.tsx
@@ -29,7 +29,7 @@ const projectSchema = yup
       .max(50, 'name is not valid, Max 50 characters allowed')
       .matches(
         /^[a-zA-Z0-9_-]{3,50}$/,
-        "Only numbers, letters, '-', and '_' are allowed"
+        "Only numbers, letters, '-', and '_' are allowed. Spaces are not allowed."
       ),
     orgId: yup.string().required()
   })

--- a/sdks/js/packages/core/react/components/organization/project/delete.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/delete.tsx
@@ -61,7 +61,6 @@ export const DeleteProject = () => {
   }, [client, projectId]);
 
   async function onSubmit(data: any) {
-    console.log('>', data);
     if (!organization?.id) return;
     if (!projectId) return;
     if (!client) return;
@@ -72,7 +71,6 @@ export const DeleteProject = () => {
     try {
       await client.frontierServiceDeleteProject(projectId);
       toast.success('project deleted');
-
       navigate({ to: '/projects' });
     } catch ({ error }: any) {
       toast.error('Something went wrong', {

--- a/sdks/js/packages/core/react/components/organization/project/members/invite.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/members/invite.tsx
@@ -142,7 +142,7 @@ export const InviteProjectTeam = () => {
                 <Controller
                   render={({ field }) => (
                     <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger className="w-[180px]">
+                      <Select.Trigger>
                         <Select.Value placeholder="Select a team" />
                       </Select.Trigger>
                       <Select.Content
@@ -184,7 +184,7 @@ export const InviteProjectTeam = () => {
                 <Controller
                   render={({ field }) => (
                     <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger className="w-[180px]">
+                      <Select.Trigger>
                         <Select.Value placeholder="Select a role" />
                       </Select.Trigger>
                       <Select.Content

--- a/sdks/js/packages/core/react/components/organization/project/project.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/project.tsx
@@ -7,7 +7,7 @@ import {
   useParams,
   useRouterState
 } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import backIcon from '~/react/assets/chevron-left.svg';
 import { useFrontier } from '~/react/contexts/FrontierContext';
@@ -26,9 +26,15 @@ export const ProjectPage = () => {
   let navigate = useNavigate({ from: '/projects/$projectId' });
   const routeState = useRouterState();
 
+  const isDeleteRoute = useMemo(() => {
+    return routeState.matches.some(
+      route => route.routeId === '/projects/$projectId/delete'
+    );
+  }, [routeState.matches]);
+
   useEffect(() => {
     async function getProjectDetails() {
-      if (!organization?.id || !projectId) return;
+      if (!organization?.id || !projectId || isDeleteRoute) return;
 
       try {
         const {
@@ -56,7 +62,13 @@ export const ProjectPage = () => {
       }
     }
     getProjectDetails();
-  }, [client, organization?.id, projectId, routeState.location.key]);
+  }, [
+    client,
+    organization?.id,
+    projectId,
+    routeState.location.key,
+    isDeleteRoute
+  ]);
 
   return (
     <Flex direction="column" style={{ width: '100%' }}>

--- a/sdks/js/packages/core/react/components/organization/project/projects.columns.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/projects.columns.tsx
@@ -37,13 +37,13 @@ export const getColumns: (
           );
         }
   },
-  {
-    header: 'Privacy',
-    accessorKey: 'privacy',
-    cell: isLoading
-      ? () => <Skeleton />
-      : info => <Text>{info.getValue() ?? 'Public'}</Text>
-  },
+  // {
+  //   header: 'Privacy',
+  //   accessorKey: 'privacy',
+  //   cell: isLoading
+  //     ? () => <Skeleton />
+  //     : info => <Text>{info.getValue() ?? 'Public'}</Text>
+  // },
   {
     header: 'Members',
     accessorKey: 'members',

--- a/sdks/js/packages/core/react/components/organization/teams/add.tsx
+++ b/sdks/js/packages/core/react/components/organization/teams/add.tsx
@@ -28,7 +28,7 @@ const teamSchema = yup
       .max(50, 'name is not valid, Max 50 characters allowed')
       .matches(
         /^[a-zA-Z0-9_-]{3,50}$/,
-        "Only numbers, letters, '-', and '_' are allowed"
+        "Only numbers, letters, '-', and '_' are allowed. Spaces are not allowed."
       )
   })
   .required();

--- a/sdks/js/packages/core/react/components/organization/teams/members/invite.tsx
+++ b/sdks/js/packages/core/react/components/organization/teams/members/invite.tsx
@@ -209,7 +209,7 @@ export const InviteTeamMembers = () => {
                 <Controller
                   render={({ field }) => (
                     <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger className="w-[180px]">
+                      <Select.Trigger>
                         <Select.Value placeholder="Select members" />
                       </Select.Trigger>
                       <Select.Content
@@ -249,7 +249,7 @@ export const InviteTeamMembers = () => {
                 <Controller
                   render={({ field }) => (
                     <Select {...field} onValueChange={field.onChange}>
-                      <Select.Trigger className="w-[180px]">
+                      <Select.Trigger>
                         <Select.Value placeholder="Select a role" />
                       </Select.Trigger>
                       <Select.Content

--- a/sdks/js/packages/core/react/components/organization/teams/team.tsx
+++ b/sdks/js/packages/core/react/components/organization/teams/team.tsx
@@ -7,7 +7,7 @@ import {
   useParams,
   useRouterState
 } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import backIcon from '~/react/assets/chevron-left.svg';
 import { useFrontier } from '~/react/contexts/FrontierContext';
@@ -26,9 +26,15 @@ export const TeamPage = () => {
   let navigate = useNavigate({ from: '/teams/$teamId' });
   const routerState = useRouterState();
 
+  const isDeleteRoute = useMemo(() => {
+    return routerState.matches.some(
+      route => route.routeId === '/teams/$teamId/delete'
+    );
+  }, [routerState.matches]);
+
   useEffect(() => {
     async function getTeamDetails() {
-      if (!organization?.id || !teamId) return;
+      if (!organization?.id || !teamId || isDeleteRoute) return;
 
       try {
         const {
@@ -44,11 +50,11 @@ export const TeamPage = () => {
       }
     }
     getTeamDetails();
-  }, [client, organization?.id, teamId]);
+  }, [client, organization?.id, teamId, isDeleteRoute]);
 
   useEffect(() => {
     async function getTeamMembers() {
-      if (!organization?.id || !teamId) return;
+      if (!organization?.id || !teamId || isDeleteRoute) return;
       try {
         const {
           // @ts-ignore
@@ -71,7 +77,13 @@ export const TeamPage = () => {
       }
     }
     getTeamMembers();
-  }, [client, organization?.id, teamId, routerState.location.key]);
+  }, [
+    client,
+    organization?.id,
+    teamId,
+    routerState.location.key,
+    isDeleteRoute
+  ]);
 
   return (
     <Flex direction="column" style={{ width: '100%' }}>

--- a/sdks/js/packages/core/react/hooks/useOrganizationTeams.ts
+++ b/sdks/js/packages/core/react/hooks/useOrganizationTeams.ts
@@ -5,10 +5,12 @@ import { V1Beta1Group } from '~/src';
 
 interface useOrganizationTeamsProps {
   withPermissions?: string[];
+  showOrgTeams?: boolean;
 }
 
 export const useOrganizationTeams = ({
-  withPermissions = []
+  withPermissions = [],
+  showOrgTeams = false
 }: useOrganizationTeamsProps) => {
   const [teams, setTeams] = useState<V1Beta1Group[]>([]);
   const [isTeamsLoading, setIsTeamsLoading] = useState(false);
@@ -18,16 +20,19 @@ export const useOrganizationTeams = ({
   const routerState = useRouterState();
 
   const getTeams = useCallback(async () => {
+    if (!organization?.id) return;
     try {
       setIsTeamsLoading(true);
       const {
         // @ts-ignore
         data: { groups = [], access_pairs = [] }
-      } = await client?.frontierServiceListCurrentUserGroups({
-        // @ts-ignore
-        org_id: organization?.id,
-        withPermissions
-      });
+      } = showOrgTeams
+        ? await client?.frontierServiceListOrganizationGroups(organization?.id)
+        : await client?.frontierServiceListCurrentUserGroups({
+            // @ts-ignore
+            org_id: organization?.id,
+            withPermissions
+          });
       setTeams(groups);
       setAccessPairs(access_pairs);
     } catch (err) {
@@ -35,7 +40,7 @@ export const useOrganizationTeams = ({
     } finally {
       setIsTeamsLoading(false);
     }
-  }, [client, organization?.id]);
+  }, [client, organization?.id, showOrgTeams]);
 
   useEffect(() => {
     getTeams();

--- a/sdks/js/pnpm-lock.yaml
+++ b/sdks/js/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1(react-hook-form@7.46.2)
       '@raystack/apsara':
-        specifier: ^0.11.5
-        version: 0.11.5(typescript@5.2.2)
+        specifier: ^0.11.7
+        version: 0.11.7(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
       '@tanstack/react-router':
         specifier: 0.0.1-beta.174
         version: 0.0.1-beta.174(react-dom@18.2.0)(react@18.2.0)
@@ -992,6 +992,34 @@ packages:
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
     dev: true
 
+  /@floating-ui/core@1.5.0:
+    resolution: {integrity: sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==}
+    dependencies:
+      '@floating-ui/utils': 0.1.6
+    dev: false
+
+  /@floating-ui/dom@1.5.3:
+    resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
+    dependencies:
+      '@floating-ui/core': 1.5.0
+      '@floating-ui/utils': 0.1.6
+    dev: false
+
+  /@floating-ui/react-dom@2.0.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.5.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@floating-ui/utils@0.1.6:
+    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+    dev: false
+
   /@gisatcz/cross-package-react-context@0.2.0(react@18.2.0):
     resolution: {integrity: sha512-E7aR/o1ArpXETO8bQi+Hltj3duHeZiLjR+x1VZrCDs3jplSLGoy+oqCcqNNE1BamTBa0YQTs8Go1Q1dtt3LEUg==}
     peerDependencies:
@@ -1322,6 +1350,86 @@ packages:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  /@radix-ui/primitive@1.0.1:
+    resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
+    dependencies:
+      '@babel/runtime': 7.22.15
+    dev: false
+
+  /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-context@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-icons@1.3.0(react@18.2.0):
     resolution: {integrity: sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==}
     peerDependencies:
@@ -1330,13 +1438,289 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@raystack/apsara@0.11.5(typescript@5.2.2):
-    resolution: {integrity: sha512-0pG0sUa09dZz4wUZxVU5YVey8FPySllbDO9JKqI+IIs9DgeH0q16Xyayc6xShoHIA5f1eeiN4IXOfCVDRWoyeA==}
+  /@radix-ui/react-id@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-popper@1.1.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@floating-ui/react-dom': 2.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/rect': 1.0.1
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-portal@1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-slot@1.0.2(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-tooltip@1.0.7(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-rect@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/rect': 1.0.1
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-size@1.0.1(@types/react@18.2.22)(react@18.2.0):
+    resolution: {integrity: sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.22)(react@18.2.0)
+      '@types/react': 18.2.22
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.22
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/rect@1.0.1:
+    resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
+    dependencies:
+      '@babel/runtime': 7.22.15
+    dev: false
+
+  /@raystack/apsara@0.11.7(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-QY793YZZHaXxHt/tpZkpswqydtRXE43G5dgROpv1QZJb1GF2+zPzocrpuKnegtMg8/dM34qIExfeseb5OS+xJQ==}
     engines: {node: '>=12.x.x'}
     dependencies:
+      '@radix-ui/react-tooltip': 1.0.7(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
       release-it: 16.2.1(typescript@5.2.2)
     transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
       - encoding
+      - react
+      - react-dom
       - supports-color
       - typescript
     dev: false
@@ -1638,13 +2022,11 @@ packages:
 
   /@types/prop-types@15.7.6:
     resolution: {integrity: sha512-RK/kBbYOQQHLYj9Z95eh7S6t7gq4Ojt/NT8HTk8bWVhA5DaF+5SMnxHKkP4gPNN3wAZkKP+VjAf0ebtYzf+fxg==}
-    dev: true
 
   /@types/react-dom@18.2.7:
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
     dependencies:
       '@types/react': 18.2.22
-    dev: true
 
   /@types/react@18.2.22:
     resolution: {integrity: sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==}
@@ -1652,7 +2034,6 @@ packages:
       '@types/prop-types': 15.7.6
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: true
 
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -1662,7 +2043,6 @@ packages:
 
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
-    dev: true
 
   /@types/semver@7.5.2:
     resolution: {integrity: sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==}
@@ -2669,7 +3049,6 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-    dev: true
 
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}


### PR DESCRIPTION
This PR will
1. remove the privacy column from project list as it is not used anywhere right now.
2. remove 180px width tailwind class from select components.
3. move useState inside the router to prevent creating new router everytime.
4. in project and team delete modal, the background page stills calls the get api after deletion due to location key change and throw 403 error.
5. Add option to switch between `current user joined teams` and `organization teams` for admin.