### PR TITLE
fix: while updating role, do full refresh of permissions

### DIFF
--- a/internal/api/v1beta1/billing_checkout.go
+++ b/internal/api/v1beta1/billing_checkout.go
@@ -128,7 +128,7 @@ func (h Handler) CreateCheckout(ctx context.Context, request *frontierv1beta1.Cr
 	})
 	if err != nil {
 		if errors.Is(err, product.ErrPerSeatLimitReached) {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		return nil, err
 	}

--- a/internal/api/v1beta1/billing_customer.go
+++ b/internal/api/v1beta1/billing_customer.go
@@ -74,7 +74,7 @@ func (h Handler) CreateBillingAccount(ctx context.Context, request *frontierv1be
 	}, request.GetOffline())
 	if err != nil {
 		if errors.Is(err, customer.ErrActiveConflict) {
-			return nil, status.Errorf(codes.FailedPrecondition, err.Error())
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
 		}
 		return nil, err
 	}

--- a/internal/api/v1beta1/deleter.go
+++ b/internal/api/v1beta1/deleter.go
@@ -17,14 +17,14 @@ type CascadeDeleter interface {
 
 func (h Handler) DeleteProject(ctx context.Context, request *frontierv1beta1.DeleteProjectRequest) (*frontierv1beta1.DeleteProjectResponse, error) {
 	if err := h.deleterService.DeleteProject(ctx, request.GetId()); err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 	return &frontierv1beta1.DeleteProjectResponse{}, nil
 }
 
 func (h Handler) DeleteOrganization(ctx context.Context, request *frontierv1beta1.DeleteOrganizationRequest) (*frontierv1beta1.DeleteOrganizationResponse, error) {
 	if err := h.deleterService.DeleteOrganization(ctx, request.GetId()); err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 	return &frontierv1beta1.DeleteOrganizationResponse{}, nil
 }

--- a/internal/store/postgres/relation_repository.go
+++ b/internal/store/postgres/relation_repository.go
@@ -32,6 +32,8 @@ func (r RelationRepository) Upsert(ctx context.Context, relationToCreate relatio
 			"object_namespace_name":    relationToCreate.Object.Namespace,
 			"object_id":                relationToCreate.Object.ID,
 			"relation_name":            relationToCreate.RelationName,
+			"created_at":               goqu.L("now()"),
+			"updated_at":               goqu.L("now()"),
 		}).OnConflict(
 		goqu.DoUpdate("subject_namespace_name, subject_id, object_namespace_name, object_id, relation_name", goqu.Record{
 			"subject_namespace_name": relationToCreate.Subject.Namespace,

--- a/internal/store/postgres/relation_repository_test.go
+++ b/internal/store/postgres/relation_repository_test.go
@@ -209,7 +209,7 @@ func (s *RelationRepositoryTestSuite) TestUpsert() {
 				"ID",
 				"CreatedAt",
 				"UpdatedAt")) {
-				s.T().Fatalf(cmp.Diff(got, tc.ExpectedRelation))
+				s.T().Fatal(cmp.Diff(got, tc.ExpectedRelation))
 			}
 		})
 	}
@@ -272,7 +272,7 @@ func (s *RelationRepositoryTestSuite) TestList() {
 				sort.Slice(tc.ExpectedRelations, func(i, j int) bool {
 					return tc.ExpectedRelations[i].RelationName < tc.ExpectedRelations[j].RelationName
 				})
-				s.T().Fatalf(cmp.Diff(got, tc.ExpectedRelations))
+				s.T().Fatal(cmp.Diff(got, tc.ExpectedRelations))
 			}
 		})
 	}

--- a/internal/store/postgres/user_repository.go
+++ b/internal/store/postgres/user_repository.go
@@ -114,10 +114,12 @@ func (r UserRepository) Create(ctx context.Context, usr user.User) (user.User, e
 	}
 
 	insertRow := goqu.Record{
-		"name":   strings.ToLower(usr.Name),
-		"email":  strings.ToLower(usr.Email),
-		"title":  usr.Title,
-		"avatar": usr.Avatar,
+		"name":       strings.ToLower(usr.Name),
+		"email":      strings.ToLower(usr.Email),
+		"title":      usr.Title,
+		"avatar":     usr.Avatar,
+		"created_at": goqu.L("now()"),
+		"updated_at": goqu.L("now()"),
 	}
 	if usr.Metadata != nil {
 		marshaledMetadata, err := json.Marshal(usr.Metadata)


### PR DESCRIPTION
Currently while updating role, frontier used to identify the deleted permissions from role and only remove them which are needed. One problem with this is if in case someone manually modifies such roles and the permissions gets out of sync, it will not try to correct them. Now it deletes all existing permissions and create the new requested on every update call.