### PR TITLE
fix: listing projects with non-inherit roles handle no groups

### DIFF
--- a/core/project/service.go
+++ b/core/project/service.go
@@ -145,16 +145,18 @@ func (s Service) ListByUser(ctx context.Context, userID string, flt Filter) ([]P
 		groupIDs := utils.Map(groups, func(g group.Group) string {
 			return g.ID
 		})
-		policies, err = s.policyService.List(ctx, policy.Filter{
-			PrincipalType: schema.GroupPrincipal,
-			PrincipalIDs:  groupIDs,
-			ResourceType:  schema.ProjectNamespace,
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, pol := range policies {
-			projIDs = append(projIDs, pol.ResourceID)
+		if len(groupIDs) > 0 {
+			policies, err = s.policyService.List(ctx, policy.Filter{
+				PrincipalType: schema.GroupPrincipal,
+				PrincipalIDs:  groupIDs,
+				ResourceType:  schema.ProjectNamespace,
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, pol := range policies {
+				projIDs = append(projIDs, pol.ResourceID)
+			}
 		}
 	} else {
 		projIDs, err = s.relationService.LookupResources(ctx, relation.Relation{


### PR DESCRIPTION
While looking for projects in policy repository, if there were no groups returned by group service, there were no filters applied on principal while querying policies returning projects which user has no direct relation