### PR TITLE
fix: add prices to plan list response

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -421,10 +421,11 @@ func buildAPIDependencies(
 		postgres.NewBillingCustomerRepository(dbc), cfg.Billing)
 
 	featureRepository := postgres.NewBillingFeatureRepository(dbc)
+	priceRepository := postgres.NewBillingPriceRepository(dbc)
 	productService := product.NewService(
 		stripeClient,
 		postgres.NewBillingProductRepository(dbc),
-		postgres.NewBillingPriceRepository(dbc),
+		priceRepository,
 		featureRepository,
 	)
 	planService := plan.NewService(
@@ -432,6 +433,7 @@ func buildAPIDependencies(
 		postgres.NewBillingPlanRepository(dbc),
 		productService,
 		featureRepository,
+		priceRepository,
 	)
 	creditService := credit.NewService(postgres.NewBillingTransactionRepository(dbc))
 	subscriptionService := subscription.NewService(

--- a/internal/store/postgres/billing_plan_repository.go
+++ b/internal/store/postgres/billing_plan_repository.go
@@ -384,6 +384,7 @@ func (r BillingPlanRepository) ListWithProducts(ctx context.Context, filter plan
 		prd.Col("created_at").As("product_created_at"),
 		prd.Col("updated_at").As("product_updated_at"),
 		prd.Col("deleted_at").As("product_deleted_at"),
+		prd.Col("plan_ids").As("product_plan_ids"),
 	)
 
 	var ids []string


### PR DESCRIPTION
- Add prices to plan list API response
- Add plans array to product (for backward compatibility, since the earlier API contract used to return it)