### PR TITLE
fix: explicitly set state of plans as active so that it is not set as empty

### DIFF
--- a/billing/plan/plan.go
+++ b/billing/plan/plan.go
@@ -58,6 +58,7 @@ func (p Plan) GetUserSeatProduct() (product.Product, bool) {
 type Filter struct {
 	IDs      []string
 	Interval string
+	State    string
 }
 
 type File struct {

--- a/billing/plan/service.go
+++ b/billing/plan/service.go
@@ -247,6 +247,7 @@ func (s Service) UpsertPlans(ctx context.Context, planFile File) error {
 				Interval:       planToCreate.Interval,
 				TrialDays:      planToCreate.TrialDays,
 				Metadata:       planToCreate.Metadata,
+				State:          planToCreate.State,
 			}); err != nil {
 				return err
 			}
@@ -262,6 +263,7 @@ func (s Service) UpsertPlans(ctx context.Context, planFile File) error {
 				Description:    planToCreate.Description,
 				TrialDays:      planToCreate.TrialDays,
 				Metadata:       planToCreate.Metadata,
+				State:          planToCreate.State,
 			}); err != nil {
 				return err
 			}

--- a/internal/store/postgres/billing_plan_repository.go
+++ b/internal/store/postgres/billing_plan_repository.go
@@ -180,6 +180,10 @@ func (r BillingPlanRepository) UpdateByName(ctx context.Context, toUpdate plan.P
 		return plan.Plan{}, fmt.Errorf("%w: %s", parseErr, err)
 	}
 
+	if toUpdate.State == "" {
+		toUpdate.State = "active"
+	}
+
 	query, params, err := dialect.Update(TABLE_BILLING_PLANS).Set(
 		goqu.Record{
 			"title":            toUpdate.Title,
@@ -187,6 +191,7 @@ func (r BillingPlanRepository) UpdateByName(ctx context.Context, toUpdate plan.P
 			"on_start_credits": toUpdate.OnStartCredits,
 			"trial_days":       toUpdate.TrialDays,
 			"metadata":         marshaledMetadata,
+			"state":            toUpdate.State,
 			"updated_at":       goqu.L("now()"),
 		}).Where(goqu.Ex{
 		"name": toUpdate.Name,
@@ -239,6 +244,13 @@ func (r BillingPlanRepository) List(ctx context.Context, filter plan.Filter) ([]
 			"interval": filter.Interval,
 		})
 	}
+	if filter.State == "" {
+		filter.State = "active"
+	}
+	stmt = stmt.Where(goqu.Ex{
+		"state": filter.State,
+	})
+
 	query, params, err := stmt.ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", parseErr, err)

--- a/test/e2e/regression/testdata/plans/subscription.credits.yaml
+++ b/test/e2e/regression/testdata/plans/subscription.credits.yaml
@@ -48,12 +48,14 @@ plans:
     interval: month
     products:
       - name: basic_access
+    state: active
   - name: starter_yearly
     title: Starter Plan
     description: Starter Plan
     interval: year
     products:
       - name: starter_access
+    state: active
   - name: starter_monthly
     title: Starter Plan
     description: Starter Plan
@@ -61,9 +63,11 @@ plans:
     on_start_credits: 50
     products:
       - name: starter_access
+    state: active
   - name: enterprise_yearly
     title: Enterprise Plan
     description: Enterprise Plan
     interval: year
     products:
       - name: enterprise_access
+    state: active


### PR DESCRIPTION
- Explicitly set `active` state, since otherwise it is set as empty string
- Return only active plans when listing plans, unless explicitly stated otherwise

This will help in using the `state` field in plans, to determine which plans to show/not show on the UI.

## Dev testing:

Plans table after these changes (earlier the state for all plans was ""):
```
frontier=# select name, state from billing_plans;
              name              |  state   
--------------------------------+----------
 monthly_enterprise_plan   | active
 yearly_enterprise_plan    | active
 standard_plan             | inactive
 monthly_professional_plan | active
 yearly_professional_plan  | active
(5 rows)
```

Output of list API call:
After the changes above, the list call returns only 4 plans from the DB shown above:
1. Monthly enterprise plan
2. Yearly enterprise plan
3. Monthly professional plan
4. Yearly professional plan
The standard plan is not shown since its state is set as `inactive`