### PR TITLE
feat: subscribe to default plan on org creation

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -655,7 +655,7 @@ func (s *Service) CreateSessionForPaymentMethod(ctx context.Context, ch Checkout
 }
 
 // Apply applies the actual request directly without creating a checkout session
-// for example when a request is created for a plan, it will be directly subscribe without
+// for example when a request is created for a plan, it will directly subscribe without
 // actually paying for it
 func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscription, *product.Product, error) {
 	// get billing
@@ -717,7 +717,7 @@ func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscri
 					Quantity: stripe.Int64(quantity),
 					Metadata: map[string]string{
 						"org_id":     billingCustomer.OrgID,
-						"feature_id": planProduct.ID,
+						"product_id": planProduct.ID,
 					},
 				}
 				subsItems = append(subsItems, itemParams)

--- a/billing/config.go
+++ b/billing/config.go
@@ -4,7 +4,9 @@ type Config struct {
 	StripeKey     string `yaml:"stripe_key" mapstructure:"stripe_key"`
 	StripeAutoTax bool   `yaml:"stripe_auto_tax" mapstructure:"stripe_auto_tax"`
 	// PlansPath is a directory path where plans are defined
-	PlansPath string `yaml:"plans_path" mapstructure:"plans_path"`
+	PlansPath       string `yaml:"plans_path" mapstructure:"plans_path"`
+	DefaultPlan     string `yaml:"default_plan" mapstructure:"default_plan"`
+	DefaultCurrency string `yaml:"default_currency" mapstructure:"default_currency"`
 
 	PlanChangeConfig   PlanChangeConfig   `yaml:"plan_change" mapstructure:"plan_change"`
 	SubscriptionConfig SubscriptionConfig `yaml:"subscription" mapstructure:"subscription"`

--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -28,6 +28,7 @@ type Repository interface {
 	GetByID(ctx context.Context, id string) (Invoice, error)
 	List(ctx context.Context, filter Filter) ([]Invoice, error)
 	UpdateByID(ctx context.Context, invoice Invoice) (Invoice, error)
+	Delete(ctx context.Context, id string) error
 }
 
 type CustomerService interface {
@@ -243,4 +244,19 @@ func stripeInvoiceToInvoice(customerID string, stripeInvoice *stripe.Invoice) In
 		PeriodStartAt: periodStartAt,
 		PeriodEndAt:   periodEndAt,
 	}
+}
+
+func (s *Service) DeleteByCustomer(ctx context.Context, c customer.Customer) error {
+	invoices, err := s.ListAll(ctx, Filter{
+		CustomerID: c.ID,
+	})
+	if err != nil {
+		return err
+	}
+	for _, i := range invoices {
+		if err := s.repository.Delete(ctx, i.ID); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -385,7 +385,12 @@ func (s *Service) UpsertFeature(ctx context.Context, feature Feature) (Feature, 
 	}
 
 	existingFeature.ProductIDs = feature.ProductIDs
-	existingFeature.Metadata = feature.Metadata
+	if len(feature.Title) > 0 {
+		existingFeature.Title = feature.Title
+	}
+	if len(feature.Metadata) > 0 {
+		existingFeature.Metadata = feature.Metadata
+	}
 	return s.featureRepository.UpdateByName(ctx, existingFeature)
 }
 

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -164,6 +164,12 @@ billing:
   # path to plans spec file that will be used to create plans in billing engine
   # e.g. file:///tmp/plans
   plans_path: ""
+  # name of the plan that should be used subscribed automatically when the org is created
+  # it also automatically creates an empty billing account under the org
+  default_plan: ""
+  # default currency to be used for billing if not provided by the user
+  # e.g. usd, inr, eur
+  default_currency: ""
   # plan change configuration applied when a user changes their subscription plan
   plan_change:
     # proration_behavior can be one of "create_prorations", "none", "always_invoice"

--- a/core/audit/context.go
+++ b/core/audit/context.go
@@ -2,7 +2,6 @@ package audit
 
 import (
 	"context"
-	"io"
 
 	"github.com/raystack/frontier/pkg/server/consts"
 )
@@ -12,7 +11,7 @@ import (
 func GetService(ctx context.Context) *Service {
 	u, ok := ctx.Value(consts.AuditServiceContextKey).(*Service)
 	if !ok {
-		return NewService("test", NewWriteOnlyRepository(io.Discard))
+		return NewService("default", NewNoopRepository())
 	}
 	return u
 }

--- a/core/audit/logger.go
+++ b/core/audit/logger.go
@@ -58,5 +58,5 @@ func (s *Logger) LogWithAttrs(action EventName, target Target, attrs map[string]
 			l.Actor = actor
 		}
 	}
-	return s.service.repository.Create(s.ctx, l)
+	return s.service.Create(s.ctx, l)
 }

--- a/core/audit/noop_repository.go
+++ b/core/audit/noop_repository.go
@@ -1,0 +1,23 @@
+package audit
+
+import (
+	"context"
+)
+
+type NoopRepository struct{}
+
+func NewNoopRepository() *NoopRepository {
+	return &NoopRepository{}
+}
+
+func (r NoopRepository) Create(ctx context.Context, log *Log) error {
+	return nil
+}
+
+func (r NoopRepository) List(ctx context.Context, filter Filter) ([]Log, error) {
+	return []Log{}, nil
+}
+
+func (r NoopRepository) GetByID(ctx context.Context, s string) (Log, error) {
+	return Log{}, nil
+}

--- a/core/deleter/deleter.go
+++ b/core/deleter/deleter.go
@@ -1,0 +1,7 @@
+package deleter
+
+import "fmt"
+
+var (
+	ErrDeleteNotAllowed = fmt.Errorf("deletion not allowed for billed accounts")
+)

--- a/core/event/listener.go
+++ b/core/event/listener.go
@@ -1,0 +1,47 @@
+package event
+
+import (
+	"context"
+	"fmt"
+
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/raystack/frontier/core/audit"
+	"go.uber.org/zap"
+)
+
+// ChanListener listens for audit logs and processes them blocking
+// one event at a time
+type ChanListener struct {
+	logs      <-chan audit.Log
+	processor *Processor
+}
+
+func NewChanListener(inputChan <-chan audit.Log, processor *Processor) *ChanListener {
+	return &ChanListener{
+		logs:      inputChan,
+		processor: processor,
+	}
+}
+
+// Listen listens for audit logs and processes them
+func (l *ChanListener) Listen(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case log := <-l.logs:
+			// process log
+			l.Process(ctx, log)
+		}
+	}
+}
+
+func (l *ChanListener) Process(ctx context.Context, log audit.Log) {
+	stdLogger := grpczap.Extract(ctx).With(zap.String("event", log.Action))
+	switch log.Action {
+	case audit.OrgCreatedEvent.String():
+		if err := l.processor.EnsureDefaultPlan(ctx, log.OrgID); err != nil {
+			stdLogger.Error(fmt.Errorf("EnsureDefaultPlan: %w", err).Error())
+		}
+	}
+}

--- a/core/event/processor.go
+++ b/core/event/processor.go
@@ -1,0 +1,112 @@
+package event
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/raystack/frontier/core/user"
+
+	"github.com/raystack/frontier/billing/plan"
+
+	"github.com/raystack/frontier/billing"
+	"github.com/raystack/frontier/billing/checkout"
+	"github.com/raystack/frontier/billing/customer"
+	"github.com/raystack/frontier/billing/product"
+	"github.com/raystack/frontier/billing/subscription"
+	"github.com/raystack/frontier/core/organization"
+)
+
+type CheckoutService interface {
+	Apply(ctx context.Context, ch checkout.Checkout) (*subscription.Subscription, *product.Product, error)
+}
+
+type CustomerService interface {
+	Create(ctx context.Context, customer customer.Customer) (customer.Customer, error)
+}
+
+type OrganizationService interface {
+	Get(ctx context.Context, id string) (organization.Organization, error)
+}
+
+type PlanService interface {
+	GetByID(ctx context.Context, id string) (plan.Plan, error)
+}
+
+type UserService interface {
+	ListByOrg(ctx context.Context, orgID string, roleFilter string) ([]user.User, error)
+}
+
+type Processor struct {
+	billingConf     billing.Config
+	checkoutService CheckoutService
+	customerService CustomerService
+	orgService      OrganizationService
+	planService     PlanService
+	userService     UserService
+}
+
+func NewProcessor(billingConf billing.Config, organizationService OrganizationService,
+	checkoutService CheckoutService, customerService CustomerService,
+	planService PlanService, userService UserService) *Processor {
+	return &Processor{
+		billingConf:     billingConf,
+		orgService:      organizationService,
+		checkoutService: checkoutService,
+		customerService: customerService,
+		planService:     planService,
+		userService:     userService,
+	}
+}
+
+// EnsureDefaultPlan create a new customer account and subscribe to the default plan if configured
+func (p *Processor) EnsureDefaultPlan(ctx context.Context, orgID string) error {
+	if p.billingConf.DefaultPlan != "" && p.billingConf.DefaultCurrency != "" {
+		// validate the plan requested is free
+		defaultPlan, err := p.planService.GetByID(ctx, p.billingConf.DefaultPlan)
+		if err != nil {
+			return fmt.Errorf("failed to get default plan: %w", err)
+		}
+		for _, prod := range defaultPlan.Products {
+			for _, price := range prod.Prices {
+				if price.Amount > 0 {
+					return fmt.Errorf("default plan is not free")
+				}
+			}
+		}
+
+		org, err := p.orgService.Get(ctx, orgID)
+		if err != nil {
+			return fmt.Errorf("failed to get organization: %w", err)
+		}
+
+		users, err := p.userService.ListByOrg(ctx, org.ID, organization.AdminRole)
+		if err != nil {
+			return fmt.Errorf("failed to list users: %w", err)
+		}
+		emailID := ""
+		if len(users) > 0 {
+			emailID = users[0].Email
+		}
+		customr, err := p.customerService.Create(ctx, customer.Customer{
+			OrgID:    org.ID,
+			Name:     org.Name,
+			Email:    emailID,
+			Currency: p.billingConf.DefaultCurrency,
+			Metadata: map[string]any{
+				"auto_created": "true",
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create customer: %w", err)
+		}
+		_, _, err = p.checkoutService.Apply(ctx, checkout.Checkout{
+			CustomerID: customr.ID,
+			PlanID:     defaultPlan.ID,
+			SkipTrial:  true,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to apply default plan: %w", err)
+		}
+	}
+	return nil
+}

--- a/core/event/publisher.go
+++ b/core/event/publisher.go
@@ -1,0 +1,22 @@
+package event
+
+import (
+	"context"
+
+	"github.com/raystack/frontier/core/audit"
+)
+
+// ChanPublisher is a blocking audit event publisher
+type ChanPublisher struct {
+	target chan<- audit.Log
+}
+
+func NewChanPublisher(target chan<- audit.Log) *ChanPublisher {
+	return &ChanPublisher{
+		target: target,
+	}
+}
+
+func (p *ChanPublisher) Publish(ctx context.Context, log audit.Log) {
+	p.target <- log
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/raystack/frontier/core/authenticate/session"
 	"github.com/raystack/frontier/core/deleter"
 	"github.com/raystack/frontier/core/domain"
+	"github.com/raystack/frontier/core/event"
 	"github.com/raystack/frontier/core/group"
 	"github.com/raystack/frontier/core/invitation"
 	"github.com/raystack/frontier/core/metaschema"
@@ -63,4 +64,6 @@ type Deps struct {
 	CreditService       *credit.Service
 	UsageService        *usage.Service
 	InvoiceService      *invoice.Service
+
+	LogListener *event.ChanListener
 }

--- a/internal/store/blob/plan_repository.go
+++ b/internal/store/blob/plan_repository.go
@@ -55,13 +55,16 @@ func (s *PlanRepository) Get(ctx context.Context) (plan.File, error) {
 	}
 
 	var allPlans []plan.Plan
-	var allFeatures []product.Product
+	var allProducts []product.Product
+	var allFeatures []product.Feature
 	for _, definition := range definitions {
 		allPlans = append(allPlans, definition.Plans...)
-		allFeatures = append(allFeatures, definition.Products...)
+		allProducts = append(allProducts, definition.Products...)
+		allFeatures = append(allFeatures, definition.Features...)
 	}
 	return plan.File{
 		Plans:    allPlans,
-		Products: allFeatures,
+		Products: allProducts,
+		Features: allFeatures,
 	}, nil
 }

--- a/internal/store/blob/plans/sample.yaml
+++ b/internal/store/blob/plans/sample.yaml
@@ -1,3 +1,8 @@
+features:
+  - name: basic_access_feature_1
+    title: Basic Access Feature 1
+    metadata:
+      description: Feature 1 for basic access of the platform
 products:
   - name: support_credits
     title: Support Credits
@@ -9,6 +14,14 @@ products:
       - name: default
         amount: 20000
         currency: inr
+  - name: free_access
+    title: Free base access
+    description: Free access to the platform
+    prices:
+      - name: monthly
+        interval: month
+        amount: 0
+        currency: inr
   - name: basic_access
     title: Basic base access
     description: Base access to the platform
@@ -17,6 +30,8 @@ products:
         interval: month
         amount: 100
         currency: inr
+    features:
+      - name: basic_access_feature_1
   - name: starter_access
     title: Starter base access
     description: Base access to the platform
@@ -56,6 +71,12 @@ products:
 #        amount: 8000
 #        currency: inr
 plans:
+  - name: free_monthly
+    title: Free Monthly Plan
+    description: Free Monthly Plan
+    interval: month
+    products:
+      - name: free_access
   - name: basic_monthly
     title: Basic Monthly Plan
     description: Basic Monthly Plan

--- a/internal/store/postgres/audit_repository.go
+++ b/internal/store/postgres/audit_repository.go
@@ -32,6 +32,9 @@ func (a AuditRepository) Create(ctx context.Context, l *audit.Log) error {
 	if l.ID == "" {
 		l.ID = uuid.NewString()
 	}
+	if l.OrgID == "" {
+		l.OrgID = uuid.Nil.String()
+	}
 
 	marshaledActor, err := json.Marshal(l.Actor)
 	if err != nil {

--- a/internal/store/postgres/billing_customer_repository.go
+++ b/internal/store/postgres/billing_customer_repository.go
@@ -158,6 +158,9 @@ func (r BillingCustomerRepository) List(ctx context.Context, flt customer.Filter
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_CUSTOMERS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &customerModels, query, params...)
 	}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return []customer.Customer{}, nil
+		}
 		return nil, fmt.Errorf("%w: %s", dbErr, err)
 	}
 

--- a/internal/store/postgres/billing_invoice_repository.go
+++ b/internal/store/postgres/billing_invoice_repository.go
@@ -226,3 +226,20 @@ func (r BillingInvoiceRepository) UpdateByID(ctx context.Context, toUpdate invoi
 
 	return invoiceModel.transform()
 }
+
+func (r BillingInvoiceRepository) Delete(ctx context.Context, id string) error {
+	query, params, err := dialect.Delete(TABLE_BILLING_INVOICES).Where(goqu.Ex{
+		"id": id,
+	}).ToSQL()
+	if err != nil {
+		return fmt.Errorf("%w: %s", queryErr, err)
+	}
+
+	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "Delete", func(ctx context.Context) error {
+		_, err := r.dbc.ExecContext(ctx, query, params...)
+		return err
+	}); err != nil {
+		return fmt.Errorf("%s: %w", txnErr, err)
+	}
+	return nil
+}

--- a/internal/store/postgres/billing_subscription_repository.go
+++ b/internal/store/postgres/billing_subscription_repository.go
@@ -381,3 +381,21 @@ func (r BillingSubscriptionRepository) List(ctx context.Context, filter subscrip
 	}
 	return subscriptions, nil
 }
+
+func (r BillingSubscriptionRepository) Delete(ctx context.Context, id string) error {
+	stmt := dialect.Delete(TABLE_BILLING_SUBSCRIPTIONS).Where(goqu.Ex{
+		"id": id,
+	})
+	query, params, err := stmt.ToSQL()
+	if err != nil {
+		return fmt.Errorf("%w: %s", parseErr, err)
+	}
+
+	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_SUBSCRIPTIONS, "Delete", func(ctx context.Context) error {
+		_, err := r.dbc.ExecContext(ctx, query, params...)
+		return err
+	}); err != nil {
+		return fmt.Errorf("%w: %s", dbErr, err)
+	}
+	return nil
+}


### PR DESCRIPTION
- two additional configs are added to configure a default plan which should be free and will be subscribed automatically on org creation
- it creates a default billing account with most fields as empty except email. Org owner email is used as the default email of billing account.
- `billing.default_plan` and `billing.default_currency` needs to be set for it to apply