### PR TITLE
feat: config to enable debug profilers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - importas
     - protogetter
     - ineffassign
+    - wastedassign
 #    - gosec
 #    - prealloc
 #    - errcheck
@@ -30,7 +31,6 @@ linters:
 #    - gocritic
 #    - goconst
 #    - perfsprint
-#    - wastedassign
 linters-settings:
   revive:
     ignore-generated-header: true

--- a/billing/credit/service.go
+++ b/billing/credit/service.go
@@ -28,10 +28,10 @@ func NewService(repository TransactionRepository) *Service {
 
 func (s Service) Add(ctx context.Context, cred Credit) error {
 	if cred.ID == "" {
-		return fmt.Errorf("credit id is empty, it is required to create a transaction")
+		return errors.New("credit id is empty, it is required to create a transaction")
 	}
 	if cred.Amount < 0 {
-		return fmt.Errorf("credit amount is negative")
+		return errors.New("credit amount is negative")
 	}
 	// check if already credited
 	t, err := s.transactionRepository.GetByID(ctx, cred.ID)
@@ -74,10 +74,10 @@ func (s Service) Add(ctx context.Context, cred Credit) error {
 
 func (s Service) Deduct(ctx context.Context, cred Credit) error {
 	if cred.ID == "" {
-		return fmt.Errorf("credit id is empty, it is required to create a transaction")
+		return errors.New("credit id is empty, it is required to create a transaction")
 	}
 	if cred.Amount < 0 {
-		return fmt.Errorf("credit amount is negative")
+		return errors.New("credit amount is negative")
 	}
 
 	// check balance, if enough, sub credits

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -954,11 +954,10 @@ func (s *Service) CancelUpcomingPhase(ctx context.Context, sub Subscription) err
 
 	sub.Phase.EffectiveAt = time.Time{}
 	sub.Phase.PlanID = ""
-	sub, err = s.repository.UpdateByID(ctx, sub)
+	_, err = s.repository.UpdateByID(ctx, sub)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -21,7 +21,10 @@ app:
     # tls_cert_file: "temp/server-cert.pem"
     # tls_key_file: "temp/server-key.pem"
     # tls_client_ca_file: "temp/ca-cert.pem"
+  # port for application metrics
   metrics_port: 9000
+  # enable pprof endpoints for cpu/mem/mutex profiling
+  profiler: false
   # WARNING: identity_proxy_header bypass all authorization checks and shouldn't be used in production
   identity_proxy_header: X-Frontier-Email
   # full path prefixed with scheme where resources config yaml files are kept

--- a/docs/docs/reference/configurations.md
+++ b/docs/docs/reference/configurations.md
@@ -23,7 +23,10 @@ app:
     # tls_cert_file: "temp/server-cert.pem"
     # tls_key_file: "temp/server-key.pem"
     # tls_client_ca_file: "temp/ca-cert.pem"
+  # port for application metrics
   metrics_port: 9000
+  # enable pprof endpoints for cpu/mem/mutex profiling
+  profiler: false
   # WARNING: identity_proxy_header bypass all authorization checks and shouldn't be used in production
   identity_proxy_header: X-Frontier-Email
   # full path prefixed with scheme where resources config yaml files are kept

--- a/internal/store/postgres/audit_repository.go
+++ b/internal/store/postgres/audit_repository.go
@@ -38,15 +38,15 @@ func (a AuditRepository) Create(ctx context.Context, l *audit.Log) error {
 
 	marshaledActor, err := json.Marshal(l.Actor)
 	if err != nil {
-		return fmt.Errorf("%w: %s", parseErr, err)
+		return fmt.Errorf("%s: %w", err, parseErr)
 	}
 	marshaledTarget, err := json.Marshal(l.Target)
 	if err != nil {
-		return fmt.Errorf("%w: %s", parseErr, err)
+		return fmt.Errorf("%s: %w", err, parseErr)
 	}
 	marshaledMetadata, err := json.Marshal(l.Metadata)
 	if err != nil {
-		return fmt.Errorf("%w: %s", parseErr, err)
+		return fmt.Errorf("%s: %w", err, parseErr)
 	}
 
 	query, params, err := dialect.Insert(TABLE_AUDITLOGS).Rows(
@@ -60,7 +60,7 @@ func (a AuditRepository) Create(ctx context.Context, l *audit.Log) error {
 			"metadata": marshaledMetadata,
 		}).Returning(&Audit{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%s: %w", err, queryErr)
 	}
 
 	var auditModel Audit

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// metrics port
 	MetricsPort int `yaml:"metrics_port" mapstructure:"metrics_port" default:"9000"`
 
+	// Profiler enables /debug/pprof under metrics port
+	Profiler bool `yaml:"profiler" mapstructure:"profiler" default:"false"`
+
 	// the network interface to listen on
 	Host string `yaml:"host" mapstructure:"host" default:"127.0.0.1"`
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/profile"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/raystack/salt/spa"
 
@@ -48,6 +50,8 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
+
+	_ "net/http/pprof"
 )
 
 const (
@@ -216,6 +220,12 @@ func Serve(
 	httpMuxMetrics.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{
 		EnableOpenMetrics: true,
 	}))
+	if cfg.Profiler {
+		// enable profilers
+		profile.Start(profile.MemProfile, profile.CPUProfile, profile.MutexProfile)
+		// add debug handlers
+		httpMuxMetrics.Handle("/debug/pprof/", http.DefaultServeMux)
+	}
 
 	logger.Info("api server starting", "http-port", cfg.Port, "grpc-port", cfg.GRPC.Port, "metrics-port", cfg.MetricsPort)
 	if err := mux.Serve(


### PR DESCRIPTION
Mem/cpu/mutex profiles can be turned on for debug endpoint of metrics port via setting true on `app.profiler`.