### PR TITLE
chore: generate an invoice when product purchases are made

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -353,8 +353,11 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 			AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{
 				Enabled: stripe.Bool(s.stripeAutoTax),
 			},
-			Currency:  stripe.String(billingCustomer.Currency),
-			Customer:  stripe.String(billingCustomer.ProviderID),
+			Currency: stripe.String(billingCustomer.Currency),
+			Customer: stripe.String(billingCustomer.ProviderID),
+			InvoiceCreation: &stripe.CheckoutSessionInvoiceCreationParams{
+				Enabled: stripe.Bool(true),
+			},
 			LineItems: subsItems,
 			Mode:      stripe.String(string(stripe.CheckoutSessionModePayment)),
 			Metadata: map[string]string{


### PR DESCRIPTION
When one time purchases are made, Stripe does not generate an invoice by default. Invoices are essential to many businesses for tax purposes as they contain more information than payment receipts. This PR enables creation of an invoice on Stripe when one-time product purchases are made via checkout process.

Link to doc: https://docs.stripe.com/receipts?payment-ui=checkout#paid-invoices