### PR TITLE
feat: configure refresh interval to sync with billing provider

### DIFF
--- a/billing/config.go
+++ b/billing/config.go
@@ -1,5 +1,7 @@
 package billing
 
+import "time"
+
 type Config struct {
 	StripeKey            string   `yaml:"stripe_key" mapstructure:"stripe_key"`
 	StripeAutoTax        bool     `yaml:"stripe_auto_tax" mapstructure:"stripe_auto_tax"`
@@ -12,6 +14,15 @@ type Config struct {
 	PlanChangeConfig   PlanChangeConfig   `yaml:"plan_change" mapstructure:"plan_change"`
 	SubscriptionConfig SubscriptionConfig `yaml:"subscription" mapstructure:"subscription"`
 	ProductConfig      ProductConfig      `yaml:"product" mapstructure:"product"`
+
+	RefreshInterval RefreshInterval `yaml:"refresh_interval" mapstructure:"refresh_interval"`
+}
+
+type RefreshInterval struct {
+	Customer     time.Duration `yaml:"customer" mapstructure:"customer" default:"1m"`
+	Subscription time.Duration `yaml:"subscription" mapstructure:"subscription" default:"1m"`
+	Checkout     time.Duration `yaml:"checkout" mapstructure:"checkout" default:"1m"`
+	Invoice      time.Duration `yaml:"invoice" mapstructure:"invoice" default:"5m"`
 }
 
 type AccountConfig struct {

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -31,7 +31,6 @@ import (
 )
 
 const (
-	SyncDelay              = time.Second * 60
 	ProviderTestResource   = "test_resource"
 	InitiatorIDMetadataKey = "initiated_by"
 )
@@ -119,7 +118,7 @@ func (s *Service) Init(ctx context.Context) error {
 		cron.SkipIfStillRunning(cron.DefaultLogger),
 		cron.Recover(cron.DefaultLogger),
 	))
-	if _, err := s.syncJob.AddFunc(fmt.Sprintf("@every %s", SyncDelay.String()), func() {
+	if _, err := s.syncJob.AddFunc(fmt.Sprintf("@every %s", s.config.RefreshInterval.Subscription.String()), func() {
 		s.backgroundSync(ctx)
 	}); err != nil {
 		return err

--- a/billing/subscription/subscription.go
+++ b/billing/subscription/subscription.go
@@ -29,6 +29,7 @@ const (
 	StateTrialing State = "trialing"
 	StatePastDue  State = "past_due"
 	StateCanceled State = "canceled"
+	StateEnded    State = "ended"
 )
 
 type PhaseReason string

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -418,7 +418,7 @@ func buildAPIDependencies(
 
 	customerService := customer.NewService(
 		stripeClient,
-		postgres.NewBillingCustomerRepository(dbc))
+		postgres.NewBillingCustomerRepository(dbc), cfg.Billing)
 	productService := product.NewService(
 		stripeClient,
 		postgres.NewBillingProductRepository(dbc),
@@ -438,11 +438,11 @@ func buildAPIDependencies(
 		productService, creditService)
 	entitlementService := entitlement.NewEntitlementService(subscriptionService, productService,
 		planService, organizationService)
-	checkoutService := checkout.NewService(stripeClient, cfg.Billing.StripeAutoTax, postgres.NewBillingCheckoutRepository(dbc),
+	checkoutService := checkout.NewService(stripeClient, cfg.Billing, postgres.NewBillingCheckoutRepository(dbc),
 		customerService, planService, subscriptionService, productService, creditService, organizationService,
 		authnService)
 
-	invoiceService := invoice.NewService(stripeClient, postgres.NewBillingInvoiceRepository(dbc), customerService)
+	invoiceService := invoice.NewService(stripeClient, postgres.NewBillingInvoiceRepository(dbc), customerService, cfg.Billing)
 
 	usageService := usage.NewService(creditService)
 

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -208,3 +208,10 @@ billing:
     # "incremental" will change the seat count to the number of users within the organization
     # but will not decrease the seat count if reduced
     seat_change_behavior: "exact"
+  # refresh interval for billing engine to sync with the billing provider
+  # e.g. 60s, 2m, 30m
+  refresh_interval:
+    customer: 1m
+    subscription: 1m
+    invoice: 5m
+    checkout: 1m

--- a/docs/docs/reference/configurations.md
+++ b/docs/docs/reference/configurations.md
@@ -203,6 +203,15 @@ billing:
     # "incremental" will change the seat count to the number of users within the organization
     # but will not decrease the seat count if reduced
     seat_change_behavior: "exact"
+  # refresh interval for billing engine to sync with the billing provider
+  # setting it too low can lead to rate limiting by the billing provider
+  # setting it too high can lead to stale data in the billing engine
+  # e.g. 60s, 2m, 30m
+  refresh_interval:
+    customer: 1m
+    subscription: 1m
+    invoice: 5m
+    checkout: 1m
 ```
 
 </details>


### PR DESCRIPTION
Additional configurations are exposed to adjust refresh interval to sync with billing provider(stripe) based on services.
```
billing:
  # .. omit config

  # refresh interval for billing engine to sync with the billing provider
  # e.g. 60s, 2m, 30m
  refresh_interval:
    customer: 1m
    subscription: 1m
    invoice: 5m
    checkout: 1m

  # .. omit config
```

Another change as part of checkout api is to cancel any running trials immediately if the user buy same plan.