### PR TITLE
fix: list only explicitly added org members

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -213,7 +213,7 @@ func buildAPIDependencies(
 	policyService := policy.NewService(policyPGRepository, relationService, roleService)
 
 	userRepository := postgres.NewUserRepository(dbc)
-	userService := user.NewService(userRepository, relationService, policyService)
+	userService := user.NewService(userRepository, relationService, policyService, roleService)
 
 	svUserRepo := postgres.NewServiceUserRepository(dbc)
 	scUserCredRepo := postgres.NewServiceUserCredentialRepository(dbc)

--- a/core/group/group.go
+++ b/core/group/group.go
@@ -20,8 +20,10 @@ const (
 	Enabled  State = "enabled"
 	Disabled State = "disabled"
 
-	MemberPermission = schema.MembershipPermission
-	AdminPermission  = schema.DeletePermission
+	AdminPermission = schema.DeletePermission
+
+	MemberRole = schema.GroupMemberRole
+	AdminRole  = schema.GroupOwnerRole
 )
 
 type Repository interface {

--- a/internal/api/v1beta1/group.go
+++ b/internal/api/v1beta1/group.go
@@ -107,7 +107,7 @@ func (h Handler) ListOrganizationGroups(ctx context.Context, request *frontierv1
 		}
 
 		if request.WithMembers {
-			groupUsers, err := h.userService.ListByGroup(ctx, v.ID, group.MemberPermission)
+			groupUsers, err := h.userService.ListByGroup(ctx, v.ID, "")
 			if err != nil {
 				logger.Error(err.Error())
 				return nil, grpcInternalServerError
@@ -233,7 +233,7 @@ func (h Handler) GetGroup(ctx context.Context, request *frontierv1beta1.GetGroup
 		return nil, grpcInternalServerError
 	}
 	if request.GetWithMembers() {
-		groupUsers, err := h.userService.ListByGroup(ctx, fetchedGroup.ID, group.MemberPermission)
+		groupUsers, err := h.userService.ListByGroup(ctx, fetchedGroup.ID, "")
 		if err != nil {
 			logger.Error(err.Error())
 			return nil, grpcInternalServerError
@@ -333,7 +333,7 @@ func (h Handler) ListGroupUsers(ctx context.Context, request *frontierv1beta1.Li
 
 	var userPBs []*frontierv1beta1.User
 	var rolePairPBs []*frontierv1beta1.ListGroupUsersResponse_RolePair
-	users, err := h.userService.ListByGroup(ctx, request.Id, group.MemberPermission)
+	users, err := h.userService.ListByGroup(ctx, request.Id, "")
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
@@ -417,7 +417,7 @@ func (h Handler) RemoveGroupUser(ctx context.Context, request *frontierv1beta1.R
 	}
 
 	// before deleting the user, check if the user is the only owner of the group
-	owners, err := h.userService.ListByGroup(ctx, request.GetId(), schema.DeletePermission)
+	owners, err := h.userService.ListByGroup(ctx, request.GetId(), group.AdminRole)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError

--- a/internal/api/v1beta1/group_test.go
+++ b/internal/api/v1beta1/group_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
-	"github.com/raystack/frontier/internal/bootstrap/schema"
 	"github.com/raystack/frontier/pkg/errors"
 	"github.com/raystack/frontier/pkg/metadata"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -1079,7 +1078,7 @@ func TestHandler_ListOrganizationGroups(t *testing.T) {
 				gs.EXPECT().List(mock.Anything, group.Filter{
 					OrganizationID: testOrgID,
 				}).Return(testGroupList, nil)
-				us.EXPECT().ListByGroup(mock.Anything, testGroupID, group.MemberPermission).Return([]user.User{
+				us.EXPECT().ListByGroup(mock.Anything, testGroupID, "").Return([]user.User{
 					{
 						ID:       testUserID,
 						Metadata: map[string]any{},
@@ -1237,7 +1236,7 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 			name: "should return internal server error if error in removing group users",
 			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.Anything, testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByGroup(mock.Anything, someGroupID, schema.DeletePermission).Return(
+				us.EXPECT().ListByGroup(mock.Anything, someGroupID, group.AdminRole).Return(
 					[]user.User{
 						testUserMap[testUserID],
 						{
@@ -1265,7 +1264,7 @@ func TestHandler_RemoveGroupUsers(t *testing.T) {
 			name: "should return success if remove group users and group service return nil error",
 			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.Anything, testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByGroup(mock.Anything, someGroupID, schema.DeletePermission).Return(
+				us.EXPECT().ListByGroup(mock.Anything, someGroupID, group.AdminRole).Return(
 					[]user.User{
 						testUserMap[testUserID],
 						{
@@ -1346,7 +1345,7 @@ func TestHandler_ListGroupUsers(t *testing.T) {
 			name: "should return internal server error if error in listing group users",
 			setup: func(gs *mocks.GroupService, us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.Anything, testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByGroup(mock.Anything, someGroupID, group.MemberPermission).Return(nil, errors.New("some error"))
+				us.EXPECT().ListByGroup(mock.Anything, someGroupID, "").Return(nil, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListGroupUsersRequest{
 				Id:    someGroupID,
@@ -1367,7 +1366,7 @@ func TestHandler_ListGroupUsers(t *testing.T) {
 					},
 				}
 
-				us.EXPECT().ListByGroup(mock.Anything, someGroupID, schema.MembershipPermission).Return(testUserList, nil)
+				us.EXPECT().ListByGroup(mock.Anything, someGroupID, "").Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListGroupUsersRequest{
 				Id:    someGroupID,
@@ -1384,7 +1383,7 @@ func TestHandler_ListGroupUsers(t *testing.T) {
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByGroup(mock.Anything, someGroupID, schema.MembershipPermission).Return(testUserList, nil)
+				us.EXPECT().ListByGroup(mock.Anything, someGroupID, "").Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListGroupUsersRequest{
 				Id:    someGroupID,

--- a/internal/api/v1beta1/org.go
+++ b/internal/api/v1beta1/org.go
@@ -236,7 +236,7 @@ func (h Handler) ListOrganizationAdmins(ctx context.Context, request *frontierv1
 		}
 	}
 
-	admins, err := h.userService.ListByOrg(ctx, orgResp.ID, organization.AdminPermission)
+	admins, err := h.userService.ListByOrg(ctx, orgResp.ID, organization.AdminRole)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
@@ -271,12 +271,7 @@ func (h Handler) ListOrganizationUsers(ctx context.Context, request *frontierv1b
 		}
 	}
 
-	permissionFilter := schema.MembershipPermission
-	if len(request.GetPermissionFilter()) > 0 {
-		permissionFilter = request.GetPermissionFilter()
-	}
-
-	users, err := h.userService.ListByOrg(ctx, orgResp.ID, permissionFilter)
+	users, err := h.userService.ListByOrg(ctx, orgResp.ID, request.GetPermissionFilter())
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
@@ -437,7 +432,7 @@ func (h Handler) RemoveOrganizationUser(ctx context.Context, request *frontierv1
 		}
 	}
 
-	admins, err := h.userService.ListByOrg(ctx, orgResp.ID, organization.AdminPermission)
+	admins, err := h.userService.ListByOrg(ctx, orgResp.ID, organization.AdminRole)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError

--- a/internal/api/v1beta1/org_test.go
+++ b/internal/api/v1beta1/org_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/raystack/frontier/pkg/utils"
 
-	"github.com/raystack/frontier/internal/bootstrap/schema"
-
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
@@ -598,7 +596,7 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, schema.UpdatePermission).Return([]user.User{}, errors.New("some error"))
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, organization.AdminRole).Return([]user.User{}, errors.New("some error"))
 			},
 			request: &frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: testOrgID,
@@ -625,7 +623,7 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, schema.UpdatePermission).Return(testUserList, nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, organization.AdminRole).Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: testOrgID,
@@ -706,7 +704,7 @@ func TestHandler_ListOrganizationUsers(t *testing.T) {
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "membership").Return(testUserList, nil)
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "").Return(testUserList, nil)
 			},
 			request: &frontierv1beta1.ListOrganizationUsersRequest{
 				Id: testOrgID,
@@ -1082,7 +1080,7 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 			name: "should return the error and not remove user if it is the last admin user",
 			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.CascadeDeleter) {
 				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "update").Return([]user.User{
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, organization.AdminRole).Return([]user.User{
 					testUserMap[testUserID],
 				}, nil)
 				ds.EXPECT().RemoveUsersFromOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, []string{testUserID}).Return(nil)
@@ -1098,7 +1096,7 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 			name: "should remove user from org successfully",
 			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.CascadeDeleter) {
 				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, "update").Return([]user.User{
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, organization.AdminRole).Return([]user.User{
 					testUserMap[testUserID],
 					{
 						ID:        "some-user-id",

--- a/internal/api/v1beta1/user.go
+++ b/internal/api/v1beta1/user.go
@@ -41,8 +41,8 @@ type UserService interface {
 	GetByEmail(ctx context.Context, email string) (user.User, error)
 	Create(ctx context.Context, user user.User) (user.User, error)
 	List(ctx context.Context, flt user.Filter) ([]user.User, error)
-	ListByOrg(ctx context.Context, orgID string, permissionFilter string) ([]user.User, error)
-	ListByGroup(ctx context.Context, groupID string, capability string) ([]user.User, error)
+	ListByOrg(ctx context.Context, orgID string, roleFilter string) ([]user.User, error)
+	ListByGroup(ctx context.Context, groupID string, roleFilter string) ([]user.User, error)
 	Update(ctx context.Context, toUpdate user.User) (user.User, error)
 	Enable(ctx context.Context, id string) error
 	Disable(ctx context.Context, id string) error


### PR DESCRIPTION
- currently org to user relation ships are calculated dynamically and all direct or indirect access controls will be evaluated but after this change only users who are added as a member or given access via a policy will be listed. For example, super users will who have access to whole platform will not be part of the list if they don't have explicit access to the org.