### PR TITLE
fix: trialing subscriptions failed to sync

### DIFF
--- a/billing/subscription/subscription.go
+++ b/billing/subscription/subscription.go
@@ -86,7 +86,7 @@ func (s Subscription) IsActive() bool {
 }
 
 func (s Subscription) IsCanceled() bool {
-	return State(s.State) == StateCanceled || !s.DeletedAt.IsZero() || !s.CanceledAt.IsZero()
+	return State(s.State) == StateCanceled || !s.DeletedAt.IsZero()
 }
 
 type Filter struct {


### PR DESCRIPTION
- Triling subscriptions were filtered out from the periodic syncer causing for it to stay in trialing state.
- Buying a trialing subscription will be canceled only after payment is finished