### PR TITLE
ci: remove goreleaser deprecated configs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,7 @@ scoops:
   - homepage: "https://github.com/raystack/frontier"
     description: "Identity and authorization system"
     license: Apache 2.0
-    bucket:
+    repository:
       owner: raystack
       name: scoop-bucket
 
@@ -88,7 +88,7 @@ brews:
   - name: frontier
     homepage: "https://github.com/raystack/frontier"
     description: "Identity and authorization system"
-    tap:
+    repository:
       owner: raystack
       name: homebrew-tap
     license: "Apache 2.0"


### PR DESCRIPTION
This PR will update the goreleaser deprecated configs
1. brew `tap` is changed to `repository` https://goreleaser.com/deprecations/#brewstap
2. scoops `bucket` is changed to `repository` https://goreleaser.com/deprecations/#scoopsbucket

[
![Screenshot 2024-02-02 at 10 30 22 AM](https://github.com/raystack/frontier/assets/9323589/d43daf1b-359b-4b4d-9bf9-9c1f409835d7)
](url)