### PR TITLE
fix: send default payment method flag in metadata

### DIFF
--- a/billing/customer/service.go
+++ b/billing/customer/service.go
@@ -206,6 +206,9 @@ func (s *Service) ListPaymentMethods(ctx context.Context, id string) ([]PaymentM
 		ListParams: stripe.ListParams{
 			Context: ctx,
 		},
+		Expand: []*string{
+			stripe.String("data.customer"),
+		},
 	})
 	var paymentMethods []PaymentMethod
 	for stripePaymentMethodItr.Next() {
@@ -224,6 +227,13 @@ func (s *Service) ListPaymentMethods(ctx context.Context, id string) ([]PaymentM
 			pm.CardExpiryMonth = stripePaymentMethod.Card.ExpMonth
 			pm.CardExpiryYear = stripePaymentMethod.Card.ExpYear
 		}
+		// set default method, if any
+		if stripePaymentMethod.Customer.InvoiceSettings != nil && stripePaymentMethod.Customer.InvoiceSettings.DefaultPaymentMethod != nil {
+			if stripePaymentMethod.Customer.InvoiceSettings.DefaultPaymentMethod.ID == stripePaymentMethod.ID {
+				pm.Metadata["default"] = true
+			}
+		}
+
 		paymentMethods = append(paymentMethods, pm)
 	}
 	return paymentMethods, nil


### PR DESCRIPTION
Without any default payment method:

<img width="445" alt="Screenshot 2024-05-09 at 1 27 26 PM" src="https://github.com/raystack/frontier/assets/17564234/5866cd14-d771-449a-bfdd-3c7136aefdc8">


With default payment method:
<img width="457" alt="image" src="https://github.com/raystack/frontier/assets/17564234/8fa98f2f-1556-4c11-8dd9-ae5c36303fb9">
