### PR TITLE
fix: users are able to accept expired invitations

### DIFF
--- a/core/invitation/invite.go
+++ b/core/invitation/invite.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("invitation not found")
+	ErrNotFound   = errors.New("invitation not found")
+	InviteExpired = errors.New("invitation expired")
 )
 
 const (

--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -281,6 +281,9 @@ func (s Service) Accept(ctx context.Context, id uuid.UUID) error {
 	if err != nil {
 		return err
 	}
+	if invite.ExpiresAt.Before(time.Now()) {
+		return InviteExpired
+	}
 
 	// check if user is already a member of the organization
 	// if yes, check if any other part of the invitation applies like group membership

--- a/internal/api/v1beta1/invitations.go
+++ b/internal/api/v1beta1/invitations.go
@@ -18,7 +18,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var grpcInvitationNotFoundError = status.Error(codes.NotFound, "invitation not found")
+var (
+	grpcInvitationNotFoundError = status.Error(codes.NotFound, "invitation not found")
+	grpcInvitationExpiredError  = status.Error(codes.InvalidArgument, "invitation expired")
+)
 
 type InvitationService interface {
 	Get(ctx context.Context, id uuid.UUID) (invitation.Invitation, error)
@@ -247,7 +250,7 @@ func (h Handler) AcceptOrganizationInvitation(ctx context.Context, request *fron
 		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, invitation.InviteExpired):
-			return nil, grpcBadBodyError
+			return nil, grpcInvitationExpiredError
 		case errors.Is(err, invitation.ErrNotFound):
 			return nil, grpcInvitationNotFoundError
 		case errors.Is(err, user.ErrNotExist):

--- a/internal/api/v1beta1/invitations.go
+++ b/internal/api/v1beta1/invitations.go
@@ -246,6 +246,8 @@ func (h Handler) AcceptOrganizationInvitation(ctx context.Context, request *fron
 	if err := h.invitationService.Accept(ctx, inviteID); err != nil {
 		logger.Error(err.Error())
 		switch {
+		case errors.Is(err, invitation.InviteExpired):
+			return nil, grpcBadBodyError
 		case errors.Is(err, invitation.ErrNotFound):
 			return nil, grpcInvitationNotFoundError
 		case errors.Is(err, user.ErrNotExist):

--- a/internal/api/v1beta1/invitations_test.go
+++ b/internal/api/v1beta1/invitations_test.go
@@ -495,7 +495,7 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 				OrgId: testOrgID,
 			},
 			want:    nil,
-			wantErr: grpcBadBodyError,
+			wantErr: grpcInvitationExpiredError,
 		},
 		{
 			name: "should accept an invitation on success",

--- a/internal/api/v1beta1/invitations_test.go
+++ b/internal/api/v1beta1/invitations_test.go
@@ -24,9 +24,11 @@ import (
 var (
 	testInvitation1ID = uuid.New()
 	testInvitation2ID = uuid.New()
+	testInvitation3ID = uuid.New()
 	testOrg2ID        = uuid.New().String()
 	testUserEmail     = "test@raystack.org"
 	testUser2Email    = "user2@raystack.org"
+	testUser3Email    = "tu3@raystack.org"
 	testInvitationMap = map[string]invitation.Invitation{
 		testInvitation1ID.String(): {
 			ID:          testInvitation1ID,
@@ -51,6 +53,17 @@ var (
 			},
 			CreatedAt: time.Time{},
 			ExpiresAt: time.Time{},
+		},
+		testInvitation3ID.String(): {
+			ID:          testInvitation3ID,
+			UserEmailID: testUser3Email,
+			OrgID:       testOrg2ID,
+			GroupIDs:    []string{},
+			Metadata: metadata.Metadata{
+				"group_ids": "",
+			},
+			CreatedAt: time.Time{}.AddDate(0, 0, -8),
+			ExpiresAt: time.Time{}.AddDate(0, 0, -1),
 		},
 	}
 )
@@ -470,6 +483,19 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: grpcInternalServerError,
+		},
+		{
+			name: "should return error if invitation is expired",
+			setup: func(is *mocks.InvitationService, us *mocks.UserService, gs *mocks.GroupService, os *mocks.OrganizationService) {
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
+				is.EXPECT().Accept(mock.AnythingOfType("context.backgroundCtx"), testInvitation3ID).Return(invitation.InviteExpired)
+			},
+			request: &frontierv1beta1.AcceptOrganizationInvitationRequest{
+				Id:    testInvitation3ID.String(),
+				OrgId: testOrgID,
+			},
+			want:    nil,
+			wantErr: grpcBadBodyError,
 		},
 		{
 			name: "should accept an invitation on success",


### PR DESCRIPTION
IDE-499

fix: return error if user is tying to accept expired invite. Currently, user can accept expired 


### Testing:

API request:

`curl --location 'http://127.0.0.1:9080/v1beta1/organizations/<org_id>/invitations/<invite_id>/accept' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'Cookie: sid= \
--data '{}'`

Response code
`400 Bad Request`

Response body:
`{"code":3,"message":"invitation expired","details":[]}`