### PR TITLE
fix: sync invoice attributes after it's created

### DIFF
--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -137,6 +137,14 @@ func (s *Service) SyncWithProvider(ctx context.Context, customr customer.Custome
 				existingInvoice.State = string(stripeInvoice.Status)
 				updateNeeded = true
 			}
+			if stripeInvoice.EffectiveAt != 0 && existingInvoice.EffectiveAt != utils.AsTimeFromEpoch(stripeInvoice.EffectiveAt) {
+				existingInvoice.EffectiveAt = utils.AsTimeFromEpoch(stripeInvoice.EffectiveAt)
+				updateNeeded = true
+			}
+			if stripeInvoice.HostedInvoiceURL != "" && existingInvoice.HostedURL != stripeInvoice.HostedInvoiceURL {
+				existingInvoice.HostedURL = stripeInvoice.HostedInvoiceURL
+				updateNeeded = true
+			}
 
 			if updateNeeded {
 				if _, err := s.repository.UpdateByID(ctx, existingInvoice); err != nil {

--- a/internal/store/postgres/billing_invoice_repository.go
+++ b/internal/store/postgres/billing_invoice_repository.go
@@ -208,6 +208,12 @@ func (r BillingInvoiceRepository) UpdateByID(ctx context.Context, toUpdate invoi
 	if toUpdate.State != "" {
 		updateRecord["state"] = toUpdate.State
 	}
+	if !toUpdate.EffectiveAt.IsZero() {
+		updateRecord["effective_at"] = toUpdate.EffectiveAt
+	}
+	if toUpdate.HostedURL != "" {
+		updateRecord["hosted_url"] = toUpdate.HostedURL
+	}
 
 	query, params, err := dialect.Update(TABLE_BILLING_INVOICES).Set(updateRecord).Where(goqu.Ex{
 		"id": toUpdate.ID,


### PR DESCRIPTION
Few attributes in Stripe invoice are not populated instantly at the time of creation causing missing values persisted in db. These can be synced back later using periodic syncer.