### PR TITLE
fix: prevent invitations from being case-sensitive

### DIFF
--- a/internal/store/postgres/invitation_repository.go
+++ b/internal/store/postgres/invitation_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/raystack/frontier/core/invitation"
@@ -54,13 +55,13 @@ func (s *InvitationRepository) Set(ctx context.Context, invite invitation.Invita
 	query, params, err := dialect.Insert(TABLE_INVITATIONS).Rows(
 		goqu.Record{
 			"id":         invite.ID,
-			"user_id":    invite.UserID,
+			"user_id":    strings.ToLower(invite.UserID),
 			"org_id":     invite.OrgID,
 			"metadata":   marshaledMetadata,
 			"created_at": invite.CreatedAt,
 			"expires_at": invite.ExpiresAt,
 		}).OnConflict(goqu.DoUpdate("id", goqu.Record{
-		"user_id":  invite.UserID,
+		"user_id":  strings.ToLower(invite.UserID),
 		"org_id":   invite.OrgID,
 		"metadata": marshaledMetadata,
 	})).Returning(&Invitation{}).ToSQL()
@@ -114,7 +115,7 @@ func (s *InvitationRepository) List(ctx context.Context, flt invitation.Filter) 
 	}
 	if flt.UserID != "" {
 		stmt = stmt.Where(goqu.Ex{
-			"user_id": flt.UserID,
+			"user_id": strings.ToLower(flt.UserID),
 		})
 	}
 
@@ -148,7 +149,7 @@ func (s *InvitationRepository) ListByUser(ctx context.Context, id string) ([]inv
 	var fetchedInvitations []Invitation
 	query, params, err := dialect.From(TABLE_INVITATIONS).Where(
 		goqu.Ex{
-			"user_id": id,
+			"user_id": strings.ToLower(id),
 		},
 	).ToSQL()
 	if err != nil {


### PR DESCRIPTION
Since the `user_id` field in the `invitations` table is of type text, it is prones to mismatches due to being case sensitive. This field usually takes the value of an email (can also take in any text we choose to pass), which are not case-sensitive in the real world. 

This PR removes the case-sensitivity of that field, and ensures that we store and fetch invitations in lowercase.


Pre-PR:
1. Invite `Abc@raystack.org` to an organization
2. User tries to login with Google or enters their email as `abc@raystack.org` -> we are unable to fetch any invitations

Post this PR:
1. Invite `Abc@raystack.org` to an organization
2. User tries to login with Google or enters their email as `abc@raystack.org` -> The invitation is shown