### PR TITLE
fix: billing account with no state in db were failing entitlement checks

### DIFF
--- a/billing/customer/service.go
+++ b/billing/customer/service.go
@@ -48,7 +48,9 @@ func NewService(stripeClient *client.API, repository Repository) *Service {
 
 func (s *Service) Create(ctx context.Context, customer Customer, offline bool) (Customer, error) {
 	// set defaults
-	customer.State = ActiveState
+	if customer.State == "" {
+		customer.State = ActiveState
+	}
 
 	// offline mode, we don't need to create the customer in billing provider
 	if !offline {

--- a/internal/store/postgres/billing_customer_repository.go
+++ b/internal/store/postgres/billing_customer_repository.go
@@ -188,7 +188,7 @@ func (r BillingCustomerRepository) List(ctx context.Context, flt customer.Filter
 	}
 	if flt.State != "" {
 		// where state is provided val or NULL or empty
-		stmt = stmt.Where(goqu.L("state = ? OR state IS NULL OR state = ''", flt.State))
+		stmt = stmt.Where(goqu.L("(state = ? OR state IS NULL OR state = '')", flt.State))
 	}
 	if flt.ProviderID != "" {
 		stmt = stmt.Where(goqu.Ex{

--- a/test/e2e/regression/billing_test.go
+++ b/test/e2e/regression/billing_test.go
@@ -994,6 +994,15 @@ func (s *BillingRegressionTestSuite) TestCheckFeatureEntitlementAPI() {
 	})
 	s.Assert().NoError(err)
 
+	// create dummy project
+	createProjResp, err := s.testBench.Client.CreateProject(ctxOrgAdminAuth, &frontierv1beta1.CreateProjectRequest{
+		Body: &frontierv1beta1.ProjectRequestBody{
+			Name:  "project-entitlement-1",
+			OrgId: createOrgResp.GetOrganization().GetId(),
+		},
+	})
+	s.Assert().NoError(err)
+
 	// wait for billing account to be created
 	s.Assert().Eventually(func() bool {
 		listCustomersResp, err := s.testBench.Client.ListBillingAccounts(ctxOrgAdminAuth, &frontierv1beta1.ListBillingAccountsRequest{
@@ -1083,6 +1092,14 @@ func (s *BillingRegressionTestSuite) TestCheckFeatureEntitlementAPI() {
 		status, err := s.testBench.Client.CheckFeatureEntitlement(ctxOrgAdminAuth, &frontierv1beta1.CheckFeatureEntitlementRequest{
 			OrgId:   createOrgResp.GetOrganization().GetId(),
 			Feature: "test-feature-entitlement-1",
+		})
+		s.Assert().NoError(err)
+		s.Assert().True(status.GetStatus())
+
+		// should infer org and billing account automatically
+		status, err = s.testBench.Client.CheckFeatureEntitlement(ctxOrgAdminAuth, &frontierv1beta1.CheckFeatureEntitlementRequest{
+			ProjectId: createProjResp.GetProject().GetId(),
+			Feature:   "test-feature-entitlement-1",
 		})
 		s.Assert().NoError(err)
 		s.Assert().True(status.GetStatus())


### PR DESCRIPTION
Billing account were not adding active state in db by default. We started adding active state later causing us to make the change backward compatible. This change while being made backward compatible used a where condition in db which although looked like it is using a `AND` between org and state filter, it was using an `OR`. The underlying library `goqu` didn't make it obvious to see from its methods.