### PR TITLE
fix: check if already deducted a transaction to avoid 5XX response.

### DIFF
--- a/billing/credit/service.go
+++ b/billing/credit/service.go
@@ -80,6 +80,16 @@ func (s Service) Deduct(ctx context.Context, cred Credit) error {
 		return errors.New("credit amount is negative")
 	}
 
+	//check if already deducted
+	t, err := s.transactionRepository.GetByID(ctx, cred.ID)
+
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	if err == nil && t.ID != "" {
+		return ErrAlreadyApplied
+	}
+
 	// check balance, if enough, sub credits
 	currentBalance, err := s.GetBalance(ctx, cred.CustomerID)
 	if err != nil {

--- a/internal/api/v1beta1/billing_usage.go
+++ b/internal/api/v1beta1/billing_usage.go
@@ -51,6 +51,9 @@ func (h Handler) CreateBillingUsage(ctx context.Context, request *frontierv1beta
 		if errors.Is(err, credit.ErrInsufficientCredits) {
 			return nil, ErrInvalidInput(err.Error())
 		}
+		if errors.Is(err, credit.ErrAlreadyApplied) {
+			return nil, status.Error(codes.AlreadyExists, err.Error())
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 


### PR DESCRIPTION
### Description 
When `CreateBillingUsage` API is called multiple times with same ID, it doesn't check if already debuted and tries to create transaction entry. This results in DB error `ERROR: duplicate key value violates unique constraint`,  HTTP status code  `500 `.
Applied a check to see if the ID is present. If no, it's BAU. If yes, it returns an error mentioning `credits already applied` with HTTP status code `409`.

### API Testing
1. Unique ID

Payload:

```
 "usages": [
    {
      "id": "cbaef2b4-eb91-44c0-bdc4-eed02666ea70",
      "customer_id": "",
      "source": "",
      "description": "",
      "type": "credit",
      "amount": "2",
      "user_id": "",
      "metadata": {},
      "created_at": "",
      "updated_at": ""
    }
```

Response status:  `200 OK`

2. Duplicate ID


Payload:

```
 "usages": [
    {
      "id": "cbaef2b4-eb91-44c0-bdc4-eed02666ea70",
      "customer_id": "",
      "source": "",
      "description": "",
      "type": "credit",
      "amount": "2",
      "user_id": "",
      "metadata": {},
      "created_at": "",
      "updated_at": ""
    }
```

Response:
status - `409 Conflict`
body -
```
{
    "code": 6,
    "message": "failed to deduct usage: credits already applied",
    "details": []
}

```
