### PR TITLE
feat: add test users login

### DIFF
--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -13,7 +13,7 @@ ui:
 
 app:
   port: 8000
-  grpc: 
+  grpc:
     port: 8001
     # optional tls config
     # tls_cert_file: "temp/server-cert.pem"
@@ -117,6 +117,11 @@ app:
       # body is a go template with `Otp` as a variable
       body: "Click on the following link or copy/paste the url in browser to login.<br><h2><a href='{{.Link}}' target='_blank'>Login</a></h2><br>Address: {{.Link}} <br>This link will expire in 15 minutes."
       validity: 15m
+    test_users:
+      enabled: false
+      domain: example.com
+      otp: ""
+
   # platform level administration
   admin:
     # Email list of users which needs to be converted as superusers

--- a/core/authenticate/config.go
+++ b/core/authenticate/config.go
@@ -1,6 +1,10 @@
 package authenticate
 
-import "time"
+import (
+	"time"
+
+	testusers "github.com/raystack/frontier/core/authenticate/test_users"
+)
 
 type Config struct {
 	// CallbackURLs is external host used for redirect uri
@@ -15,6 +19,7 @@ type Config struct {
 	MailOTP    MailOTPConfig         `yaml:"mail_otp" mapstructure:"mail_otp"`
 	MailLink   MailLinkConfig        `yaml:"mail_link" mapstructure:"mail_link"`
 	PassKey    PassKeyConfig         `yaml:"passkey" mapstructure:"passkey"`
+	TestUsers  testusers.Config      `yaml:"test_users" mapstructure:"test_users"`
 }
 
 type TokenConfig struct {

--- a/core/authenticate/service.go
+++ b/core/authenticate/service.go
@@ -205,7 +205,7 @@ func (s Service) StartFlow(ctx context.Context, request RegistrationStartRequest
 
 	if request.Method == MailOTPAuthMethod.String() {
 		mailLinkStrat := strategy.NewMailOTP(s.mailDialer, s.config.MailOTP.Subject, s.config.MailOTP.Body)
-		nonce, err := mailLinkStrat.SendMail(request.Email)
+		nonce, err := mailLinkStrat.SendMail(request.Email, s.config.TestUsers)
 		if err != nil {
 			return nil, err
 		}
@@ -230,7 +230,7 @@ func (s Service) StartFlow(ctx context.Context, request RegistrationStartRequest
 
 	if request.Method == MailLinkAuthMethod.String() {
 		mailLinkStrat := strategy.NewMailLink(s.mailDialer, request.CallbackUrl, s.config.MailLink.Subject, s.config.MailLink.Body)
-		nonce, err := mailLinkStrat.SendMail(flow.ID.String(), request.Email)
+		nonce, err := mailLinkStrat.SendMail(flow.ID.String(), request.Email, s.config.TestUsers)
 		if err != nil {
 			return nil, err
 		}

--- a/core/authenticate/strategy/mail_link.go
+++ b/core/authenticate/strategy/mail_link.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	testusers "github.com/raystack/frontier/core/authenticate/test_users"
 	"github.com/raystack/frontier/pkg/mailer"
+	"github.com/raystack/frontier/pkg/utils"
 	"gopkg.in/mail.v2"
 )
 
@@ -38,8 +40,15 @@ func NewMailLink(d mailer.Dialer, host, subject, body string) *MailLink {
 }
 
 // SendMail sends a mail with a one time password embedded link to user's email id
-func (m MailLink) SendMail(id, to string) (string, error) {
-	otp := GenerateNonceFromLetters(otpLen, otpLetterRunes)
+func (m MailLink) SendMail(id, to string, testUsersConfig testusers.Config) (string, error) {
+	var otp string
+	userDomain := utils.ExtractDomainFromEmail(to)
+	if testUsersConfig.Enabled && userDomain == testUsersConfig.Domain && len(testUsersConfig.OTP) > 0 {
+		otp = testUsersConfig.OTP
+	} else {
+		otp = GenerateNonceFromLetters(otpLen, otpLetterRunes)
+	}
+
 	t, err := template.New("body").Parse(m.body)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse email template: %w", err)

--- a/core/authenticate/strategy/mail_otp.go
+++ b/core/authenticate/strategy/mail_otp.go
@@ -7,7 +7,9 @@ import (
 	"math/rand"
 	"time"
 
+	testusers "github.com/raystack/frontier/core/authenticate/test_users"
 	"github.com/raystack/frontier/pkg/mailer"
+	"github.com/raystack/frontier/pkg/utils"
 	"gopkg.in/mail.v2"
 )
 
@@ -41,8 +43,14 @@ func NewMailOTP(d mailer.Dialer, subject, body string) *MailOTP {
 }
 
 // SendMail sends a mail with a one time password embedded link to user's email id
-func (m MailOTP) SendMail(to string) (string, error) {
-	otp := GenerateNonceFromLetters(otpLen, otpLetterRunes)
+func (m MailOTP) SendMail(to string, testUsersConfig testusers.Config) (string, error) {
+	var otp string
+	userDomain := utils.ExtractDomainFromEmail(to)
+	if testUsersConfig.Enabled && userDomain == testUsersConfig.Domain && len(testUsersConfig.OTP) > 0 {
+		otp = testUsersConfig.OTP
+	} else {
+		otp = GenerateNonceFromLetters(otpLen, otpLetterRunes)
+	}
 
 	tpl := template.New("body")
 	t, err := tpl.Parse(m.body)

--- a/core/authenticate/strategy/mail_otp_test.go
+++ b/core/authenticate/strategy/mail_otp_test.go
@@ -43,7 +43,6 @@ func mock1(t *testing.T, email string, otp string) *mocks.Dialer {
 }
 
 func TestMailOTP_SendMail(t *testing.T) {
-
 	type fields struct {
 		dialer  mailer.Dialer
 		subject string

--- a/core/authenticate/test_users/config.go
+++ b/core/authenticate/test_users/config.go
@@ -1,0 +1,7 @@
+package testusers
+
+type Config struct {
+	Enabled bool   `yaml:"enabled" mapstructure:"enabled"`
+	Domain  string `yaml:"domain" mapstructure:"domain"`
+	OTP     string `yaml:"otp" mapstructure:"otp"`
+}

--- a/core/domain/service.go
+++ b/core/domain/service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/raystack/frontier/core/organization"
+	"github.com/raystack/frontier/pkg/utils"
 
 	"github.com/raystack/salt/log"
 
@@ -144,7 +145,7 @@ func (s Service) Join(ctx context.Context, orgID string, userId string) error {
 		}
 	}
 
-	userDomain := extractDomainFromEmail(currUser.Email)
+	userDomain := utils.ExtractDomainFromEmail(currUser.Email)
 	if userDomain == "" {
 		return user.ErrInvalidEmail
 	}
@@ -174,7 +175,7 @@ func (s Service) Join(ctx context.Context, orgID string, userId string) error {
 }
 
 func (s Service) ListJoinableOrgsByDomain(ctx context.Context, email string) ([]string, error) {
-	domain := extractDomainFromEmail(email)
+	domain := utils.ExtractDomainFromEmail(email)
 	domains, err := s.repository.List(ctx, Filter{
 		Name:  domain,
 		State: Verified,
@@ -239,12 +240,4 @@ func generateRandomTXT() (string, error) {
 	// Encode the random bytes in Base64
 	txtRecord := base64.StdEncoding.EncodeToString(randomBytes)
 	return txtRecord, nil
-}
-
-func extractDomainFromEmail(email string) string {
-	parts := strings.Split(email, "@")
-	if len(parts) == 2 {
-		return parts[1]
-	}
-	return ""
 }

--- a/pkg/utils/domain.go
+++ b/pkg/utils/domain.go
@@ -1,0 +1,11 @@
+package utils
+
+import "strings"
+
+func ExtractDomainFromEmail(email string) string {
+	parts := strings.Split(email, "@")
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
+}


### PR DESCRIPTION
We are setting up automated end to end testing for our platform. 
The tests will create new users and new org for every test run.
but due to frontier login strategies it is very difficult to login from test user accounts.

We looked for multiple solution for this.

1. Use gmail apis to read inbox and get otp. eg [gmail-tester](https://github.com/levz0r/cypress-gmail-tester)
    But this will expose real user gmail creds on CI.
2. Use throw away email to send otp in that and read email via api. eg [mailosour](https://mailosaur.com/email-testing)
3. Have support for test users and use hardcoded otp.

This PR will add support for test users. The test user is similar to [stripe payment test](https://docs.stripe.com/testing) where hardcoded payment methods can be used for testing.

The test users will be enabled from config.

1. `app.authentication.test_users.enabled` will enable test users. it is disabled by default. and it is recommended to enable only on dev server.
2. `app.authentication.test_users.domain` will set test users email domain. it is recommended to use some custom domain instead of real users like `test_user1@test.example.com`.
3. `app.authentication.test_users.otp` will set the otp for test users.
