### PR TITLE
ci: set goreleaser to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v1"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}


### PR DESCRIPTION
We are using the `latest` version of goreleaser. However, a few days ago, goreleaser [v2](https://github.com/goreleaser/goreleaser/releases/tag/v2.0.0) was released, which has some breaking changes.

This PR will set the version of the goreleaser to v1. 
ref https://github.com/goreleaser/goreleaser-action/pull/461


