### PR TITLE
fix (admin-ui): set default page size of 200 when fetching user list

### DIFF
--- a/ui/src/containers/users.list/index.tsx
+++ b/ui/src/containers/users.list/index.tsx
@@ -13,6 +13,8 @@ const pageHeader = {
   breadcrumb: [],
 };
 
+const DEFAULT_PAGE_SIZE = 200
+
 type ContextType = { user: V1Beta1User | null };
 export default function UserList() {
   const { client } = useFrontier();
@@ -23,7 +25,9 @@ export default function UserList() {
       const {
         // @ts-ignore
         data: { users },
-      } = await client?.adminServiceListAllUsers();
+      } = await client?.adminServiceListAllUsers({
+        page_size: DEFAULT_PAGE_SIZE
+      });
       setUsers(users);
     }
     getAllUsers();


### PR DESCRIPTION
By default, backend sends 50 users only if no pageSize is set. 