### PR TITLE
fix: product seat limit shouldn't use 0 as default

### DIFF
--- a/billing/product/product.go
+++ b/billing/product/product.go
@@ -71,7 +71,9 @@ func (prod Product) IsSeatLimitBreached(seatsConsumed int64) bool {
 	if !prod.HasPerSeatBehavior() {
 		return false
 	}
-
+	if prod.Config.SeatLimit == 0 {
+		return false
+	}
 	return seatsConsumed > prod.Config.SeatLimit
 }
 


### PR DESCRIPTION
- Product of seat limit behaviour can limit number of users allowed inside a plan via a config. It's default value was getting treated as explicit limit.