### PR TITLE
fix: check for resource.ErrNotExist error in check permission

### DIFF
--- a/internal/api/v1beta1/permission_check.go
+++ b/internal/api/v1beta1/permission_check.go
@@ -269,9 +269,9 @@ func handleAuthErr(ctx context.Context, err error) error {
 	switch {
 	case errors.Is(err, user.ErrInvalidEmail) || errors.Is(err, errors.ErrUnauthenticated):
 		return grpcUnauthenticated
-	case errors.Is(err, organization.ErrNotExist):
-		return status.Errorf(codes.NotFound, err.Error())
-	case errors.Is(err, project.ErrNotExist):
+	case errors.Is(err, organization.ErrNotExist),
+		errors.Is(err, project.ErrNotExist),
+		errors.Is(err, resource.ErrNotExist):
 		return status.Errorf(codes.NotFound, err.Error())
 	default:
 		return err


### PR DESCRIPTION
Problem.
If a random ID is passed in the `CheckFederatedResourcePermission` API `resource` body. The API throws an `Internal` error. And in the server logs, the error is `resource doesn't exist`. 
After debugging, I found that we [fetch the resource from the db](https://github.com/raystack/frontier/blob/main/core/resource/service.go#L222), and it returns `ErrNotExist` error.
This error was not handled in the API handler function.

This PR adds a check for the `resource.ErrNotExist` error. It also refactors the switch statement. 

