### PR TITLE
fix (ID-561): add path to api-client dist in package.json

### DIFF
--- a/sdks/js/packages/core/package.json
+++ b/sdks/js/packages/core/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist/**/*",
     "react/dist/**/*",
+    "api-client/dist/**/*",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
[IDE-561](https://linear.app/pixxel/issue/IDE-561/[qa]-api-clientdist-not-getting-published-to-npm)

**Description:**
sdk package.json missing the  api-client/dist/**/* path due to which api-client/dist folder is not published to npm.

**Solution:**
Add an entry in package.json.