### PR TITLE
feat: collect address on checkout if it is required for taxation, and sync it

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -485,7 +485,6 @@ func (s *Service) SyncWithProvider(ctx context.Context, customerID string) error
 				}
 			}
 		}
-
 	}
 
 	// if payment is completed, create subscription for them in system


### PR DESCRIPTION
Currently, if `stripe_auto_tax` is enabled, and the user does not have an address associated with the billing account, we get an error from stripe as follows:
```
{
    "code": "customer_tax_location_invalid",
    "doc_url": "https://stripe.com/docs/error-codes/customer-tax-location-invalid",
    "status": 400,
    "message": "Automatic tax calculation in Checkout requires a valid address on the Customer. Add a valid address to the Customer or set either `customer_update[address]` to 'auto' or `customer_update[shipping]` to 'auto' to save the address entered in Checkout to the Customer.",
    "request_id": "",
    "request_log_url": "",
    "type": "invalid_request_error"
}
```

In order to fix this, the `customer_update[address]` field needs to be set to `auto` in order to collect the billing address for taxation during the checkout. This address is later synced back to Frontier's database in the `syncWithProvider` method in checkouts.

Stripe checkout screen when address is not pre-added:
<img width="1110" alt="Screenshot 2024-04-02 at 1 54 47 PM" src="https://github.com/raystack/frontier/assets/17564234/f51f6acc-0d73-49a6-a124-0222961892d7">


Stripe checkout screen when address was already added earlier to stripe account:
<img width="1224" alt="Screenshot 2024-04-02 at 1 54 36 PM" src="https://github.com/raystack/frontier/assets/17564234/18a8c2e1-b72d-4eb1-9987-b796db6804bb">
