### PR TITLE
feat(admin-ui): add cancellation and status

### DIFF
--- a/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
+++ b/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
@@ -3,6 +3,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Text } from "@raystack/apsara";
 import { capitalizeFirstLetter, getFormattedDateString } from "~/utils/helper";
+import { SUBSCRIPTION_STATUSES } from "~/utils/constants";
 const columnHelper = createColumnHelper<V1Beta1Subscription>();
 
 interface getColumnsOptions {
@@ -52,22 +53,22 @@ export const getColumns: (
         headerFilter: false,
       },
       cell: (info) => getFormattedDateString(info.getValue()),
-
       footer: (props) => props.column.id,
     },
     {
       header: "Cancellation date",
       accessorKey: "canceled_at",
-      meta: {
-        headerFilter: false,
-      },
+      filterVariant: "date",
       cell: (info) => getFormattedDateString(info.getValue()),
     },
     {
       header: "Status",
       accessorKey: "state",
       cell: (info) => capitalizeFirstLetter(info.getValue()),
-      filterVariant: "text",
+      meta: {
+        data: SUBSCRIPTION_STATUSES
+      },
+      filterVariant: "select",
     },
   ];
 };

--- a/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
+++ b/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
@@ -2,6 +2,7 @@ import { V1Beta1Plan, V1Beta1Subscription } from "@raystack/frontier";
 import type { ColumnDef } from "@tanstack/react-table";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Text } from "@raystack/apsara";
+import { capitalizeFirstLetter, getFormattedDateString } from "~/utils/helper";
 const columnHelper = createColumnHelper<V1Beta1Subscription>();
 
 interface getColumnsOptions {
@@ -28,8 +29,9 @@ export const getColumns: (
       accessorKey: "plan_id",
       cell: (info) => {
         const planId = info.getValue();
-        const planName = `${plansMap[planId]?.title} (${plansMap[planId]?.interval})`;
-        return <Text>{planName}</Text>;
+        const planName = plansMap[planId]?.title;
+        const planInterval = plansMap[planId]?.interval;
+        return planName ? <Text>{planName} ({planInterval})</Text> : '-'
       },
       filterVariant: "text",
     },
@@ -39,12 +41,7 @@ export const getColumns: (
       meta: {
         headerFilter: false,
       },
-      cell: (info) =>
-        new Date(info.getValue() as Date).toLocaleString("en", {
-          month: "long",
-          day: "numeric",
-          year: "numeric",
-        }),
+      cell: (info) => getFormattedDateString(info.getValue()),
 
       footer: (props) => props.column.id,
     },
@@ -54,14 +51,24 @@ export const getColumns: (
       meta: {
         headerFilter: false,
       },
-      cell: (info) =>
-        new Date(info.getValue() as Date).toLocaleString("en", {
-          month: "long",
-          day: "numeric",
-          year: "numeric",
-        }),
+      cell: (info) => getFormattedDateString(info.getValue()),
 
       footer: (props) => props.column.id,
+    },
+    {
+      header: "Cancellation date",
+      accessorKey: "canceled_at",
+      meta: {
+        headerFilter: false,
+      },
+      cell: (info) => getFormattedDateString(info.getValue()),
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Status",
+      accessorKey: "state",
+      cell: (info) => capitalizeFirstLetter(info.getValue()),
+      filterVariant: "text",
     },
   ];
 };

--- a/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
+++ b/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
@@ -62,7 +62,7 @@ export const getColumns: (
         headerFilter: false,
       },
       cell: (info) => getFormattedDateString(info.getValue()),
-      footer: (props) => props.column.id,
+      // footer: (props) => props.column.id,
     },
     {
       header: "Status",

--- a/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
+++ b/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
@@ -62,7 +62,6 @@ export const getColumns: (
         headerFilter: false,
       },
       cell: (info) => getFormattedDateString(info.getValue()),
-      // footer: (props) => props.column.id,
     },
     {
       header: "Status",

--- a/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
+++ b/ui/src/containers/organisations.list/billingaccounts/subscriptions/columns.tsx
@@ -39,19 +39,14 @@ export const getColumns: (
     {
       header: "Period start date",
       accessorKey: "current_period_start_at",
-      meta: {
-        headerFilter: false,
-      },
+      filterVariant: "date",
       cell: (info) => getFormattedDateString(info.getValue()),
-
       footer: (props) => props.column.id,
     },
     {
       header: "Period end date",
       accessorKey: "current_period_end_at",
-      meta: {
-        headerFilter: false,
-      },
+      filterVariant: "date",
       cell: (info) => getFormattedDateString(info.getValue()),
       footer: (props) => props.column.id,
     },

--- a/ui/src/containers/organisations.list/billingaccounts/subscriptions/index.tsx
+++ b/ui/src/containers/organisations.list/billingaccounts/subscriptions/index.tsx
@@ -88,7 +88,7 @@ export default function OrganisationBASubscriptions() {
 export const noDataChildren = (
   <EmptyState>
     <div className="svg-container"></div>
-    <h3>0 subsctription created</h3>
+    <h3>0 subscriptions created</h3>
   </EmptyState>
 );
 

--- a/ui/src/contexts/App.tsx
+++ b/ui/src/contexts/App.tsx
@@ -42,7 +42,7 @@ export const AppContext = createContext<AppContextValue>(
   AppContextDefaultValue
 );
 
-export const AppConextProvider: React.FC<PropsWithChildren> = function ({
+export const AppContextProvider: React.FC<PropsWithChildren> = function ({
   children,
 }) {
   const { client, user, isUserLoading } = useFrontier();

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { Toaster } from "sonner";
 import Routes from "./routes";
-import { AppConextProvider } from "./contexts/App";
+import { AppContextProvider } from "./contexts/App";
 
 const getFrontierConfig = () => {
   const frontierEndpoint =
@@ -32,9 +32,9 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
           baseColor="var(--background-base-hover)"
         >
           <FrontierProvider config={frontierConfig}>
-            <AppConextProvider>
+            <AppContextProvider>
               <Routes />
-            </AppConextProvider>
+            </AppContextProvider>
           </FrontierProvider>
           <Toaster richColors />
         </SkeletonTheme>

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -3,3 +3,12 @@ export const DEFAULT_DATE_FORMAT = "MMM DD, YYYY";
 export const PERMISSIONS = {
   OrganizationNamespace: "app/organization",
 } as const;
+
+
+export const SUBSCRIPTION_STATUSES = [
+  {label: 'Active', value: 'active'},
+  {label: 'Trialing', value: 'trialing'},
+  {label: 'Past due', value: 'past_due'},
+  {label: 'Canceled', value: 'canceled'},
+  {label: 'Ended', value: 'ended'}
+]

--- a/ui/src/utils/helper.ts
+++ b/ui/src/utils/helper.ts
@@ -1,4 +1,6 @@
+import dayjs from "dayjs";
 import type { TableColumnMetadata } from "~/types/types";
+import { DEFAULT_DATE_FORMAT } from "./constants";
 
 const DEFAULT_REDIRECT = "/";
 const currencySymbolMap: Record<string, string> = {
@@ -48,3 +50,8 @@ export const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
 export const keyToColumnMetaObject = (key: any) =>
   ({ key: key, name: key, value: key } as TableColumnMetadata);
+
+/*
+ * @desc returns date string - Eg, June 13, 2025. return '-' if the date in the argument is invalid.
+ */
+export const getFormattedDateString = (date: string) => date ? dayjs(date).format(DEFAULT_DATE_FORMAT) : '-'


### PR DESCRIPTION
- Add status and cancellation columns in the subscription page.
- Add dayjs for formatting.
- Handle undefined planName. Fallback to '-'.
- Date filter type for start and end date.
- Typo fixes

Linear: [ID-505](https://linear.app/pixxel/issue/IDE-505/[admin-panel]-show-status-and-canceled-at-on-subscriptions-page)

URL: /organisations/`organisationId`/billingaccounts/`billingaccountId`/subscriptions

Testing:
Dev tested on Chrome.

<img width="1503" alt="Screenshot 2024-08-07 at 4 49 55 PM" src="https://github.com/user-attachments/assets/532e36d1-1152-4b96-adaa-eb73f3247e2f">
