### PR TITLE
fix: remove unreachable product fetch block

### DIFF
--- a/billing/entitlement/service.go
+++ b/billing/entitlement/service.go
@@ -2,7 +2,6 @@ package entitlement
 
 import (
 	"context"
-	"errors"
 
 	"github.com/raystack/frontier/billing/plan"
 
@@ -48,8 +47,8 @@ func NewEntitlementService(subscriptionService SubscriptionService,
 	}
 }
 
-// Check checks if the customer has access to the feature or product
-func (s *Service) Check(ctx context.Context, customerID, featureOrProductID string) (bool, error) {
+// Check checks if the customer has access to the feature
+func (s *Service) Check(ctx context.Context, customerID, featureID string) (bool, error) {
 	// get all subscriptions for the customer
 	subs, err := s.subscriptionService.List(ctx, subscription.Filter{
 		CustomerID: customerID,
@@ -59,7 +58,7 @@ func (s *Service) Check(ctx context.Context, customerID, featureOrProductID stri
 	}
 
 	// get the feature
-	feature, err := s.productService.GetFeatureByID(ctx, featureOrProductID)
+	feature, err := s.productService.GetFeatureByID(ctx, featureID)
 	if err != nil {
 		return false, err
 	}
@@ -70,15 +69,6 @@ func (s *Service) Check(ctx context.Context, customerID, featureOrProductID stri
 	})
 	if err != nil {
 		return false, err
-	}
-
-	// could be product ID as well
-	asProduct, err := s.productService.GetByID(ctx, featureOrProductID)
-	if err != nil && !errors.Is(err, product.ErrProductNotFound) {
-		return false, err
-	}
-	if asProduct.ID != "" {
-		products = append(products, asProduct)
 	}
 
 	// check if the product is in any of the subscriptions


### PR DESCRIPTION
Per documentation, the entitlement check should work with both, product id as well as feature id.
However, this is what the actual behaviour is:

1. We try to fetch the feature by feature id
2. In case there is no feature, we return an error 
3. Thus, even if someone tries to check entitlement with product id, they would never be able to do so since we would never reach the product block once feature check fails.

This PR updates the method to work with only feature IDs, as that is what the existing behaviour is.