### PR TITLE
feat: cancel subscription after trial

### DIFF
--- a/billing/config.go
+++ b/billing/config.go
@@ -55,8 +55,8 @@ type PlanChangeConfig struct {
 }
 
 type SubscriptionConfig struct {
-	// CancelAfterTrial will cancel the subscription after trial end and will not generate invoice.
-	CancelAfterTrial bool `yaml:"cancel_after_trial" mapstructure:"cancel_after_trial" default:"false"`
+	// BehaviorAfterTrial as `cancel` will cancel the subscription after trial end and will not generate invoice.
+	BehaviorAfterTrial string `yaml:"behavior_after_trial" mapstructure:"behavior_after_trial" default:"release"`
 }
 
 type ProductConfig struct {

--- a/billing/config.go
+++ b/billing/config.go
@@ -55,6 +55,8 @@ type PlanChangeConfig struct {
 }
 
 type SubscriptionConfig struct {
+	// CancelAfterTrial will cancel the subscription after trial end and will not generate invoice.
+	CancelAfterTrial bool `yaml:"cancel_after_trial" mapstructure:"cancel_after_trial" default:"false"`
 }
 
 type ProductConfig struct {

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -990,7 +990,7 @@ func (s *Service) CancelUpcomingPhase(ctx context.Context, sub Subscription) err
 
 	var endBehavior = stripe.SubscriptionScheduleEndBehaviorRelease
 
-	if stripeSub.Status == stripe.SubscriptionStatusTrialing {
+	if stripeSub.Status == stripe.SubscriptionStatusTrialing && s.config.SubscriptionConfig.CancelAfterTrial {
 		endBehavior = stripe.SubscriptionScheduleEndBehaviorCancel
 	}
 

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -990,7 +990,7 @@ func (s *Service) CancelUpcomingPhase(ctx context.Context, sub Subscription) err
 
 	var endBehavior = stripe.SubscriptionScheduleEndBehaviorRelease
 
-	if stripeSub.Status == stripe.SubscriptionStatusTrialing && s.config.SubscriptionConfig.CancelAfterTrial {
+	if stripeSub.Status == stripe.SubscriptionStatusTrialing && s.config.SubscriptionConfig.BehaviorAfterTrial == "cancel" {
 		endBehavior = stripe.SubscriptionScheduleEndBehaviorCancel
 	}
 

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -972,7 +972,7 @@ func (s *Service) getPlanFromSchedule(ctx context.Context, stripeSchedule *strip
 
 // CancelUpcomingPhase cancels the scheduled phase of the subscription
 func (s *Service) CancelUpcomingPhase(ctx context.Context, sub Subscription) error {
-	_, stripeSchedule, err := s.createOrGetSchedule(ctx, sub)
+	stripeSub, stripeSchedule, err := s.createOrGetSchedule(ctx, sub)
 	if err != nil {
 		return err
 	}
@@ -987,6 +987,12 @@ func (s *Service) CancelUpcomingPhase(ctx context.Context, sub Subscription) err
 	}
 	var currency = string(stripeSchedule.Phases[0].Currency)
 	var prorationBehavior = s.config.PlanChangeConfig.ProrationBehavior
+
+	var endBehavior = stripe.SubscriptionScheduleEndBehaviorRelease
+
+	if stripeSub.Status == stripe.SubscriptionStatusTrialing {
+		endBehavior = stripe.SubscriptionScheduleEndBehaviorCancel
+	}
 
 	// update the phases
 	_, err = s.stripeClient.SubscriptionSchedules.Update(stripeSchedule.ID, &stripe.SubscriptionScheduleParams{
@@ -1005,7 +1011,7 @@ func (s *Service) CancelUpcomingPhase(ctx context.Context, sub Subscription) err
 				},
 			},
 		},
-		EndBehavior:       stripe.String("release"),
+		EndBehavior:       stripe.String(string(endBehavior)),
 		ProrationBehavior: stripe.String(prorationBehavior),
 		DefaultSettings: &stripe.SubscriptionScheduleDefaultSettingsParams{
 			CollectionMethod: stripe.String(s.config.PlanChangeConfig.CollectionMethod),

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -227,3 +227,5 @@ billing:
     subscription: 1m
     invoice: 5m
     checkout: 1m
+  subscription:
+    cancel_after_trial: true


### PR DESCRIPTION
This PR will update the `end_behavior` in the cancel upcoming phase 
If the user is on trial and config.subscription.cancel_after_trial is set to true, then the `end_behavior` in [subscription update call ](https://docs.stripe.com/api/subscription_schedules/object#subscription_schedule_object-end_behavior)will be set to `cancel`