### PR TITLE
Include all SMTP configuration option in the example docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,10 @@ services:
 #      - FRONTIER_APP_MAILER_SMTP_PORT=2525
 #      - FRONTIER_APP_MAILER_SMTP_USERNAME=
 #      - FRONTIER_APP_MAILER_SMTP_PASSWORD=
+#      - FRONTIER_APP_MAILER_SMTP_INSECURE=false
+#      - FRONTIER_APP_MAILER_SMTP_TLS_POLICY=mandatory    # possible values are "mandatory", "opportunistic", or "none"
 #      - FRONTIER_APP_ADMIN_USERS=sample@example.com
+
 
   spicedb-migration:
     image: quay.io/authzed/spicedb:v1.29.2


### PR DESCRIPTION
After adding values for the smtp settings in the docker-compose.yml file the login was still failing due to the mandatory TLS policy.
So including this additional smtp setting will allow new users to get up to speed faster.