### PR TITLE
fix: add isolation level in transaction repository

### DIFF
--- a/internal/api/v1beta1/org.go
+++ b/internal/api/v1beta1/org.go
@@ -3,6 +3,8 @@ package v1beta1
 import (
 	"context"
 
+	"github.com/raystack/frontier/core/serviceuser"
+
 	"github.com/raystack/frontier/core/authenticate"
 
 	"go.uber.org/zap"
@@ -318,13 +320,15 @@ func (h Handler) ListOrganizationServiceUsers(ctx context.Context, request *fron
 		}
 	}
 
-	users, err := h.serviceUserService.ListByOrg(ctx, orgResp.ID)
+	usersList, err := h.serviceUserService.List(ctx, serviceuser.Filter{
+		OrgID: orgResp.ID,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	var usersPB []*frontierv1beta1.ServiceUser
-	for _, rel := range users {
+	for _, rel := range usersList {
 		u, err := transformServiceUserToPB(rel)
 		if err != nil {
 			return nil, err

--- a/internal/api/v1beta1/org_test.go
+++ b/internal/api/v1beta1/org_test.go
@@ -790,7 +790,9 @@ func TestHandler_ListOrganizationServiceUsers(t *testing.T) {
 				for _, u := range testUserMap {
 					testUserList = append(testUserList, u)
 				}
-				us.EXPECT().ListByOrg(mock.AnythingOfType("context.backgroundCtx"), testOrgID).Return([]serviceuser.ServiceUser{
+				us.EXPECT().List(mock.AnythingOfType("context.backgroundCtx"), serviceuser.Filter{
+					OrgID: testOrgID,
+				}).Return([]serviceuser.ServiceUser{
 					{
 						ID:    "9f256f86-31a3-11ec-8d3d-0242ac130003",
 						Title: "Sample Service User",

--- a/internal/store/postgres/billing_transactions_repository.go
+++ b/internal/store/postgres/billing_transactions_repository.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
 	"github.com/raystack/frontier/billing/customer"
+
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 
 	"github.com/jackc/pgconn"
@@ -81,122 +83,82 @@ func NewBillingTransactionRepository(dbc *db.Client) *BillingTransactionReposito
 	}
 }
 
+var (
+	maxRetries = 5
+	// Error codes from https://www.postgresql.org/docs/current/errcodes-appendix.html
+	serializationFailureCode = "40001"
+	deadlockDetectedCode     = "40P01"
+)
+
+func (r BillingTransactionRepository) withRetry(ctx context.Context, fn func() error) error {
+	var lastErr error
+	for i := 0; i < maxRetries && ctx.Err() == nil; i++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		var pqErr *pgconn.PgError
+		if errors.As(err, &pqErr) {
+			// Retry on serialization failures or deadlocks
+			if pqErr.Code == serializationFailureCode || pqErr.Code == deadlockDetectedCode {
+				lastErr = err
+				// Exponential backoff with jitter
+				backoff := time.Duration(1<<uint(i)) * 50 * time.Millisecond
+				jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
+				time.Sleep(backoff + jitter)
+				continue
+			}
+		}
+		return err // Return immediately for other errors
+	}
+	return fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
 func (r BillingTransactionRepository) CreateEntry(ctx context.Context, debitEntry credit.Transaction,
 	creditEntry credit.Transaction) ([]credit.Transaction, error) {
-	var customerAcc customer.Customer
+	txOpts := sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+		ReadOnly:  false,
+	}
+
 	var err error
+	var debitModel Transaction
+	var creditModel Transaction
+	var customerAcc customer.Customer
+
 	if debitEntry.CustomerID != schema.PlatformOrgID.String() {
-		// only fetch if it's a customer debit entry
 		customerAcc, err = r.customerRepo.GetByID(ctx, debitEntry.CustomerID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get customer account: %w", err)
 		}
 	}
 
-	if debitEntry.Metadata == nil {
-		debitEntry.Metadata = make(map[string]any)
-	}
-	debitMetadata, err := json.Marshal(debitEntry.Metadata)
-	if err != nil {
-		return nil, err
-	}
-	debitRecord := goqu.Record{
-		"account_id":  debitEntry.CustomerID,
-		"description": debitEntry.Description,
-		"type":        debitEntry.Type,
-		"source":      debitEntry.Source,
-		"amount":      debitEntry.Amount,
-		"user_id":     debitEntry.UserID,
-		"metadata":    debitMetadata,
-		"created_at":  goqu.L("now()"),
-		"updated_at":  goqu.L("now()"),
-	}
-	if debitEntry.ID != "" {
-		debitRecord["id"] = debitEntry.ID
-	}
-
-	if creditEntry.Metadata == nil {
-		creditEntry.Metadata = make(map[string]any)
-	}
-	creditMetadata, err := json.Marshal(creditEntry.Metadata)
-	if err != nil {
-		return nil, err
-	}
-	creditRecord := goqu.Record{
-		"account_id":  creditEntry.CustomerID,
-		"description": creditEntry.Description,
-		"type":        creditEntry.Type,
-		"source":      creditEntry.Source,
-		"amount":      creditEntry.Amount,
-		"user_id":     creditEntry.UserID,
-		"metadata":    creditMetadata,
-		"created_at":  goqu.L("now()"),
-		"updated_at":  goqu.L("now()"),
-	}
-	if creditEntry.ID != "" {
-		creditRecord["id"] = creditEntry.ID
-	}
-
 	var creditReturnedEntry, debitReturnedEntry credit.Transaction
-	if err := r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
-		// check if balance is enough if it's a customer entry
-		if customerAcc.ID != "" {
-			currentBalance, err := r.getBalanceInTx(ctx, tx, customerAcc.ID)
-			if err != nil {
-				return fmt.Errorf("failed to apply transaction: %w", err)
-			}
-			if err := isSufficientBalance(customerAcc.CreditMin, currentBalance, debitEntry.Amount); err != nil {
-				return err
-			}
-		}
-
-		var debitModel Transaction
-		var creditModel Transaction
-		query, params, err := dialect.Insert(TABLE_BILLING_TRANSACTIONS).Rows(debitRecord).Returning(&Transaction{}).ToSQL()
-		if err != nil {
-			return fmt.Errorf("%w: %s", parseErr, err)
-		}
-		if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "Create", func(ctx context.Context) error {
-			return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&debitModel)
-		}); err != nil {
-			var pqErr *pgconn.PgError
-			if errors.As(err, &pqErr) && (pqErr.Code == "23505") { // handle unique key violations
-				if pqErr.ConstraintName == "billing_transactions_pkey" { // primary key violation
-					return credit.ErrAlreadyApplied
+	err = r.withRetry(ctx, func() error {
+		return r.dbc.WithTxn(ctx, txOpts, func(tx *sqlx.Tx) error {
+			if debitEntry.CustomerID != schema.PlatformOrgID.String() {
+				// check for balance only when deducting from customer account
+				currentBalance, err := r.getBalanceInTx(ctx, tx, debitEntry.CustomerID)
+				if err != nil {
+					return fmt.Errorf("failed to get balance: %w", err)
 				}
-				// add other specific unique key violations here if needed
-			}
-			return fmt.Errorf("%w: %s", dbErr, err)
-		}
 
-		query, params, err = dialect.Insert(TABLE_BILLING_TRANSACTIONS).Rows(creditRecord).Returning(&Transaction{}).ToSQL()
-		if err != nil {
-			return fmt.Errorf("%w: %s", parseErr, err)
-		}
-		if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "Create", func(ctx context.Context) error {
-			return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&creditModel)
-		}); err != nil {
-			var pqErr *pgconn.PgError
-			if errors.As(err, &pqErr) && (pqErr.Code == "23505") { // handle unique key violations
-				if pqErr.ConstraintName == "billing_transactions_pkey" { // primary key violation
-					return credit.ErrAlreadyApplied
+				if err := isSufficientBalance(customerAcc.CreditMin, currentBalance, debitEntry.Amount); err != nil {
+					return err
 				}
-				// add other specific unique key violations here if needed
 			}
-			return fmt.Errorf("%w: %s", dbErr, err)
-		}
 
-		creditReturnedEntry, err = creditModel.transform()
-		if err != nil {
-			return fmt.Errorf("failed to transform credit entry: %w", err)
-		}
-		debitReturnedEntry, err = debitModel.transform()
-		if err != nil {
-			return fmt.Errorf("failed to transform debit entry: %w", err)
-		}
-
-		return nil
-	}); err != nil {
+			if err := r.createTransactionEntry(ctx, tx, debitEntry, &debitModel); err != nil {
+				return fmt.Errorf("failed to create debit entry: %w", err)
+			}
+			if err := r.createTransactionEntry(ctx, tx, creditEntry, &creditModel); err != nil {
+				return fmt.Errorf("failed to create credit entry: %w", err)
+			}
+			return nil
+		})
+	})
+	if err != nil {
 		if errors.Is(err, credit.ErrAlreadyApplied) {
 			return nil, credit.ErrAlreadyApplied
 		} else if errors.Is(err, credit.ErrInsufficientCredits) {
@@ -205,7 +167,59 @@ func (r BillingTransactionRepository) CreateEntry(ctx context.Context, debitEntr
 		return nil, fmt.Errorf("failed to create transaction entry: %w", err)
 	}
 
+	creditReturnedEntry, err = creditModel.transform()
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform credit entry: %w", err)
+	}
+	debitReturnedEntry, err = debitModel.transform()
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform debit entry: %w", err)
+	}
 	return []credit.Transaction{debitReturnedEntry, creditReturnedEntry}, nil
+}
+
+func (r BillingTransactionRepository) createTransactionEntry(ctx context.Context, tx *sqlx.Tx, entry credit.Transaction, model *Transaction) error {
+	if entry.Metadata == nil {
+		entry.Metadata = make(map[string]any)
+	}
+	metadata, err := json.Marshal(entry.Metadata)
+	if err != nil {
+		return err
+	}
+
+	record := goqu.Record{
+		"account_id":  entry.CustomerID,
+		"description": entry.Description,
+		"type":        entry.Type,
+		"source":      entry.Source,
+		"amount":      entry.Amount,
+		"user_id":     entry.UserID,
+		"metadata":    metadata,
+		"created_at":  goqu.L("now()"),
+		"updated_at":  goqu.L("now()"),
+	}
+	if entry.ID != "" {
+		record["id"] = entry.ID
+	}
+
+	query, params, err := dialect.Insert(TABLE_BILLING_TRANSACTIONS).Rows(record).Returning(&Transaction{}).ToSQL()
+	if err != nil {
+		return fmt.Errorf("%w: %w", parseErr, err)
+	}
+
+	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "Create", func(ctx context.Context) error {
+		return tx.QueryRowxContext(ctx, query, params...).StructScan(model)
+	}); err != nil {
+		var pqErr *pgconn.PgError
+		if errors.As(err, &pqErr) && (pqErr.Code == "23505") {
+			if pqErr.ConstraintName == "billing_transactions_pkey" {
+				return credit.ErrAlreadyApplied
+			}
+		}
+		return fmt.Errorf("%w: %w", dbErr, err)
+	}
+
+	return nil
 }
 
 // isSufficientBalance checks if the customer has enough balance to perform the transaction.
@@ -328,6 +342,7 @@ func (r BillingTransactionRepository) getDebitBalance(ctx context.Context, tx *s
 		"account_id": accountID,
 		"type":       credit.DebitType,
 	})
+
 	query, params, err := stmt.ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", parseErr, err)
@@ -347,6 +362,7 @@ func (r BillingTransactionRepository) getCreditBalance(ctx context.Context, tx *
 		"account_id": accountID,
 		"type":       credit.CreditType,
 	})
+
 	query, params, err := stmt.ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", parseErr, err)
@@ -388,11 +404,17 @@ func (r BillingTransactionRepository) getBalanceInTx(ctx context.Context, tx *sq
 // in transaction table till now.
 func (r BillingTransactionRepository) GetBalance(ctx context.Context, accountID string) (int64, error) {
 	var amount int64
-	if err := r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
-		var err error
-		amount, err = r.getBalanceInTx(ctx, tx, accountID)
-		return err
-	}); err != nil {
+	err := r.withRetry(ctx, func() error {
+		return r.dbc.WithTxn(ctx, sql.TxOptions{
+			Isolation: sql.LevelSerializable,
+			ReadOnly:  true,
+		}, func(tx *sqlx.Tx) error {
+			var err error
+			amount, err = r.getBalanceInTx(ctx, tx, accountID)
+			return err
+		})
+	})
+	if err != nil {
 		return 0, fmt.Errorf("failed to get balance: %w", err)
 	}
 	return amount, nil

--- a/internal/store/postgres/group_repository.go
+++ b/internal/store/postgres/group_repository.go
@@ -43,7 +43,7 @@ func (r GroupRepository) GetByID(ctx context.Context, id string) (group.Group, e
 			"id": id,
 		}).Where(notDisabledGroupExp).ToSQL()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", queryErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var groupModel Group
@@ -63,7 +63,7 @@ func (r GroupRepository) GetByID(ctx context.Context, id string) (group.Group, e
 
 	transformedGroup, err := groupModel.transformToGroup()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	return transformedGroup, nil
@@ -91,7 +91,7 @@ func (r GroupRepository) GetByIDs(ctx context.Context, groupIDs []string, flt gr
 			"id": goqu.Op{"in": groupIDs},
 		}).Where(notDisabledGroupExp).ToSQL()
 	if err != nil {
-		return []group.Group{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_GROUPS, "GetByIDs", func(ctx context.Context) error {
@@ -112,7 +112,7 @@ func (r GroupRepository) GetByIDs(ctx context.Context, groupIDs []string, flt gr
 	for _, g := range fetchedGroups {
 		transformedGroup, err := g.transformToGroup()
 		if err != nil {
-			return []group.Group{}, fmt.Errorf("%w: %s", parseErr, err)
+			return []group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
 		}
 
 		transformedGroups = append(transformedGroups, transformedGroup)
@@ -128,7 +128,7 @@ func (r GroupRepository) Create(ctx context.Context, grp group.Group) (group.Gro
 
 	marshaledMetadata, err := json.Marshal(grp.Metadata)
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	insertRow := goqu.Record{
@@ -142,7 +142,7 @@ func (r GroupRepository) Create(ctx context.Context, grp group.Group) (group.Gro
 	}
 	query, params, err := dialect.Insert(TABLE_GROUPS).Rows(insertRow).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", queryErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var groupModel Group
@@ -164,7 +164,7 @@ func (r GroupRepository) Create(ctx context.Context, grp group.Group) (group.Gro
 
 	transformedGroup, err := groupModel.transformToGroup()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	return transformedGroup, nil
@@ -186,7 +186,7 @@ func (r GroupRepository) List(ctx context.Context, flt group.Filter) ([]group.Gr
 
 	query, params, err := sqlStatement.ToSQL()
 	if err != nil {
-		return []group.Group{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var fetchedGroups []Group
@@ -200,7 +200,7 @@ func (r GroupRepository) List(ctx context.Context, flt group.Filter) ([]group.Gr
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return []group.Group{}, nil
 		default:
-			return []group.Group{}, fmt.Errorf("%w: %s", dbErr, err)
+			return []group.Group{}, fmt.Errorf("%w: %w", dbErr, err)
 		}
 	}
 
@@ -208,7 +208,7 @@ func (r GroupRepository) List(ctx context.Context, flt group.Filter) ([]group.Gr
 	for _, v := range fetchedGroups {
 		transformedGroup, err := v.transformToGroup()
 		if err != nil {
-			return []group.Group{}, fmt.Errorf("%w: %s", parseErr, err)
+			return []group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
 		}
 		transformedGroups = append(transformedGroups, transformedGroup)
 	}
@@ -227,7 +227,7 @@ func (r GroupRepository) UpdateByID(ctx context.Context, grp group.Group) (group
 
 	marshaledMetadata, err := json.Marshal(grp.Metadata)
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_GROUPS).Set(
@@ -241,7 +241,7 @@ func (r GroupRepository) UpdateByID(ctx context.Context, grp group.Group) (group
 		"id": grp.ID,
 	}).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %s", queryErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var groupModel Group
@@ -259,7 +259,7 @@ func (r GroupRepository) UpdateByID(ctx context.Context, grp group.Group) (group
 		case errors.Is(err, ErrForeignKeyViolation):
 			return group.Group{}, organization.ErrNotExist
 		default:
-			return group.Group{}, fmt.Errorf("%w: %s", dbErr, err)
+			return group.Group{}, fmt.Errorf("%w: %w", dbErr, err)
 		}
 	}
 
@@ -281,7 +281,7 @@ func (r GroupRepository) SetState(ctx context.Context, id string, state group.St
 		},
 	).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var groupModel Group
@@ -308,7 +308,7 @@ func (r GroupRepository) Delete(ctx context.Context, id string) error {
 		},
 	).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var groupModel Group

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -41,7 +41,7 @@ func (r OrganizationRepository) GetByID(ctx context.Context, id string) (organiz
 		"id": id,
 	}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization
@@ -61,7 +61,7 @@ func (r OrganizationRepository) GetByID(ctx context.Context, id string) (organiz
 
 	transformedOrg, err := orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	return transformedOrg, nil
@@ -76,7 +76,7 @@ func (r OrganizationRepository) GetByIDs(ctx context.Context, ids []string) ([]o
 		"id": goqu.Op{"in": ids},
 	}).Where(notDisabledOrgExp).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgs []Organization
@@ -116,7 +116,7 @@ func (r OrganizationRepository) GetByName(ctx context.Context, name string) (org
 		"name": name,
 	}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization
@@ -136,7 +136,7 @@ func (r OrganizationRepository) GetByName(ctx context.Context, name string) (org
 
 	transformedOrg, err := orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	return transformedOrg, nil
@@ -149,7 +149,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	insertRow := goqu.Record{
@@ -163,7 +163,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 	}
 	query, params, err := dialect.Insert(TABLE_ORGANIZATIONS).Rows(insertRow).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization
@@ -181,7 +181,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 
 	transformedOrg, err := orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	return transformedOrg, nil
@@ -209,14 +209,14 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 		totalCountStmt := stmt.Select(goqu.COUNT("*"))
 		totalCountQuery, _, err := totalCountStmt.ToSQL()
 		if err != nil {
-			return []organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+			return []organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 		}
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_ORGANIZATIONS, "Count", func(ctx context.Context) error {
 			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery)
 		}); err != nil {
-			return nil, fmt.Errorf("%w: %s", dbErr, err)
+			return nil, fmt.Errorf("%w: %w", dbErr, err)
 		}
 
 		flt.Pagination.SetCount(totalCount)
@@ -225,7 +225,7 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModels []Organization
@@ -235,14 +235,14 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 		if errors.Is(err, sql.ErrNoRows) {
 			return []organization.Organization{}, nil
 		}
-		return []organization.Organization{}, fmt.Errorf("%w: %s", dbErr, err)
+		return []organization.Organization{}, fmt.Errorf("%w: %w", dbErr, err)
 	}
 
 	var transformedOrgs []organization.Organization
 	for _, o := range orgModels {
 		transformedOrg, err := o.transformToOrg()
 		if err != nil {
-			return []organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+			return []organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 		}
 		transformedOrgs = append(transformedOrgs, transformedOrg)
 	}
@@ -261,7 +261,7 @@ func (r OrganizationRepository) UpdateByID(ctx context.Context, org organization
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_ORGANIZATIONS).Set(
@@ -274,7 +274,7 @@ func (r OrganizationRepository) UpdateByID(ctx context.Context, org organization
 		"id": org.ID,
 	}).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization
@@ -309,7 +309,7 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_ORGANIZATIONS).Set(
@@ -323,7 +323,7 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 			"name": org.Name,
 		}).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %s", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization
@@ -359,7 +359,7 @@ func (r OrganizationRepository) SetState(ctx context.Context, id string, state o
 		},
 	).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization
@@ -384,7 +384,7 @@ func (r OrganizationRepository) Delete(ctx context.Context, id string) error {
 		},
 	).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %w", queryErr, err)
 	}
 
 	var orgModel Organization

--- a/test/e2e/testbench/testbench.go
+++ b/test/e2e/testbench/testbench.go
@@ -86,8 +86,8 @@ func Init(appConfig *config.Frontier) (*TestBench, error) {
 		URL:             connMainPGExternal,
 		MaxIdleConns:    10,
 		MaxOpenConns:    10,
-		ConnMaxLifeTime: time.Millisecond * 100,
-		MaxQueryTimeout: time.Millisecond * 100,
+		ConnMaxLifeTime: time.Second * 60,
+		MaxQueryTimeout: time.Second * 30,
 	}
 	appConfig.SpiceDB = spicedb.Config{
 		Host:            "localhost",


### PR DESCRIPTION
Currently there were chances to have race conditions while writing to transaction repository. I have added a test to verify it doesn't happen. Database is using `Serializable` as the isolation level to avoid overlapping transactions.