### PR TITLE
feat: add a way to disable background sync jobs

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -141,6 +141,9 @@ func NewService(stripeClient *client.API, cfg billing.Config, repository Reposit
 }
 
 func (s *Service) Init(ctx context.Context) error {
+	if s.syncDelay == time.Duration(0) {
+		return nil
+	}
 	if s.syncJob != nil {
 		<-s.syncJob.Stop().Done()
 	}

--- a/billing/customer/service.go
+++ b/billing/customer/service.go
@@ -349,6 +349,9 @@ func (s *Service) ListPaymentMethods(ctx context.Context, id string) ([]PaymentM
 }
 
 func (s *Service) Init(ctx context.Context) error {
+	if s.syncDelay == time.Duration(0) {
+		return nil
+	}
 	if s.syncJob != nil {
 		<-s.syncJob.Stop().Done()
 	}

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -112,6 +112,10 @@ func (s *Service) GetByProviderID(ctx context.Context, id string) (Subscription,
 }
 
 func (s *Service) Init(ctx context.Context) error {
+	syncDelay := s.config.RefreshInterval.Subscription
+	if syncDelay == time.Duration(0) {
+		return nil
+	}
 	if s.syncJob != nil {
 		<-s.syncJob.Stop().Done()
 	}
@@ -120,7 +124,7 @@ func (s *Service) Init(ctx context.Context) error {
 		cron.SkipIfStillRunning(cron.DefaultLogger),
 		cron.Recover(cron.DefaultLogger),
 	))
-	if _, err := s.syncJob.AddFunc(fmt.Sprintf("@every %s", s.config.RefreshInterval.Subscription.String()), func() {
+	if _, err := s.syncJob.AddFunc(fmt.Sprintf("@every %s", syncDelay.String()), func() {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		s.backgroundSync(ctx)


### PR DESCRIPTION
This will help us to run a single pod that does the background sync, while other pods can just serve http requests.