### PR TITLE
chore: add checkout_id to subscription metadata

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -536,6 +536,9 @@ func (s *Service) ensureSubscription(ctx context.Context, ch Checkout) (string, 
 		CustomerID: ch.CustomerID,
 		PlanID:     ch.PlanID,
 		ProviderID: ch.Metadata[ProviderIDSubscriptionMetadataKey].(string),
+		Metadata: map[string]any{
+			"checkout_id": ch.ID,
+		},
 	})
 	if err != nil {
 		return "", err
@@ -687,8 +690,9 @@ func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscri
 			CustomerID: billingCustomer.ID,
 			PlanID:     plan.ID,
 			Metadata: map[string]any{
-				"org_id":    billingCustomer.OrgID,
-				"delegated": "true",
+				"org_id":      billingCustomer.OrgID,
+				"delegated":   "true",
+				"checkout_id": ch.ID,
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
This PR will add `checkout_id` in the subscription's metadata after checkout