### PR TITLE
fix: add filter for providerID on subscription repo, and remove unnecessary invoice event in syncer

### DIFF
--- a/core/event/service.go
+++ b/core/event/service.go
@@ -235,7 +235,7 @@ func (p *Service) BillingWebhook(ctx context.Context, payload ProviderWebhookEve
 			if err != nil {
 				stdLogger.Error("error syncing customer", zap.Error(err), zap.String("provider_id", providerID))
 			}
-		case "invoice.payment_succeeded", "customer.subscription.created",
+		case "customer.subscription.created",
 			"customer.subscription.updated", "customer.subscription.deleted":
 			// trigger subscriptions sync
 			deDupKey := fmt.Sprintf("subscription-%s-%d", providerID, currentExecutionUnit)

--- a/internal/store/postgres/billing_subscription_repository.go
+++ b/internal/store/postgres/billing_subscription_repository.go
@@ -353,6 +353,11 @@ func (r BillingSubscriptionRepository) List(ctx context.Context, filter subscrip
 			"customer_id": filter.CustomerID,
 		})
 	}
+	if filter.ProviderID != "" {
+		stmt = stmt.Where(goqu.Ex{
+			"provider_id": filter.ProviderID,
+		})
+	}
 	if filter.PlanID != "" {
 		stmt = stmt.Where(goqu.Ex{
 			"plan_id": filter.PlanID,


### PR DESCRIPTION
This PR solves a couple of issues:

1. We used to sync only the first subscription in our repository because the subscription repository did not use the providerID passed to it as input. This PR fixes that.
2. The event for "invoice created" cannot use the same provider id that is passed since the provider id there refers to invoice id, whereas the code written assumes that the id passed is a customer id. Due to issue (1), the "invoice created" event was anyway not getting triggered