### PR TITLE
fix: context cancel errors are no longer internal errors

### DIFF
--- a/internal/api/v1beta1/audit.go
+++ b/internal/api/v1beta1/audit.go
@@ -3,7 +3,6 @@ package v1beta1
 import (
 	"context"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/raystack/frontier/core/audit"
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/pkg/errors"
@@ -18,17 +17,15 @@ type AuditService interface {
 }
 
 func (h Handler) ListOrganizationAuditLogs(ctx context.Context, request *frontierv1beta1.ListOrganizationAuditLogsRequest) (*frontierv1beta1.ListOrganizationAuditLogsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
@@ -42,8 +39,7 @@ func (h Handler) ListOrganizationAuditLogs(ctx context.Context, request *frontie
 		IgnoreSystem: request.GetIgnoreSystem(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	for _, v := range logList {
 		logs = append(logs, transformAuditLogToPB(v))
@@ -55,17 +51,15 @@ func (h Handler) ListOrganizationAuditLogs(ctx context.Context, request *frontie
 }
 
 func (h Handler) CreateOrganizationAuditLogs(ctx context.Context, request *frontierv1beta1.CreateOrganizationAuditLogsRequest) (*frontierv1beta1.CreateOrganizationAuditLogsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
@@ -92,32 +86,28 @@ func (h Handler) CreateOrganizationAuditLogs(ctx context.Context, request *front
 			},
 			Metadata: log.GetContext(),
 		}); err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 	return &frontierv1beta1.CreateOrganizationAuditLogsResponse{}, nil
 }
 
 func (h Handler) GetOrganizationAuditLog(ctx context.Context, request *frontierv1beta1.GetOrganizationAuditLogRequest) (*frontierv1beta1.GetOrganizationAuditLogResponse, error) {
-	logger := grpczap.Extract(ctx)
 	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	log, err := h.auditService.GetByID(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	return &frontierv1beta1.GetOrganizationAuditLogResponse{

--- a/internal/api/v1beta1/audit_test.go
+++ b/internal/api/v1beta1/audit_test.go
@@ -101,7 +101,7 @@ func TestHandler_ListOrganizationAuditLogs(t *testing.T) {
 				EndTime:   timestamppb.New(time.Time{}),
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test-error"),
 		},
 		{
 			name: "should return error when org is disabled",
@@ -249,7 +249,7 @@ func TestHandler_CreateOrganizationAuditLogs(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test-error"),
 		},
 	}
 
@@ -339,7 +339,7 @@ func TestHandler_GetOrganizationAuditLog(t *testing.T) {
 				OrgId: "org-id",
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test-error"),
 		},
 	}
 

--- a/internal/api/v1beta1/billing_check.go
+++ b/internal/api/v1beta1/billing_check.go
@@ -10,7 +10,6 @@ import (
 	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 )
 
@@ -20,12 +19,9 @@ type EntitlementService interface {
 }
 
 func (h Handler) CheckFeatureEntitlement(ctx context.Context, request *frontierv1beta1.CheckFeatureEntitlementRequest) (*frontierv1beta1.CheckFeatureEntitlementResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	checkStatus, err := h.entitlementService.Check(ctx, request.GetBillingId(), request.GetFeature())
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	return &frontierv1beta1.CheckFeatureEntitlementResponse{

--- a/internal/api/v1beta1/billing_invoice.go
+++ b/internal/api/v1beta1/billing_invoice.go
@@ -6,7 +6,6 @@ import (
 	"github.com/raystack/frontier/billing/invoice"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 )
 
@@ -17,19 +16,15 @@ type InvoiceService interface {
 }
 
 func (h Handler) ListAllInvoices(ctx context.Context, request *frontierv1beta1.ListAllInvoicesRequest) (*frontierv1beta1.ListAllInvoicesResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	invoices, err := h.invoiceService.ListAll(ctx, invoice.Filter{})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	var invoicePBs []*frontierv1beta1.Invoice
 	for _, v := range invoices {
 		invoicePB, err := transformInvoiceToPB(v)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 		invoicePBs = append(invoicePBs, invoicePB)
 	}
@@ -40,22 +35,18 @@ func (h Handler) ListAllInvoices(ctx context.Context, request *frontierv1beta1.L
 }
 
 func (h Handler) ListInvoices(ctx context.Context, request *frontierv1beta1.ListInvoicesRequest) (*frontierv1beta1.ListInvoicesResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	invoices, err := h.invoiceService.List(ctx, invoice.Filter{
 		CustomerID:  request.GetBillingId(),
 		NonZeroOnly: request.GetNonzeroAmountOnly(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	var invoicePBs []*frontierv1beta1.Invoice
 	for _, v := range invoices {
 		invoicePB, err := transformInvoiceToPB(v)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 		invoicePBs = append(invoicePBs, invoicePB)
 	}
@@ -66,17 +57,13 @@ func (h Handler) ListInvoices(ctx context.Context, request *frontierv1beta1.List
 }
 
 func (h Handler) GetUpcomingInvoice(ctx context.Context, request *frontierv1beta1.GetUpcomingInvoiceRequest) (*frontierv1beta1.GetUpcomingInvoiceResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	invoice, err := h.invoiceService.GetUpcoming(ctx, request.GetBillingId())
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	invoicePB, err := transformInvoiceToPB(invoice)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	return &frontierv1beta1.GetUpcomingInvoiceResponse{

--- a/internal/api/v1beta1/billing_usage.go
+++ b/internal/api/v1beta1/billing_usage.go
@@ -14,7 +14,6 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 )
 
@@ -29,8 +28,6 @@ type UsageService interface {
 }
 
 func (h Handler) CreateBillingUsage(ctx context.Context, request *frontierv1beta1.CreateBillingUsageRequest) (*frontierv1beta1.CreateBillingUsageResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	createRequests := make([]usage.Usage, 0, len(request.GetUsages()))
 	for _, v := range request.GetUsages() {
 		usageType := usage.CreditType
@@ -51,7 +48,6 @@ func (h Handler) CreateBillingUsage(ctx context.Context, request *frontierv1beta
 	}
 
 	if err := h.usageService.Report(ctx, createRequests); err != nil {
-		logger.Error(err.Error())
 		if errors.Is(err, credit.ErrInsufficientCredits) {
 			return nil, ErrInvalidInput(err.Error())
 		}
@@ -62,7 +58,6 @@ func (h Handler) CreateBillingUsage(ctx context.Context, request *frontierv1beta
 }
 
 func (h Handler) ListBillingTransactions(ctx context.Context, request *frontierv1beta1.ListBillingTransactionsRequest) (*frontierv1beta1.ListBillingTransactionsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	if request.GetBillingId() == "" {
 		return nil, grpcBadBodyError
 	}
@@ -85,14 +80,12 @@ func (h Handler) ListBillingTransactions(ctx context.Context, request *frontierv
 		EndRange:   endRange,
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	for _, v := range transactionsList {
 		transactionPB, err := transformTransactionToPB(v)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 		transactions = append(transactions, transactionPB)
 	}
@@ -103,10 +96,8 @@ func (h Handler) ListBillingTransactions(ctx context.Context, request *frontierv
 }
 
 func (h Handler) RevertBillingUsage(ctx context.Context, request *frontierv1beta1.RevertBillingUsageRequest) (*frontierv1beta1.RevertBillingUsageResponse, error) {
-	logger := grpczap.Extract(ctx)
 	if err := h.usageService.Revert(ctx, request.GetBillingId(),
 		request.GetUsageId(), request.GetAmount()); err != nil {
-		logger.Error(err.Error())
 		if errors.Is(err, usage.ErrRevertAmountExceeds) {
 			return nil, ErrInvalidInput(err.Error())
 		} else if errors.Is(err, usage.ErrExistingRevertedUsage) {
@@ -118,7 +109,7 @@ func (h Handler) RevertBillingUsage(ctx context.Context, request *frontierv1beta
 		} else if errors.Is(err, credit.ErrAlreadyApplied) {
 			return nil, ErrInvalidInput(err.Error())
 		}
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	return &frontierv1beta1.RevertBillingUsageResponse{}, nil
 }

--- a/internal/api/v1beta1/deleter.go
+++ b/internal/api/v1beta1/deleter.go
@@ -3,7 +3,6 @@ package v1beta1
 import (
 	"context"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,18 +16,14 @@ type CascadeDeleter interface {
 }
 
 func (h Handler) DeleteProject(ctx context.Context, request *frontierv1beta1.DeleteProjectRequest) (*frontierv1beta1.DeleteProjectResponse, error) {
-	logger := grpczap.Extract(ctx)
 	if err := h.deleterService.DeleteProject(ctx, request.GetId()); err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	return &frontierv1beta1.DeleteProjectResponse{}, nil
 }
 
 func (h Handler) DeleteOrganization(ctx context.Context, request *frontierv1beta1.DeleteOrganizationRequest) (*frontierv1beta1.DeleteOrganizationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	if err := h.deleterService.DeleteOrganization(ctx, request.GetId()); err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	return &frontierv1beta1.DeleteOrganizationResponse{}, nil

--- a/internal/api/v1beta1/errors.go
+++ b/internal/api/v1beta1/errors.go
@@ -9,7 +9,6 @@ import (
 // HTTP Codes defined here:
 // https://github.com/grpc-ecosystem/grpc-gateway/blob/master/runtime/errors.go#L36
 var (
-	ErrInternalServer        = errors.New("internal server error")
 	ErrBadRequest            = errors.New("invalid syntax in body")
 	ErrInvalidMetadata       = errors.New("metadata schema validation failed")
 	ErrConflictRequest       = errors.New("already exist")
@@ -18,7 +17,6 @@ var (
 	ErrEmailConflict         = errors.New("user email can't be updated")
 	ErrOperationUnsupported  = errors.New("operation not supported")
 
-	grpcInternalServerError    = status.Errorf(codes.Internal, ErrInternalServer.Error())
 	grpcConflictError          = status.Errorf(codes.AlreadyExists, ErrConflictRequest.Error())
 	grpcBadBodyError           = status.Error(codes.InvalidArgument, ErrBadRequest.Error())
 	grpcBadBodyMetaSchemaError = status.Error(codes.InvalidArgument, ErrBadRequest.Error()+" : "+ErrInvalidMetadata.Error())

--- a/internal/api/v1beta1/invitations.go
+++ b/internal/api/v1beta1/invitations.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/raystack/frontier/core/invitation"
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/core/user"
@@ -33,17 +32,15 @@ type InvitationService interface {
 }
 
 func (h Handler) ListOrganizationInvitations(ctx context.Context, request *frontierv1beta1.ListOrganizationInvitationsRequest) (*frontierv1beta1.ListOrganizationInvitationsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
@@ -52,14 +49,12 @@ func (h Handler) ListOrganizationInvitations(ctx context.Context, request *front
 		UserID: request.GetUserId(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	var pbinvs []*frontierv1beta1.Invitation
 	for _, inv := range invite {
 		pbInv, err := transformInvitationToPB(inv)
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		pbinvs = append(pbinvs, pbInv)
@@ -70,7 +65,6 @@ func (h Handler) ListOrganizationInvitations(ctx context.Context, request *front
 }
 
 func (h Handler) ListCurrentUserInvitations(ctx context.Context, request *frontierv1beta1.ListCurrentUserInvitationsRequest) (*frontierv1beta1.ListCurrentUserInvitationsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	principal, err := h.GetLoggedInPrincipal(ctx)
 	if err != nil {
 		return nil, err
@@ -81,7 +75,6 @@ func (h Handler) ListCurrentUserInvitations(ctx context.Context, request *fronti
 
 	invites, err := h.invitationService.ListByUser(ctx, principal.User.Email)
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	var invPBs []*frontierv1beta1.Invitation
@@ -89,7 +82,6 @@ func (h Handler) ListCurrentUserInvitations(ctx context.Context, request *fronti
 	for _, inv := range invites {
 		pbInv, err := transformInvitationToPB(inv)
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		invPBs = append(invPBs, pbInv)
@@ -100,12 +92,10 @@ func (h Handler) ListCurrentUserInvitations(ctx context.Context, request *fronti
 	for _, org := range orgIds {
 		orgResp, err := h.orgService.Get(ctx, org)
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, fmt.Errorf("failed to get org: %w", err).Error())
 		}
 		orgPB, err := transformOrgToPB(orgResp)
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, fmt.Errorf("failed to transform org to pb: %w", err).Error())
 		}
 		orgPBs = append(orgPBs, orgPB)
@@ -117,17 +107,14 @@ func (h Handler) ListCurrentUserInvitations(ctx context.Context, request *fronti
 }
 
 func (h Handler) ListUserInvitations(ctx context.Context, request *frontierv1beta1.ListUserInvitationsRequest) (*frontierv1beta1.ListUserInvitationsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	invite, err := h.invitationService.ListByUser(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	var pbinvs []*frontierv1beta1.Invitation
 	for _, inv := range invite {
 		pbInv, err := transformInvitationToPB(inv)
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		pbinvs = append(pbinvs, pbInv)
@@ -138,23 +125,20 @@ func (h Handler) ListUserInvitations(ctx context.Context, request *frontierv1bet
 }
 
 func (h Handler) CreateOrganizationInvitation(ctx context.Context, request *frontierv1beta1.CreateOrganizationInvitationRequest) (*frontierv1beta1.CreateOrganizationInvitationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	for _, userID := range request.GetUserIds() {
 		if !isValidEmail(userID) {
-			logger.Error("invalid email")
 			return nil, status.Errorf(codes.InvalidArgument, "invalid email")
 		}
 	}
@@ -168,7 +152,6 @@ func (h Handler) CreateOrganizationInvitation(ctx context.Context, request *fron
 			GroupIDs:    request.GetGroupIds(),
 		})
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		createdInvitations = append(createdInvitations, inv)
@@ -178,7 +161,6 @@ func (h Handler) CreateOrganizationInvitation(ctx context.Context, request *fron
 	for _, inv := range createdInvitations {
 		pbInv, err := transformInvitationToPB(inv)
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		pbInvs = append(pbInvs, pbInv)
@@ -189,35 +171,30 @@ func (h Handler) CreateOrganizationInvitation(ctx context.Context, request *fron
 }
 
 func (h Handler) GetOrganizationInvitation(ctx context.Context, request *frontierv1beta1.GetOrganizationInvitationRequest) (*frontierv1beta1.GetOrganizationInvitationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	inviteID, err := uuid.Parse(request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, grpcBadBodyError
 	}
 
 	inv, err := h.invitationService.Get(ctx, inviteID)
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	pbInv, err := transformInvitationToPB(inv)
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	return &frontierv1beta1.GetOrganizationInvitationResponse{
@@ -226,28 +203,24 @@ func (h Handler) GetOrganizationInvitation(ctx context.Context, request *frontie
 }
 
 func (h Handler) AcceptOrganizationInvitation(ctx context.Context, request *frontierv1beta1.AcceptOrganizationInvitationRequest) (*frontierv1beta1.AcceptOrganizationInvitationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	inviteID, err := uuid.Parse(request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, grpcBadBodyError
 	}
 
 	if err := h.invitationService.Accept(ctx, inviteID); err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, invitation.InviteExpired):
 			return nil, grpcInvitationExpiredError
@@ -256,35 +229,31 @@ func (h Handler) AcceptOrganizationInvitation(ctx context.Context, request *fron
 		case errors.Is(err, user.ErrNotExist):
 			return nil, grpcUserNotFoundError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 	return &frontierv1beta1.AcceptOrganizationInvitationResponse{}, nil
 }
 
 func (h Handler) DeleteOrganizationInvitation(ctx context.Context, request *frontierv1beta1.DeleteOrganizationInvitationRequest) (*frontierv1beta1.DeleteOrganizationInvitationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	_, err := h.orgService.Get(ctx, request.GetOrgId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	inviteID, err := uuid.Parse(request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, grpcBadBodyError
 	}
 
 	if err := h.invitationService.Delete(ctx, inviteID); err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	return &frontierv1beta1.DeleteOrganizationInvitationResponse{}, nil

--- a/internal/api/v1beta1/invitations_test.go
+++ b/internal/api/v1beta1/invitations_test.go
@@ -482,7 +482,7 @@ func TestHandler_AcceptOrganizationInvitation(t *testing.T) {
 				OrgId: testOrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return error if invitation is expired",

--- a/internal/api/v1beta1/metaschema_test.go
+++ b/internal/api/v1beta1/metaschema_test.go
@@ -48,11 +48,11 @@ func TestHandler_ListMetaSchemas(t *testing.T) {
 		{
 			name: "should return an error if Meta schema service return some error",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().List(mock.AnythingOfType("context.backgroundCtx")).Return([]metaschema.MetaSchema{}, errors.New("some_err"))
+				m.EXPECT().List(mock.AnythingOfType("context.backgroundCtx")).Return([]metaschema.MetaSchema{}, errors.New("test error"))
 			},
 			req:     &frontierv1beta1.ListMetaSchemasRequest{},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 	}
 	for _, tt := range tests {
@@ -154,7 +154,7 @@ func Test_CreateMetaSchema(t *testing.T) {
 				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
-				}).Return(metaschema.MetaSchema{}, errors.New("some_err"))
+				}).Return(metaschema.MetaSchema{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.CreateMetaSchemaRequest{
 				Body: &frontierv1beta1.MetaSchemaRequestBody{
@@ -163,7 +163,7 @@ func Test_CreateMetaSchema(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 	}
 	for _, tt := range tests {
@@ -236,13 +236,13 @@ func Test_GetMetaSchema(t *testing.T) {
 		{
 			name: "should return an error if meta schema service return some error",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(metaschema.MetaSchema{}, errors.New("some_error"))
+				m.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(metaschema.MetaSchema{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.GetMetaSchemaRequest{
 				Id: "some_id",
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 	}
 	for _, tt := range tests {
@@ -384,7 +384,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 				m.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), "some_id", metaschema.MetaSchema{
 					Name:   "some_name",
 					Schema: "some_schema",
-				}).Return(metaschema.MetaSchema{}, errors.New("some_err"))
+				}).Return(metaschema.MetaSchema{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.UpdateMetaSchemaRequest{
 				Id: "some_id",
@@ -394,7 +394,7 @@ func Test_UpdateMetaSchema(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 	}
 	for _, tt := range tests {
@@ -455,13 +455,13 @@ func Test_DeleteMetaSchema(t *testing.T) {
 		{
 			name: "should return an error if Meta schema service return some error ",
 			setup: func(m *mocks.MetaSchemaService) {
-				m.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(errors.New("some_error"))
+				m.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "some_id").Return(errors.New("test error"))
 			},
 			req: &frontierv1beta1.DeleteMetaSchemaRequest{
 				Id: "some_id",
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/api/v1beta1/namespace.go
+++ b/internal/api/v1beta1/namespace.go
@@ -7,7 +7,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/raystack/frontier/core/namespace"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -23,20 +22,17 @@ type NamespaceService interface {
 var grpcNamespaceNotFoundErr = status.Errorf(codes.NotFound, "namespace doesn't exist")
 
 func (h Handler) ListNamespaces(ctx context.Context, request *frontierv1beta1.ListNamespacesRequest) (*frontierv1beta1.ListNamespacesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	var namespaces []*frontierv1beta1.Namespace
 
 	nsList, err := h.namespaceService.List(ctx)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	for _, ns := range nsList {
 		nsPB, err := transformNamespaceToPB(ns)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 
 		namespaces = append(namespaces, &nsPB)
@@ -46,24 +42,20 @@ func (h Handler) ListNamespaces(ctx context.Context, request *frontierv1beta1.Li
 }
 
 func (h Handler) GetNamespace(ctx context.Context, request *frontierv1beta1.GetNamespaceRequest) (*frontierv1beta1.GetNamespaceResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	fetchedNS, err := h.namespaceService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, namespace.ErrNotExist),
 			errors.Is(err, namespace.ErrInvalidID):
 			return nil, grpcNamespaceNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	nsPB, err := transformNamespaceToPB(fetchedNS)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	return &frontierv1beta1.GetNamespaceResponse{Namespace: &nsPB}, nil

--- a/internal/api/v1beta1/namespace_test.go
+++ b/internal/api/v1beta1/namespace_test.go
@@ -13,8 +13,6 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -51,10 +49,10 @@ func TestListNamespaces(t *testing.T) {
 		{
 			title: "should return internal error if namespace service return some error",
 			setup: func(ns *mocks.NamespaceService) {
-				ns.EXPECT().List(mock.Anything).Return([]namespace.Namespace{}, errors.New("some error"))
+				ns.EXPECT().List(mock.Anything).Return([]namespace.Namespace{}, errors.New("test error"))
 			},
 			want: nil,
-			err:  status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return success if namespace service return nil error",
@@ -118,13 +116,13 @@ func TestHandler_GetNamespace(t *testing.T) {
 		{
 			name: "should return internal error if namespace service return some error",
 			setup: func(ns *mocks.NamespaceService) {
-				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{}, errors.New("some error"))
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetNamespaceRequest{
 				Id: testNSID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if namespace id is empty",

--- a/internal/api/v1beta1/org.go
+++ b/internal/api/v1beta1/org.go
@@ -47,22 +47,19 @@ type OrganizationService interface {
 }
 
 func (h Handler) ListOrganizations(ctx context.Context, request *frontierv1beta1.ListOrganizationsRequest) (*frontierv1beta1.ListOrganizationsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	var orgs []*frontierv1beta1.Organization
 	orgList, err := h.orgService.List(ctx, organization.Filter{
 		State:  organization.State(request.GetState()),
 		UserID: request.GetUserId(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	for _, v := range orgList {
 		orgPB, err := transformOrgToPB(v)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 
 		orgs = append(orgs, orgPB)
@@ -74,23 +71,19 @@ func (h Handler) ListOrganizations(ctx context.Context, request *frontierv1beta1
 }
 
 func (h Handler) ListAllOrganizations(ctx context.Context, request *frontierv1beta1.ListAllOrganizationsRequest) (*frontierv1beta1.ListAllOrganizationsResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	var orgs []*frontierv1beta1.Organization
 	orgList, err := h.orgService.List(ctx, organization.Filter{
 		State:  organization.State(request.GetState()),
 		UserID: request.GetUserId(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	for _, v := range orgList {
 		orgPB, err := transformOrgToPB(v)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 
 		orgs = append(orgs, orgPB)
@@ -102,11 +95,9 @@ func (h Handler) ListAllOrganizations(ctx context.Context, request *frontierv1be
 }
 
 func (h Handler) CreateOrganization(ctx context.Context, request *frontierv1beta1.CreateOrganizationRequest) (*frontierv1beta1.CreateOrganizationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	metaDataMap := metadata.Build(request.GetBody().GetMetadata().AsMap())
 
 	if err := h.metaSchemaService.Validate(metaDataMap, orgMetaSchema); err != nil {
-		logger.Error(err.Error())
 		return nil, grpcBadBodyMetaSchemaError
 	}
 
@@ -117,7 +108,6 @@ func (h Handler) CreateOrganization(ctx context.Context, request *frontierv1beta
 		Metadata: metaDataMap,
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, user.ErrInvalidEmail):
 			return nil, grpcUnauthenticated
@@ -126,14 +116,13 @@ func (h Handler) CreateOrganization(ctx context.Context, request *frontierv1beta
 		case errors.Is(err, organization.ErrConflict):
 			return nil, grpcConflictError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	orgPB, err := transformOrgToPB(newOrg)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	audit.GetAuditor(ctx, newOrg.ID).LogWithAttrs(audit.OrgCreatedEvent, audit.OrgTarget(newOrg.ID), map[string]string{
@@ -144,25 +133,21 @@ func (h Handler) CreateOrganization(ctx context.Context, request *frontierv1beta
 }
 
 func (h Handler) GetOrganization(ctx context.Context, request *frontierv1beta1.GetOrganizationRequest) (*frontierv1beta1.GetOrganizationResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	fetchedOrg, err := h.orgService.GetRaw(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrNotExist), errors.Is(err, organization.ErrInvalidID):
 			return nil, grpcOrgNotFoundErr
 		case errors.Is(err, organization.ErrInvalidUUID):
 			return nil, grpcBadBodyError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	orgPB, err := transformOrgToPB(fetchedOrg)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, status.Errorf(codes.Internal, ErrInternalServer.Error())
+		return nil, err
 	}
 
 	return &frontierv1beta1.GetOrganizationResponse{
@@ -171,8 +156,6 @@ func (h Handler) GetOrganization(ctx context.Context, request *frontierv1beta1.G
 }
 
 func (h Handler) UpdateOrganization(ctx context.Context, request *frontierv1beta1.UpdateOrganizationRequest) (*frontierv1beta1.UpdateOrganizationResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	if request.GetBody() == nil {
 		return nil, grpcBadBodyError
 	}
@@ -180,7 +163,6 @@ func (h Handler) UpdateOrganization(ctx context.Context, request *frontierv1beta
 	metaDataMap := metadata.Build(request.GetBody().GetMetadata().AsMap())
 
 	if err := h.metaSchemaService.Validate(metaDataMap, orgMetaSchema); err != nil {
-		logger.Error(err.Error())
 		return nil, grpcBadBodyMetaSchemaError
 	}
 
@@ -203,21 +185,19 @@ func (h Handler) UpdateOrganization(ctx context.Context, request *frontierv1beta
 		})
 	}
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrNotExist), errors.Is(err, organization.ErrInvalidID):
 			return nil, grpcOrgNotFoundErr
 		case errors.Is(err, organization.ErrConflict):
 			return nil, grpcConflictError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	orgPB, err := transformOrgToPB(updatedOrg)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, ErrInternalServer
+		return nil, err
 	}
 
 	audit.GetAuditor(ctx, updatedOrg.ID).Log(audit.OrgUpdatedEvent, audit.OrgTarget(updatedOrg.ID))
@@ -225,32 +205,28 @@ func (h Handler) UpdateOrganization(ctx context.Context, request *frontierv1beta
 }
 
 func (h Handler) ListOrganizationAdmins(ctx context.Context, request *frontierv1beta1.ListOrganizationAdminsRequest) (*frontierv1beta1.ListOrganizationAdminsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	admins, err := h.userService.ListByOrg(ctx, orgResp.ID, organization.AdminRole)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	var adminsPB []*frontierv1beta1.User
 	for _, user := range admins {
 		u, err := transformUserToPB(user)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, ErrInternalServer
+			return nil, err
 		}
 
 		adminsPB = append(adminsPB, u)
@@ -263,29 +239,26 @@ func (h Handler) ListOrganizationUsers(ctx context.Context, request *frontierv1b
 	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	users, err := h.userService.ListByOrg(ctx, orgResp.ID, request.GetPermissionFilter())
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	var usersPB []*frontierv1beta1.User
 	for _, rel := range users {
 		u, err := transformUserToPB(rel)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, ErrInternalServer
+			return nil, err
 		}
 
 		usersPB = append(usersPB, u)
@@ -296,8 +269,7 @@ func (h Handler) ListOrganizationUsers(ctx context.Context, request *frontierv1b
 		for _, user := range users {
 			roles, err := h.policyService.ListRoles(ctx, schema.UserPrincipal, user.ID, schema.OrganizationNamespace, request.GetId())
 			if err != nil {
-				logger.Error(err.Error())
-				return nil, grpcInternalServerError
+				return nil, err
 			}
 
 			rolesPb := utils.Filter(utils.Map(roles, func(role role.Role) *frontierv1beta1.Role {
@@ -324,32 +296,28 @@ func (h Handler) ListOrganizationUsers(ctx context.Context, request *frontierv1b
 }
 
 func (h Handler) ListOrganizationServiceUsers(ctx context.Context, request *frontierv1beta1.ListOrganizationServiceUsersRequest) (*frontierv1beta1.ListOrganizationServiceUsersResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	users, err := h.serviceUserService.ListByOrg(ctx, orgResp.ID)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	var usersPB []*frontierv1beta1.ServiceUser
 	for _, rel := range users {
 		u, err := transformServiceUserToPB(rel)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, ErrInternalServer
+			return nil, err
 		}
 
 		usersPB = append(usersPB, u)
@@ -358,17 +326,15 @@ func (h Handler) ListOrganizationServiceUsers(ctx context.Context, request *fron
 }
 
 func (h Handler) ListOrganizationProjects(ctx context.Context, request *frontierv1beta1.ListOrganizationProjectsRequest) (*frontierv1beta1.ListOrganizationProjectsResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
@@ -377,16 +343,14 @@ func (h Handler) ListOrganizationProjects(ctx context.Context, request *frontier
 		WithMemberCount: request.GetWithMemberCount(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	var projectPB []*frontierv1beta1.Project
 	for _, rel := range projects {
 		u, err := transformProjectToPB(rel)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, ErrInternalServer
+			return nil, err
 		}
 
 		projectPB = append(projectPB, u)
@@ -396,17 +360,15 @@ func (h Handler) ListOrganizationProjects(ctx context.Context, request *frontier
 }
 
 func (h Handler) AddOrganizationUsers(ctx context.Context, request *frontierv1beta1.AddOrganizationUsersRequest) (*frontierv1beta1.AddOrganizationUsersResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
@@ -415,57 +377,48 @@ func (h Handler) AddOrganizationUsers(ctx context.Context, request *frontierv1be
 	}
 
 	if err := h.orgService.AddUsers(ctx, orgResp.ID, request.GetUserIds()); err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	return &frontierv1beta1.AddOrganizationUsersResponse{}, nil
 }
 
 func (h Handler) RemoveOrganizationUser(ctx context.Context, request *frontierv1beta1.RemoveOrganizationUserRequest) (*frontierv1beta1.RemoveOrganizationUserResponse, error) {
-	logger := grpczap.Extract(ctx)
 	orgResp, err := h.orgService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
 			return nil, grpcOrgDisabledErr
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, grpcOrgNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	admins, err := h.userService.ListByOrg(ctx, orgResp.ID, organization.AdminRole)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	if len(admins) == 1 && admins[0].ID == request.GetUserId() {
 		return nil, grpcMinAdminCountErr
 	}
 
 	if err := h.deleterService.RemoveUsersFromOrg(ctx, orgResp.ID, []string{request.GetUserId()}); err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	return &frontierv1beta1.RemoveOrganizationUserResponse{}, nil
 }
 
 func (h Handler) EnableOrganization(ctx context.Context, request *frontierv1beta1.EnableOrganizationRequest) (*frontierv1beta1.EnableOrganizationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	if err := h.orgService.Enable(ctx, request.GetId()); err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	return &frontierv1beta1.EnableOrganizationResponse{}, nil
 }
 
 func (h Handler) DisableOrganization(ctx context.Context, request *frontierv1beta1.DisableOrganizationRequest) (*frontierv1beta1.DisableOrganizationResponse, error) {
-	logger := grpczap.Extract(ctx)
 	if err := h.orgService.Disable(ctx, request.GetId()); err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 	return &frontierv1beta1.DisableOrganizationResponse{}, nil
 }

--- a/internal/api/v1beta1/org_test.go
+++ b/internal/api/v1beta1/org_test.go
@@ -20,8 +20,6 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -54,10 +52,10 @@ func TestHandler_ListOrganization(t *testing.T) {
 		{
 			title: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), organization.Filter{}).Return([]organization.Organization{}, errors.New("some error"))
+				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), organization.Filter{}).Return([]organization.Organization{}, errors.New("test error"))
 			},
 			want: nil,
-			err:  status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return success if org service return nil",
@@ -147,7 +145,7 @@ func TestHandler_CreateOrganization(t *testing.T) {
 				os.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), organization.Organization{
 					Name:     "abc",
 					Metadata: metadata.Metadata{},
-				}).Return(organization.Organization{}, errors.New("some error"))
+				}).Return(organization.Organization{}, errors.New("test error"))
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			req: &frontierv1beta1.CreateOrganizationRequest{Body: &frontierv1beta1.OrganizationRequestBody{
@@ -155,7 +153,7 @@ func TestHandler_CreateOrganization(t *testing.T) {
 				Metadata: &structpb.Struct{},
 			}},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return bad request error if name is empty",
@@ -263,13 +261,13 @@ func TestHandler_GetOrganization(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().GetRaw(mock.AnythingOfType("context.backgroundCtx"), someOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().GetRaw(mock.AnythingOfType("context.backgroundCtx"), someOrgID).Return(organization.Organization{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetOrganizationRequest{
 				Id: someOrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if org id is not uuid (slug) and org not exist",
@@ -354,7 +352,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 						"valid": true,
 					},
 					Name: "new-org",
-				}).Return(organization.Organization{}, errors.New("some error"))
+				}).Return(organization.Organization{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.UpdateOrganizationRequest{
 				Id: someOrgID,
@@ -370,7 +368,7 @@ func TestHandler_UpdateOrganization(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if org id is not uuid (slug) and not exist",
@@ -596,13 +594,13 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
 				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(testOrgMap[testOrgID], nil)
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, organization.AdminRole).Return([]user.User{}, errors.New("some error"))
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID, organization.AdminRole).Return([]user.User{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: testOrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return error if org id is not exist",
@@ -677,13 +675,13 @@ func TestHandler_ListOrganizationUsers(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.UserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(organization.Organization{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListOrganizationUsersRequest{
 				Id: "some-org-id",
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return org not found error if org id is not exist",
@@ -759,14 +757,14 @@ func TestHandler_ListOrganizationServiceUsers(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(us *mocks.ServiceUserService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return([]serviceuser.ServiceUser{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("test error"))
+				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return([]serviceuser.ServiceUser{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.ListOrganizationServiceUsersRequest{
 				Id: testOrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return org not found error if org doesnt exist",
@@ -849,11 +847,11 @@ func TestHandler_ListAllOrganizations(t *testing.T) {
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
 				os.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"),
-					organization.Filter{}).Return([]organization.Organization{}, errors.New("some error"))
+					organization.Filter{}).Return([]organization.Organization{}, errors.New("test error"))
 			},
 			req:     &frontierv1beta1.ListAllOrganizationsRequest{},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return empty list of orgs if org service return nil error",
@@ -923,13 +921,13 @@ func TestHandler_EnableOrganization(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(errors.New("some error"))
+				os.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(errors.New("test error"))
 			},
 			req: &frontierv1beta1.EnableOrganizationRequest{
 				Id: testOrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should enable org successfully",
@@ -970,13 +968,13 @@ func TestHandler_DisableOrganization(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(errors.New("some error"))
+				os.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), "some-org-id").Return(errors.New("test error"))
 			},
 			req: &frontierv1beta1.DisableOrganizationRequest{
 				Id: "some-org-id",
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should disable org successfully",
@@ -1017,14 +1015,14 @@ func TestHandler_AddOrganizationUser(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.AddOrganizationUsersRequest{
 				Id:      testOrgID,
 				UserIds: []string{"some-user-id"},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should add user to org successfully",
@@ -1067,14 +1065,14 @@ func TestHandler_RemoveOrganizationUser(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.CascadeDeleter) {
-				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.RemoveOrganizationUserRequest{
 				Id:     testOrgID,
 				UserId: "some-user-id",
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return the error and not remove user if it is the last admin user",
@@ -1163,13 +1161,13 @@ func TestHandler_ListOrganizationProjects(t *testing.T) {
 		{
 			name: "should return internal error if org service return some error",
 			setup: func(ps *mocks.ProjectService, os *mocks.OrganizationService) {
-				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("some error"))
+				os.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return(organization.Organization{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.ListOrganizationProjectsRequest{
 				Id: testOrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return list of projects successfully",

--- a/internal/api/v1beta1/permission_check_test.go
+++ b/internal/api/v1beta1/permission_check_test.go
@@ -16,8 +16,6 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestHandler_CheckResourcePermission(t *testing.T) {
@@ -63,7 +61,7 @@ func TestHandler_CheckResourcePermission(t *testing.T) {
 						ID:        testRelationV2.Object.ID,
 						Namespace: testRelationV2.Object.Namespace,
 					}, Permission: schema.UpdatePermission,
-				}).Return(false, errors.New("some error"))
+				}).Return(false, errors.New("test error"))
 				perm.EXPECT().Get(mock.Anything, schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, schema.UpdatePermission)).
 					Return(testPermission, nil)
 			},
@@ -72,7 +70,7 @@ func TestHandler_CheckResourcePermission(t *testing.T) {
 				Resource:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return true when CheckAuthz function returns true bool",
@@ -180,14 +178,14 @@ func TestHandler_IsAuthorized(t *testing.T) {
 						ID:        "subjectID",
 						Namespace: "subjectNamespace",
 					}, Permission: "permis",
-				}).Return(true, errors.New("some error"))
+				}).Return(true, errors.New("test error"))
 			},
 			args: autA{
 				objectNamespace: "objectNamespace",
 				objectID:        "objectID",
 				permission:      "permis",
 			},
-			wantErr: status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return bad request error if object id is empty or namespace is empty",

--- a/internal/api/v1beta1/permission_test.go
+++ b/internal/api/v1beta1/permission_test.go
@@ -19,8 +19,6 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (
@@ -62,10 +60,10 @@ func TestListPermissions(t *testing.T) {
 		{
 			title: "should return internal error if action service return some error",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().List(mock.Anything, permission.Filter{}).Return([]permission.Permission{}, errors.New("some error"))
+				as.EXPECT().List(mock.Anything, permission.Filter{}).Return([]permission.Permission{}, errors.New("test error"))
 			},
 			want: nil,
-			err:  status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return success if permission service return nil error",
@@ -140,7 +138,7 @@ func TestCreatePermission(t *testing.T) {
 							Description: "",
 						},
 					},
-				}).Return(errors.New("some error"))
+				}).Return(errors.New("test error"))
 			},
 			req: &frontierv1beta1.CreatePermissionRequest{
 				Bodies: []*frontierv1beta1.PermissionRequestBody{
@@ -151,7 +149,7 @@ func TestCreatePermission(t *testing.T) {
 				},
 			},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return bad request error if namespace id is empty",
@@ -315,13 +313,13 @@ func TestHandler_GetPermission(t *testing.T) {
 		{
 			name: "should return internal error if permission service return some error",
 			setup: func(as *mocks.PermissionService) {
-				as.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPermissions[testPermissionIdx].ID).Return(permission.Permission{}, errors.New("some error"))
+				as.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPermissions[testPermissionIdx].ID).Return(permission.Permission{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetPermissionRequest{
 				Id: testPermissions[testPermissionIdx].ID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if permission id not exist",
@@ -394,7 +392,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 					ID:          testPermissions[testPermissionIdx].ID,
 					Name:        testPermissions[testPermissionIdx].Name,
 					NamespaceID: testPermissions[testPermissionIdx].NamespaceID,
-				}).Return(permission.Permission{}, errors.New("some error"))
+				}).Return(permission.Permission{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.UpdatePermissionRequest{
 				Id: testPermissions[testPermissionIdx].ID,
@@ -404,7 +402,7 @@ func TestHandler_UpdatePermission(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if permission id not exist",

--- a/internal/api/v1beta1/platform.go
+++ b/internal/api/v1beta1/platform.go
@@ -78,7 +78,7 @@ func (h Handler) ListPlatformUsers(ctx context.Context, req *frontierv1beta1.Lis
 			userPB, err := transformUserToPB(u)
 			if err != nil {
 				logger.Error(err.Error())
-				return nil, grpcInternalServerError
+				return nil, err
 			}
 			userPBs = append(userPBs, userPB)
 		}
@@ -101,7 +101,7 @@ func (h Handler) ListPlatformUsers(ctx context.Context, req *frontierv1beta1.Lis
 			serviceUserPB, err := transformServiceUserToPB(u)
 			if err != nil {
 				logger.Error(err.Error())
-				return nil, grpcInternalServerError
+				return nil, err
 			}
 			serviceUserPBs = append(serviceUserPBs, serviceUserPB)
 		}

--- a/internal/api/v1beta1/policy.go
+++ b/internal/api/v1beta1/policy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/raystack/frontier/pkg/utils"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -35,26 +34,22 @@ type PolicyService interface {
 var grpcPolicyNotFoundErr = status.Errorf(codes.NotFound, "policy doesn't exist")
 
 func (h Handler) ListPolicies(ctx context.Context, request *frontierv1beta1.ListPoliciesRequest) (*frontierv1beta1.ListPoliciesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	var policies []*frontierv1beta1.Policy
 
 	filter, err := h.resolveFilter(ctx, request)
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, grpcBadBodyError
 	}
 
 	policyList, err := h.policyService.List(ctx, filter)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	for _, p := range policyList {
 		policyPB, err := transformPolicyToPB(p)
 		if err != nil {
-			logger.Error(err.Error())
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 
 		policies = append(policies, policyPB)
@@ -64,8 +59,6 @@ func (h Handler) ListPolicies(ctx context.Context, request *frontierv1beta1.List
 }
 
 func (h Handler) CreatePolicy(ctx context.Context, request *frontierv1beta1.CreatePolicyRequest) (*frontierv1beta1.CreatePolicyResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	var metaDataMap metadata.Metadata
 	var err error
 	if request.GetBody().GetMetadata() != nil {
@@ -90,21 +83,19 @@ func (h Handler) CreatePolicy(ctx context.Context, request *frontierv1beta1.Crea
 		Metadata:      metaDataMap,
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, role.ErrInvalidID):
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		case errors.Is(err, policy.ErrInvalidDetail):
 			return nil, grpcBadBodyError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	policyPB, err := transformPolicyToPB(newPolicy)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	auditPolicyCreationEvent(ctx, newPolicy)
@@ -112,8 +103,6 @@ func (h Handler) CreatePolicy(ctx context.Context, request *frontierv1beta1.Crea
 }
 
 func (h Handler) CreatePolicyForProject(ctx context.Context, request *frontierv1beta1.CreatePolicyForProjectRequest) (*frontierv1beta1.CreatePolicyForProjectResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	if request.GetBody() == nil || request.GetBody().GetRoleId() == "" || request.GetBody().GetPrincipal() == "" {
 		return nil, grpcBadBodyError
 	}
@@ -138,14 +127,13 @@ func (h Handler) CreatePolicyForProject(ctx context.Context, request *frontierv1
 
 	newPolicy, err := h.policyService.Create(ctx, p)
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, role.ErrInvalidID):
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		case errors.Is(err, policy.ErrInvalidDetail):
 			return nil, grpcBadBodyError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
@@ -154,25 +142,21 @@ func (h Handler) CreatePolicyForProject(ctx context.Context, request *frontierv1
 }
 
 func (h Handler) GetPolicy(ctx context.Context, request *frontierv1beta1.GetPolicyRequest) (*frontierv1beta1.GetPolicyResponse, error) {
-	logger := grpczap.Extract(ctx)
-
 	fetchedPolicy, err := h.policyService.Get(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, policy.ErrNotExist),
 			errors.Is(err, policy.ErrInvalidUUID),
 			errors.Is(err, policy.ErrInvalidID):
 			return nil, grpcPolicyNotFoundErr
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 
 	policyPB, err := transformPolicyToPB(fetchedPolicy)
 	if err != nil {
-		logger.Error(err.Error())
-		return nil, grpcInternalServerError
+		return nil, err
 	}
 
 	return &frontierv1beta1.GetPolicyResponse{Policy: policyPB}, nil
@@ -184,10 +168,8 @@ func (h Handler) UpdatePolicy(ctx context.Context, request *frontierv1beta1.Upda
 }
 
 func (h Handler) DeletePolicy(ctx context.Context, request *frontierv1beta1.DeletePolicyRequest) (*frontierv1beta1.DeletePolicyResponse, error) {
-	logger := grpczap.Extract(ctx)
 	err := h.policyService.Delete(ctx, request.GetId())
 	if err != nil {
-		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, policy.ErrNotExist),
 			errors.Is(err, policy.ErrInvalidID),
@@ -199,7 +181,7 @@ func (h Handler) DeletePolicy(ctx context.Context, request *frontierv1beta1.Dele
 		case errors.Is(err, policy.ErrConflict):
 			return nil, grpcConflictError
 		default:
-			return nil, grpcInternalServerError
+			return nil, err
 		}
 	}
 

--- a/internal/api/v1beta1/policy_test.go
+++ b/internal/api/v1beta1/policy_test.go
@@ -14,8 +14,6 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (
@@ -44,10 +42,10 @@ func TestListPolicies(t *testing.T) {
 		{
 			title: "should return internal error if policy service return some error",
 			setup: func(ps *mocks.PolicyService) {
-				ps.EXPECT().List(mock.Anything, policy.Filter{}).Return([]policy.Policy{}, errors.New("some error"))
+				ps.EXPECT().List(mock.Anything, policy.Filter{}).Return([]policy.Policy{}, errors.New("test error"))
 			},
 			want: nil,
-			err:  status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return success if policy service return nil error",
@@ -101,7 +99,7 @@ func TestCreatePolicy(t *testing.T) {
 					ResourceType:  "ns",
 					PrincipalID:   "id",
 					PrincipalType: "ns",
-				}).Return(policy.Policy{}, errors.New("some error"))
+				}).Return(policy.Policy{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.CreatePolicyRequest{Body: &frontierv1beta1.PolicyRequestBody{
 				RoleId:    "Admin",
@@ -109,7 +107,7 @@ func TestCreatePolicy(t *testing.T) {
 				Principal: "ns:id",
 			}},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return bad request error if foreign reference not exist",
@@ -187,13 +185,13 @@ func TestHandler_GetPolicy(t *testing.T) {
 		{
 			name: "should return internal error if policy service return some error",
 			setup: func(rs *mocks.PolicyService) {
-				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPolicyID).Return(policy.Policy{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testPolicyID).Return(policy.Policy{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetPolicyRequest{
 				Id: testPolicyID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if id is empty",

--- a/internal/api/v1beta1/preferences.go
+++ b/internal/api/v1beta1/preferences.go
@@ -3,7 +3,6 @@ package v1beta1
 import (
 	"context"
 
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/raystack/frontier/core/preference"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 	"github.com/raystack/frontier/pkg/errors"
@@ -21,13 +20,11 @@ type PreferenceService interface {
 }
 
 func (h Handler) ListPreferences(ctx context.Context, in *frontierv1beta1.ListPreferencesRequest) (*frontierv1beta1.ListPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	prefs, err := h.preferenceService.List(ctx, preference.Filter{
 		ResourceID:   preference.PlatformID,
 		ResourceType: schema.PlatformNamespace,
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -41,7 +38,6 @@ func (h Handler) ListPreferences(ctx context.Context, in *frontierv1beta1.ListPr
 }
 
 func (h Handler) CreatePreferences(ctx context.Context, request *frontierv1beta1.CreatePreferencesRequest) (*frontierv1beta1.CreatePreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	var createdPreferences []preference.Preference
 	for _, prefBody := range request.GetPreferences() {
 		pref, err := h.preferenceService.Create(ctx, preference.Preference{
@@ -51,7 +47,6 @@ func (h Handler) CreatePreferences(ctx context.Context, request *frontierv1beta1
 			ResourceType: schema.PlatformNamespace,
 		})
 		if err != nil {
-			logger.Error(err.Error())
 			if errors.Is(err, preference.ErrTraitNotFound) {
 				return nil, status.Errorf(codes.InvalidArgument, err.Error())
 			}
@@ -82,7 +77,6 @@ func (h Handler) DescribePreferences(ctx context.Context, request *frontierv1bet
 }
 
 func (h Handler) CreateOrganizationPreferences(ctx context.Context, request *frontierv1beta1.CreateOrganizationPreferencesRequest) (*frontierv1beta1.CreateOrganizationPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	var createdPreferences []preference.Preference
 	for _, prefBody := range request.GetBodies() {
 		pref, err := h.preferenceService.Create(ctx, preference.Preference{
@@ -92,7 +86,6 @@ func (h Handler) CreateOrganizationPreferences(ctx context.Context, request *fro
 			ResourceType: schema.OrganizationNamespace,
 		})
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		createdPreferences = append(createdPreferences, pref)
@@ -108,12 +101,10 @@ func (h Handler) CreateOrganizationPreferences(ctx context.Context, request *fro
 }
 
 func (h Handler) ListOrganizationPreferences(ctx context.Context, request *frontierv1beta1.ListOrganizationPreferencesRequest) (*frontierv1beta1.ListOrganizationPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	prefs, err := h.preferenceService.List(ctx, preference.Filter{
 		OrgID: request.GetId(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -147,7 +138,6 @@ func (h Handler) ListGroupPreferences(ctx context.Context, request *frontierv1be
 }
 
 func (h Handler) CreateUserPreferences(ctx context.Context, request *frontierv1beta1.CreateUserPreferencesRequest) (*frontierv1beta1.CreateUserPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	var createdPreferences []preference.Preference
 	for _, prefBody := range request.GetBodies() {
 		pref, err := h.preferenceService.Create(ctx, preference.Preference{
@@ -157,7 +147,6 @@ func (h Handler) CreateUserPreferences(ctx context.Context, request *frontierv1b
 			ResourceType: schema.UserPrincipal,
 		})
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		createdPreferences = append(createdPreferences, pref)
@@ -173,12 +162,10 @@ func (h Handler) CreateUserPreferences(ctx context.Context, request *frontierv1b
 }
 
 func (h Handler) ListUserPreferences(ctx context.Context, request *frontierv1beta1.ListUserPreferencesRequest) (*frontierv1beta1.ListUserPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	prefs, err := h.preferenceService.List(ctx, preference.Filter{
 		UserID: request.GetId(),
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
@@ -192,7 +179,6 @@ func (h Handler) ListUserPreferences(ctx context.Context, request *frontierv1bet
 }
 
 func (h Handler) CreateCurrentUserPreferences(ctx context.Context, request *frontierv1beta1.CreateCurrentUserPreferencesRequest) (*frontierv1beta1.CreateCurrentUserPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	principal, err := h.GetLoggedInPrincipal(ctx)
 	if err != nil {
 		return nil, err
@@ -207,7 +193,6 @@ func (h Handler) CreateCurrentUserPreferences(ctx context.Context, request *fron
 			ResourceType: schema.UserPrincipal,
 		})
 		if err != nil {
-			logger.Error(err.Error())
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
 		createdPreferences = append(createdPreferences, pref)
@@ -223,7 +208,6 @@ func (h Handler) CreateCurrentUserPreferences(ctx context.Context, request *fron
 }
 
 func (h Handler) ListCurrentUserPreferences(ctx context.Context, request *frontierv1beta1.ListCurrentUserPreferencesRequest) (*frontierv1beta1.ListCurrentUserPreferencesResponse, error) {
-	logger := grpczap.Extract(ctx)
 	principal, err := h.GetLoggedInPrincipal(ctx)
 	if err != nil {
 		return nil, err
@@ -232,7 +216,6 @@ func (h Handler) ListCurrentUserPreferences(ctx context.Context, request *fronti
 		UserID: principal.ID,
 	})
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 

--- a/internal/api/v1beta1/preferences_test.go
+++ b/internal/api/v1beta1/preferences_test.go
@@ -270,12 +270,6 @@ func Test_CreateUserPreferences(t *testing.T) {
 			name: "should return error if authenServ return some error",
 			setup: func(m *mocks.PreferenceService, a *mocks.AuthnService) {
 				a.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{}, errors.New("some_error_auth"))
-				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
-					Name:         "some_name",
-					Value:        "some_value",
-					ResourceID:   "",
-					ResourceType: schema.UserPrincipal,
-				}).Return(preference.Preference{}, grpcInternalServerError)
 			},
 			req: &frontierv1beta1.CreateCurrentUserPreferencesRequest{
 				Bodies: []*frontierv1beta1.PreferenceRequestBody{
@@ -286,7 +280,7 @@ func Test_CreateUserPreferences(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("some_error_auth"),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/api/v1beta1/project_test.go
+++ b/internal/api/v1beta1/project_test.go
@@ -93,7 +93,7 @@ func TestCreateProject(t *testing.T) {
 					Metadata: metadata.Metadata{
 						"team": "Platforms",
 					},
-				}).Return(project.Project{}, errors.New("some error"))
+				}).Return(project.Project{}, errors.New("test error"))
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			req: &frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
@@ -104,7 +104,7 @@ func TestCreateProject(t *testing.T) {
 					},
 				},
 			}},
-			err: grpcInternalServerError,
+			err: errors.New("test error"),
 		},
 		{
 			title: "should return bad request error if org id is not uuid",
@@ -257,10 +257,10 @@ func TestListProjects(t *testing.T) {
 			title: "should return internal error if project service return some error",
 			req:   &frontierv1beta1.ListProjectsRequest{},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), project.Filter{}).Return([]project.Project{}, errors.New("some error"))
+				ps.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), project.Filter{}).Return([]project.Project{}, errors.New("test error"))
 			},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return success if project return nil error",
@@ -334,9 +334,9 @@ func TestGetProject(t *testing.T) {
 				Id: someProjectID,
 			},
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(project.Project{}, errors.New("some error"))
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(project.Project{}, errors.New("test error"))
 			},
-			err: grpcInternalServerError,
+			err: errors.New("test error"),
 		},
 		{
 			title: "should return not found error if project doesnt exist",
@@ -416,7 +416,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, errors.New("some error"))
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.UpdateProjectRequest{
 				Id: testProjectID,
@@ -431,7 +431,7 @@ func TestHandler_UpdateProject(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return bad request error if org id is not uuid",
@@ -643,13 +643,13 @@ func TestHandler_ListProjectAdmins(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, schema.DeletePermission).Return([]user.User{}, errors.New("some error"))
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, schema.DeletePermission).Return([]user.User{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListProjectAdminsRequest{
 				Id: testProjectID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if org id is not exist",
@@ -721,13 +721,13 @@ func TestHandler_EnableProject(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("some error"))
+				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("test error"))
 			},
 			req: &frontierv1beta1.EnableProjectRequest{
 				Id: testProjectID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if project id is not exist",
@@ -778,13 +778,13 @@ func TestHandler_DisableProject(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("some error"))
+				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("test error"))
 			},
 			req: &frontierv1beta1.DisableProjectRequest{
 				Id: testProjectID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if project id is not exist",
@@ -835,13 +835,13 @@ func TestHandler_ListProjectUsers(t *testing.T) {
 		{
 			name: "should return internal error if project service return some error",
 			setup: func(ps *mocks.ProjectService) {
-				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.MemberPermission).Return(nil, errors.New("some error"))
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.MemberPermission).Return(nil, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListProjectUsersRequest{
 				Id: testProjectID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if project id is not exist",

--- a/internal/api/v1beta1/relation_test.go
+++ b/internal/api/v1beta1/relation_test.go
@@ -56,10 +56,10 @@ func TestHandler_ListRelations(t *testing.T) {
 		{
 			name: "should return internal error if relation service return some error",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), relation.Filter{}).Return([]relation.Relation{}, errors.New("some error"))
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), relation.Filter{}).Return([]relation.Relation{}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return relations if relation service return nil error",
@@ -157,7 +157,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 						ID:        testRelationV2.Object.ID,
 						Namespace: testRelationV2.Object.Namespace,
 					},
-				}).Return(relation.Relation{}, errors.New("some error"))
+				}).Return(relation.Relation{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.CreateRelationRequest{
 				Body: &frontierv1beta1.RelationRequestBody{
@@ -167,7 +167,7 @@ func TestHandler_CreateRelation(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return bad request error if field value not exist in foreign reference",
@@ -266,13 +266,13 @@ func TestHandler_GetRelation(t *testing.T) {
 		{
 			name: "should return internal error if relation service return some error",
 			setup: func(rs *mocks.RelationService) {
-				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(relation.Relation{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(relation.Relation{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetRelationRequest{
 				Id: testRelationV2.ID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if id is empty",
@@ -394,7 +394,7 @@ func TestHandler_DeleteRelation(t *testing.T) {
 						ID:        testRelationV2.Object.ID,
 						Namespace: testRelationV2.Object.Namespace,
 					},
-				}).Return(errors.New("some-error"))
+				}).Return(errors.New("test error"))
 			},
 			request: &frontierv1beta1.DeleteRelationRequest{
 				Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
@@ -402,7 +402,7 @@ func TestHandler_DeleteRelation(t *testing.T) {
 				Relation: testRelationV2.Subject.SubRelationName,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should successfully delete when relation exist and user has permission to edit it",

--- a/internal/api/v1beta1/resource_test.go
+++ b/internal/api/v1beta1/resource_test.go
@@ -55,11 +55,11 @@ func TestHandler_ListResources(t *testing.T) {
 		{
 			name: "should return internal error if resource service return some error",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), resource.Filter{}).Return([]resource.Resource{}, errors.New("some error"))
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), resource.Filter{}).Return([]resource.Resource{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListResourcesRequest{},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return resources if resource service return nil error",
@@ -121,7 +121,7 @@ func TestHandler_CreateProjectResource(t *testing.T) {
 					NamespaceID:   testResource.NamespaceID,
 					PrincipalID:   testUserID,
 					PrincipalType: testResource.PrincipalType,
-				}).Return(resource.Resource{}, errors.New("some error"))
+				}).Return(resource.Resource{}, errors.New("test error"))
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			request: &frontierv1beta1.CreateProjectResourceRequest{
@@ -132,7 +132,7 @@ func TestHandler_CreateProjectResource(t *testing.T) {
 					Principal: testUserID,
 				}},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return bad request error if field value not exist in foreign reference",
@@ -230,13 +230,13 @@ func TestHandler_GetProjectResource(t *testing.T) {
 		{
 			name: "should return internal error if resource service return some error",
 			setup: func(rs *mocks.ResourceService) {
-				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ID).Return(resource.Resource{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testResource.ID).Return(resource.Resource{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetProjectResourceRequest{
 				Id: testResource.ID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if id is empty",
@@ -328,7 +328,7 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 					PrincipalID:   testResource.PrincipalID,
 					PrincipalType: testResource.PrincipalType,
 					NamespaceID:   testResource.NamespaceID,
-				}).Return(resource.Resource{}, errors.New("some error"))
+				}).Return(resource.Resource{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.UpdateProjectResourceRequest{
 				Id:        testResourceID,
@@ -340,7 +340,7 @@ func TestHandler_UpdateProjectResource(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if id is empty",
@@ -539,13 +539,13 @@ func TestHandler_ListProjectResources(t *testing.T) {
 			name: "should return internal error if resource service return error",
 			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
 				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"),
-					resource.Filter{ProjectID: testProjectID}).Return(nil, errors.New("error"))
+					resource.Filter{ProjectID: testProjectID}).Return(nil, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListProjectResourcesRequest{
 				ProjectId: testProjectID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return success if resource service return nil",

--- a/internal/api/v1beta1/role_test.go
+++ b/internal/api/v1beta1/role_test.go
@@ -97,10 +97,10 @@ func TestHandler_ListOrganizationRoles(t *testing.T) {
 		{
 			name: "should return internal error if role service return some error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), role.Filter{}).Return([]role.Role{}, errors.New("some error"))
+				rs.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), role.Filter{}).Return([]role.Role{}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return success if role service return nil error",
@@ -168,7 +168,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 		{
 			name: "should return bad body error if metaschema validation fails",
 			setup: func(rs *mocks.RoleService, ms *mocks.MetaSchemaService) {
-				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(errors.New("some error"))
+				ms.EXPECT().Validate(mock.AnythingOfType("metadata.Metadata"), roleMetaSchema).Return(errors.New("test error"))
 			},
 			request: &frontierv1beta1.CreateOrganizationRoleRequest{
 				OrgId: testRoleMap[testRoleID].OrgID,
@@ -192,7 +192,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
 					Metadata:    testRoleMap[testRoleID].Metadata,
-				}).Return(role.Role{}, errors.New("some error"))
+				}).Return(role.Role{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.CreateOrganizationRoleRequest{
 				OrgId: testRoleMap[testRoleID].OrgID,
@@ -207,7 +207,7 @@ func TestHandler_CreateOrganizationRole(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return bad request error if namespace id not exist",
@@ -355,13 +355,13 @@ func TestHandler_GetOrganizationRole(t *testing.T) {
 		{
 			name: "should return internal error if role service return some error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRoleID).Return(role.Role{}, errors.New("some error"))
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRoleID).Return(role.Role{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.GetOrganizationRoleRequest{
 				Id: testRoleID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if id not exist",
@@ -462,7 +462,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 					Permissions: testRoleMap[testRoleID].Permissions,
 					OrgID:       testRoleMap[testRoleID].OrgID,
 					Metadata:    testRoleMap[testRoleID].Metadata,
-				}).Return(role.Role{}, errors.New("some error"))
+				}).Return(role.Role{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.UpdateOrganizationRoleRequest{
 				Id:    testRoleMap[testRoleID].ID,
@@ -478,7 +478,7 @@ func TestHandler_UpdateOrganizationRole(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error if id not exist",
@@ -698,14 +698,14 @@ func TestHandler_DeleteOrganizationRole(t *testing.T) {
 		{
 			name: "should return internal error if role service gives unknown error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(errors.New("unknown error"))
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(errors.New("test error"))
 			},
 			request: &frontierv1beta1.DeleteOrganizationRoleRequest{
 				Id:    testRoleMap[testRoleID].ID,
 				OrgId: testRoleMap[testRoleID].OrgID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return nil if role service return nil",
@@ -765,13 +765,13 @@ func TestHandler_DeleteRole(t *testing.T) {
 		{
 			name: "should return internal error if role service gives unknown error",
 			setup: func(rs *mocks.RoleService) {
-				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(errors.New("unknown error"))
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), testRoleMap[testRoleID].ID).Return(errors.New("test error"))
 			},
 			request: &frontierv1beta1.DeleteRoleRequest{
 				Id: testRoleMap[testRoleID].ID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return nil if role service return nil",

--- a/internal/api/v1beta1/serviceuser_test.go
+++ b/internal/api/v1beta1/serviceuser_test.go
@@ -84,10 +84,10 @@ func TestHandler_ListServiveUsers(t *testing.T) {
 				su.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Filter{
 					OrgID: "",
 					State: "",
-				}).Return(nil, errors.New("error"))
+				}).Return(nil, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "Test List Service Users",
@@ -138,10 +138,10 @@ func TestHandler_GetServiceUser(t *testing.T) {
 				Id: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.ServiceUser{}, errors.New("error"))
+				su.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.ServiceUser{}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error when service user is not found",
@@ -207,10 +207,10 @@ func TestHandler_CreateServiceUser(t *testing.T) {
 					Title:    su1.Title,
 					Metadata: su1.Metadata,
 					OrgID:    su1.OrgID,
-				}).Return(serviceuser.ServiceUser{}, errors.New("error"))
+				}).Return(serviceuser.ServiceUser{}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return service user",
@@ -265,10 +265,10 @@ func TestHandler_DeleteServiceUser(t *testing.T) {
 				Id: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("error"))
+				su.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error when service user is not found",
@@ -328,10 +328,10 @@ func TestHandler_CreateServiceUserJWK(t *testing.T) {
 				su.EXPECT().CreateKey(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Credential{
 					Title:         "title",
 					ServiceUserID: "1",
-				}).Return(serviceuser.Credential{}, errors.New("error"))
+				}).Return(serviceuser.Credential{}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error when service user is not found",
@@ -413,10 +413,10 @@ func TestHandler_ListServiceUserJWKs(t *testing.T) {
 				Id: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().ListKeys(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil, errors.New("error"))
+				su.EXPECT().ListKeys(mock.AnythingOfType("context.backgroundCtx"), "1").Return(nil, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error when service user is not found",
@@ -483,10 +483,10 @@ func TestHandler_GetServiceUserJWK(t *testing.T) {
 				KeyId: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().GetKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.Credential{}, errors.New("error"))
+				su.EXPECT().GetKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(serviceuser.Credential{}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error when service user is not found",
@@ -555,10 +555,10 @@ func TestHandler_DeleteServiceUserJWK(t *testing.T) {
 				KeyId: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("error"))
+				su.EXPECT().DeleteKey(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return not found error when service user is not found",
@@ -617,10 +617,10 @@ func TestHandler_DeleteServiceUserCredential(t *testing.T) {
 				SecretId: "1",
 			},
 			setup: func(su *mocks.ServiceUserService) {
-				su.EXPECT().DeleteSecret(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("error"))
+				su.EXPECT().DeleteSecret(mock.AnythingOfType("context.backgroundCtx"), "1").Return(errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return service user secret",
@@ -675,10 +675,10 @@ func TestHandler_CreateServiceUserCredential(t *testing.T) {
 					ID:        "1",
 					Value:     "value",
 					CreatedAt: time.Now(),
-				}, errors.New("error"))
+				}, errors.New("test error"))
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return service user secret",

--- a/internal/api/v1beta1/user_test.go
+++ b/internal/api/v1beta1/user_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -66,7 +64,7 @@ func TestListUsers(t *testing.T) {
 		{
 			title: "should return internal error in if user service return some error",
 			setup: func(us *mocks.UserService) {
-				us.EXPECT().List(mock.Anything, mock.Anything).Return([]user.User{}, errors.New("some error"))
+				us.EXPECT().List(mock.Anything, mock.Anything).Return([]user.User{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.ListUsersRequest{
 				PageSize: 50,
@@ -74,7 +72,7 @@ func TestListUsers(t *testing.T) {
 				Keyword:  "",
 			},
 			want: nil,
-			err:  status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			err:  errors.New("test error"),
 		}, {
 			title: "should return all users if user service return all users",
 			setup: func(us *mocks.UserService) {
@@ -403,11 +401,11 @@ func TestGetCurrentUser(t *testing.T) {
 		{
 			title: "should return error if user service return some error",
 			setup: func(ctx context.Context, us *mocks.AuthnService, ss *mocks.SessionService) context.Context {
-				us.EXPECT().GetPrincipal(mock.AnythingOfType("*context.valueCtx")).Return(authenticate.Principal{}, errors.New("some error"))
+				us.EXPECT().GetPrincipal(mock.AnythingOfType("*context.valueCtx")).Return(authenticate.Principal{}, errors.New("test error"))
 				return authenticate.SetContextWithEmail(ctx, email)
 			},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return user if user service return nil error",
@@ -489,7 +487,7 @@ func TestUpdateUser(t *testing.T) {
 					Metadata: metadata.Metadata{
 						"foo": "bar",
 					},
-				}).Return(user.User{}, errors.New("some error"))
+				}).Return(user.User{}, errors.New("test error"))
 			},
 			req: &frontierv1beta1.UpdateUserRequest{
 				Id: someID,
@@ -503,7 +501,7 @@ func TestUpdateUser(t *testing.T) {
 					},
 				}},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return not found error if id is invalid",
@@ -756,7 +754,7 @@ func TestUpdateCurrentUser(t *testing.T) {
 					Metadata: metadata.Metadata{
 						"foo": "bar",
 					},
-				}).Return(user.User{}, errors.New("some error"))
+				}).Return(user.User{}, errors.New("test error"))
 				as.EXPECT().GetPrincipal(mock.AnythingOfType("context.backgroundCtx")).Return(authenticate.Principal{ID: userID}, nil)
 				return ctx
 			},
@@ -770,7 +768,7 @@ func TestUpdateCurrentUser(t *testing.T) {
 				},
 			}},
 			want: nil,
-			err:  grpcInternalServerError,
+			err:  errors.New("test error"),
 		},
 		{
 			title: "should return bad request error if empty request body",
@@ -856,13 +854,13 @@ func TestHandler_ListUserGroups(t *testing.T) {
 			name: "should return internal error if group service return some error",
 			setup: func(gs *mocks.GroupService) {
 				gs.EXPECT().ListByUser(mock.AnythingOfType("context.backgroundCtx"), someUserID, schema.UserPrincipal,
-					group.Filter{}).Return([]group.Group{}, errors.New("some error"))
+					group.Filter{}).Return([]group.Group{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListUserGroupsRequest{
 				Id: someUserID,
 			},
 			want:    nil,
-			wantErr: grpcInternalServerError,
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return empty list if user does not exist",
@@ -935,14 +933,14 @@ func TestHandler_ListAllUsers(t *testing.T) {
 		{
 			name: "should return internal error in if user service return some error",
 			setup: func(us *mocks.UserService) {
-				us.EXPECT().List(mock.Anything, mock.Anything).Return([]user.User{}, errors.New("some error"))
+				us.EXPECT().List(mock.Anything, mock.Anything).Return([]user.User{}, errors.New("test error"))
 			},
 			request: &frontierv1beta1.ListAllUsersRequest{
 				PageSize: 50,
 				PageNum:  1,
 			},
 			want:    nil,
-			wantErr: status.Errorf(codes.Internal, ErrInternalServer.Error()),
+			wantErr: errors.New("test error"),
 		},
 		{
 			name: "should return all users if user service return success",

--- a/internal/metrics/stripe.go
+++ b/internal/metrics/stripe.go
@@ -19,7 +19,7 @@ var stripeAPILatencyFactory = func(name string) *prometheus.HistogramVec {
 	return promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    fmt.Sprintf("stripe_latency_%s", name),
 		Help:    "Time took to execute Stripe related API calls",
-		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90, 180},
+		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 90, 180, 300, 600},
 	}, []string{"operation", "method"})
 }
 
@@ -27,6 +27,6 @@ var billingSyncLatencyFactory = func() *prometheus.HistogramVec {
 	return promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "billing_sync_latency",
 		Help:    "Time took to sync billing data",
-		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90, 180},
+		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 90, 180, 300, 600},
 	}, []string{"service"})
 }

--- a/internal/store/postgres/billing_customer_repository.go
+++ b/internal/store/postgres/billing_customer_repository.go
@@ -182,7 +182,7 @@ func (r BillingCustomerRepository) GetByID(ctx context.Context, id string) (cust
 }
 
 func (r BillingCustomerRepository) List(ctx context.Context, flt customer.Filter) ([]customer.Customer, error) {
-	stmt := dialect.Select().From(TABLE_BILLING_CUSTOMERS)
+	stmt := dialect.Select().From(TABLE_BILLING_CUSTOMERS).Order(goqu.I("created_at").Desc())
 
 	if flt.OrgID != "" {
 		stmt = stmt.Where(goqu.Ex{

--- a/internal/store/postgres/billing_subscription_repository.go
+++ b/internal/store/postgres/billing_subscription_repository.go
@@ -347,7 +347,7 @@ func (r BillingSubscriptionRepository) toSubscriptionChanges(toUpdate subscripti
 }
 
 func (r BillingSubscriptionRepository) List(ctx context.Context, filter subscription.Filter) ([]subscription.Subscription, error) {
-	stmt := dialect.Select().From(TABLE_BILLING_SUBSCRIPTIONS)
+	stmt := dialect.Select().From(TABLE_BILLING_SUBSCRIPTIONS).Order(goqu.I("created_at").Desc())
 	if filter.CustomerID != "" {
 		stmt = stmt.Where(goqu.Ex{
 			"customer_id": filter.CustomerID,

--- a/pkg/server/interceptors/enrich.go
+++ b/pkg/server/interceptors/enrich.go
@@ -2,7 +2,6 @@ package interceptors
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"strings"
 
@@ -39,11 +38,6 @@ func UnaryAPIRequestEnrich() grpc.UnaryServerInterceptor {
 		ctx = UnaryCtxWithStripeTestClock(ctx, serverHandler, info.FullMethod)
 		resp, err = handler(ctx, req)
 		if err != nil {
-			// check if err was context canceled
-			if errors.Is(err, context.Canceled) {
-				// override grpc status with context canceled
-				return nil, status.Error(codes.Canceled, err.Error())
-			}
 			return nil, err
 		}
 

--- a/pkg/server/interceptors/errors.go
+++ b/pkg/server/interceptors/errors.go
@@ -1,0 +1,46 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrInternalServer       = errors.New("internal server error")
+	grpcInternalServerError = status.Errorf(codes.Internal, ErrInternalServer.Error())
+)
+
+// UnaryErrorHandler is a unary server interceptor that captures the request and response and overrides the error message
+func UnaryErrorHandler() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		resp, err = handler(ctx, req)
+		if err != nil {
+			return nil, errWrapper(ctx, err)
+		}
+		return resp, nil
+	}
+}
+
+func errWrapper(ctx context.Context, err error) error {
+	grpczap.Extract(ctx).Error(err.Error())
+
+	// check if grpc status error
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	// check if err was context canceled
+	if errors.Is(err, context.Canceled) {
+		// override grpc status with context canceled
+		return status.Error(codes.Canceled, err.Error())
+	}
+
+	// defaults to internal server error
+	return grpcInternalServerError
+}

--- a/pkg/server/interceptors/errors_test.go
+++ b/pkg/server/interceptors/errors_test.go
@@ -1,0 +1,41 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test_errWrapper(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{
+			name:    "status errors should pass through",
+			err:     status.Error(codes.InvalidArgument, "bad value"),
+			wantErr: status.Error(codes.InvalidArgument, "bad value"),
+		},
+		{
+			name:    "context.Canceled should be converted to Canceled",
+			err:     context.Canceled,
+			wantErr: status.Error(codes.Canceled, context.Canceled.Error()),
+		},
+		{
+			name:    "default to internal server error",
+			err:     errors.New("some error"),
+			wantErr: grpcInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errWrapper(context.Background(), tt.err)
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -288,6 +288,7 @@ func getGRPCMiddleware(logger log.Logger, identityProxyHeader string, nrApp newr
 			grpc_ctxtags.UnaryServerInterceptor(),
 			grpc_validator.UnaryServerInterceptor(),
 			sessionMiddleware.UnaryGRPCRequestHeadersAnnotator(),
+			interceptors.UnaryErrorHandler(),
 			interceptors.UnaryAuthenticationCheck(),
 			interceptors.UnaryAPIRequestEnrich(),
 			interceptors.UnaryAuthorizationCheck(),


### PR DESCRIPTION
- context cancellation will be treated as `status.Error(codes.Canceled, err.Error())`
- additionally added more histogram buckets for stripe syncs
- new vector `[.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 90, 180, 300, 600]`