### PR TITLE
feat: role filter while listing organization users

### DIFF
--- a/core/policy/filter.go
+++ b/core/policy/filter.go
@@ -5,6 +5,7 @@ type Filter struct {
 	ProjectID string
 	GroupID   string
 	RoleID    string
+	RoleIDs   []string
 
 	PrincipalType string
 	PrincipalID   string

--- a/internal/store/postgres/policy_repository.go
+++ b/internal/store/postgres/policy_repository.go
@@ -118,6 +118,11 @@ func applyListFilter(stmt *goqu.SelectDataset, flt policy.Filter) *goqu.SelectDa
 			"role_id": flt.RoleID,
 		})
 	}
+	if len(flt.RoleIDs) > 0 {
+		stmt = stmt.Where(goqu.Ex{
+			"role_id": flt.RoleIDs,
+		})
+	}
 	return stmt
 }
 


### PR DESCRIPTION
- https://github.com/raystack/proton/pull/371
- a list of role name/ids are accepted as inputs, it can't be used when `with_roles` is toggled on.