### PR TITLE
feat: emit audit event+webhook when user is removed from a group

### DIFF
--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -52,9 +52,10 @@ const (
 	ServiceUserCreatedEvent EventName = "app.serviceuser.created"
 	ServiceUserDeletedEvent EventName = "app.serviceuser.deleted"
 
-	GroupCreatedEvent EventName = "app.group.created"
-	GroupUpdatedEvent EventName = "app.group.updated"
-	GroupDeletedEvent EventName = "app.group.deleted"
+	GroupCreatedEvent       EventName = "app.group.created"
+	GroupUpdatedEvent       EventName = "app.group.updated"
+	GroupDeletedEvent       EventName = "app.group.deleted"
+	GroupMemberRemovedEvent EventName = "app.group.member.removed"
 
 	RoleCreatedEvent EventName = "app.role.created"
 	RoleUpdatedEvent EventName = "app.role.updated"

--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -55,7 +55,7 @@ const (
 	GroupCreatedEvent       EventName = "app.group.created"
 	GroupUpdatedEvent       EventName = "app.group.updated"
 	GroupDeletedEvent       EventName = "app.group.deleted"
-	GroupMemberRemovedEvent EventName = "app.group.member.removed"
+	GroupMemberRemovedEvent EventName = "app.group.members.removed"
 
 	RoleCreatedEvent EventName = "app.role.created"
 	RoleUpdatedEvent EventName = "app.role.updated"

--- a/core/group/service.go
+++ b/core/group/service.go
@@ -307,6 +307,12 @@ func (s Service) AddUsers(ctx context.Context, groupID string, userIDs []string)
 // RemoveUsers removes users from a group as members
 func (s Service) RemoveUsers(ctx context.Context, groupID string, userIDs []string) error {
 	var err error
+
+	group, err := s.repository.GetByID(ctx, groupID)
+	if err != nil {
+		return err
+	}
+
 	for _, userID := range userIDs {
 		// remove all access via policies
 		userPolicies, currentErr := s.policyService.List(ctx, policy.Filter{
@@ -338,7 +344,7 @@ func (s Service) RemoveUsers(ctx context.Context, groupID string, userIDs []stri
 		}
 
 		if currentErr == nil {
-			audit.GetAuditor(ctx, schema.PlatformOrgID.String()).LogWithAttrs(audit.GroupMemberRemovedEvent, audit.GroupTarget(groupID), map[string]string{
+			audit.GetAuditor(ctx, group.OrganizationID).LogWithAttrs(audit.GroupMemberRemovedEvent, audit.GroupTarget(groupID), map[string]string{
 				"userID": userID,
 			})
 		}

--- a/core/group/service.go
+++ b/core/group/service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/raystack/frontier/core/audit"
+
 	"github.com/raystack/frontier/pkg/utils"
 
 	"github.com/raystack/frontier/core/policy"
@@ -335,6 +337,13 @@ func (s Service) RemoveUsers(ctx context.Context, groupID string, userIDs []stri
 			err = errors.Join(err, currentErr)
 		}
 	}
+
+	if err == nil {
+		audit.GetAuditor(ctx, schema.PlatformOrgID.String()).LogWithAttrs(audit.GroupMemberRemovedEvent, audit.GroupTarget(groupID), map[string]string{
+			"userIDs": strings.Join(userIDs, ", "),
+		})
+	}
+
 	return err
 }
 

--- a/core/group/service.go
+++ b/core/group/service.go
@@ -336,12 +336,12 @@ func (s Service) RemoveUsers(ctx context.Context, groupID string, userIDs []stri
 		}); currentErr != nil {
 			err = errors.Join(err, currentErr)
 		}
-	}
 
-	if err == nil {
-		audit.GetAuditor(ctx, schema.PlatformOrgID.String()).LogWithAttrs(audit.GroupMemberRemovedEvent, audit.GroupTarget(groupID), map[string]string{
-			"userIDs": strings.Join(userIDs, ", "),
-		})
+		if currentErr == nil {
+			audit.GetAuditor(ctx, schema.PlatformOrgID.String()).LogWithAttrs(audit.GroupMemberRemovedEvent, audit.GroupTarget(groupID), map[string]string{
+				"userID": userID,
+			})
+		}
 	}
 
 	return err

--- a/core/webhook/service.go
+++ b/core/webhook/service.go
@@ -107,6 +107,7 @@ func (s Service) Publish(ctx context.Context, evt Event) error {
 		Data:      data,
 		CreatedAt: timestamppb.New(evt.CreatedAt),
 	}
+
 	payload, err := protojson.Marshal(event)
 	if err != nil {
 		logger.Error("failed to marshal event", zap.Error(err))


### PR DESCRIPTION
We require a webhook which notifies downstream services about removal of user from groups. This PR introduces that into the service.

The reason for doing this in service is so that this event is triggered even if different handlers are used to perform this action.

The idea behind adding this instead of adding more and more information into policy events is to provide an easy to understand event to downstream services so that appropriate action can be taken by them. A few more events such as this will be introduced in subsequent PRs.