### PR TITLE
test: spicedb tracer to debug check calls

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -331,7 +331,7 @@ func buildAPIDependencies(
 	namespaceService := namespace.NewService(namespaceRepository)
 
 	authzSchemaRepository := spicedb.NewSchemaRepository(logger, sdb)
-	authzRelationRepository := spicedb.NewRelationRepository(sdb, cfg.SpiceDB.FullyConsistent)
+	authzRelationRepository := spicedb.NewRelationRepository(sdb, cfg.SpiceDB.FullyConsistent, cfg.SpiceDB.CheckTrace)
 
 	permissionRepository := postgres.NewPermissionRepository(dbc)
 	permissionService := permission.NewService(permissionRepository)

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -163,6 +163,9 @@ spicedb:
   # fully_consistent ensures APIs although slower than usual will result in responses always most consistent
   # suggested to keep it false for performance
   fully_consistent: false
+  # check_trace enables tracing in check api for spicedb, it adds considerable
+  # latency to the check calls and shouldn't be enabled in production
+  check_trace: false
 
 billing:
   # stripe key to be used for billing

--- a/docs/docs/reference/configurations.md
+++ b/docs/docs/reference/configurations.md
@@ -158,6 +158,9 @@ spicedb:
   # fully_consistent ensures APIs although slower than usual will result in responses always most consistent
   # suggested to keep it false for performance
   fully_consistent: false
+  # check_trace enables tracing in check api for spicedb, it adds considerable
+  # latency to the check calls and shouldn't be enabled in production
+  check_trace: false
 
 billing:
   # stripe key to be used for billing

--- a/internal/store/spicedb/config.go
+++ b/internal/store/spicedb/config.go
@@ -7,4 +7,8 @@ type Config struct {
 
 	// FullyConsistent ensures APIs although slower than usual will result in responses always most consistent
 	FullyConsistent bool `yaml:"fully_consistent" mapstructure:"fully_consistent" default:"false"`
+
+	// CheckTrace enables tracing in check api for spicedb, it adds considerable
+	// latency to the check calls and shouldn't be enabled in production
+	CheckTrace bool `yaml:"check_trace" mapstructure:"check_trace" default:"false"`
 }


### PR DESCRIPTION
Config has additional flag to debug permission checks which can be enabled via `spicedb.check_trace:true`