### PR TITLE
feat(sdk): add dialog to remove member from project

### DIFF
--- a/sdks/js/packages/core/react/components/organization/project/members/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/members/index.tsx
@@ -218,8 +218,8 @@ const AddMemberDropdown = ({
       invitableUser
         .filter(user =>
           query
-            ? user.title &&
-              user.title.toLowerCase().includes(query.toLowerCase())
+            ? user.title?.toLowerCase().includes(query.toLowerCase()) ||
+              user.email?.includes(query)
             : true
         )
         .slice(0, 7),
@@ -253,7 +253,7 @@ const AddMemberDropdown = ({
           role_id: PERMISSIONS.RoleProjectViewer,
           principal
         };
-        await client?.frontierServiceCreatePolicyForProject(projectId, policy)
+        await client?.frontierServiceCreatePolicyForProject(projectId, policy);
         toast.success('Member added');
         if (refetch) {
           refetch();

--- a/sdks/js/packages/core/react/components/organization/project/members/member.columns.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/members/member.columns.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { DotsHorizontalIcon, UpdateIcon } from '@radix-ui/react-icons';
+import {
+  DotsHorizontalIcon,
+  TrashIcon,
+  UpdateIcon
+} from '@radix-ui/react-icons';
 import {
   ApsaraColumnDef,
   Avatar,
@@ -153,6 +157,17 @@ const MembersActions = ({
   const { client } = useFrontier();
   const navigate = useNavigate({ from: '/projects' });
 
+  function removeMember() {
+    navigate({
+      to: '/projects/$projectId/$membertype/$memberId/remove',
+      params: {
+        projectId: projectId,
+        membertype: member?.isTeam ? 'team' : 'user',
+        memberId: member?.id as string
+      }
+    });
+  }
+
   async function updateRole(role: V1Beta1Role) {
     try {
       const resource = `app/project:${projectId}`;
@@ -163,8 +178,8 @@ const MembersActions = ({
         // @ts-ignore
         data: { policies = [] }
       } = await client?.frontierServiceListPolicies({
-        projectId: projectId,
-        userId: member.id
+        project_id: projectId,
+        user_id: member.id
       });
 
       const deletePromises = policies.map((p: V1Beta1Policy) =>
@@ -173,7 +188,7 @@ const MembersActions = ({
 
       await Promise.all(deletePromises);
       await client?.frontierServiceCreatePolicy({
-        roleId: role.id as string,
+        role_id: role.id as string,
         title: role.name as string,
         resource: resource,
         principal: principal
@@ -197,6 +212,7 @@ const MembersActions = ({
           {excludedRoles.map((role: V1Beta1Role) => (
             <DropdownMenu.Item style={{ padding: 0 }} key={role.id}>
               <div
+                data-test-id="frontier-sdk-update-project-member-role-btn"
                 onClick={() => updateRole(role)}
                 className={styles.dropdownActionItem}
               >
@@ -205,6 +221,16 @@ const MembersActions = ({
               </div>
             </DropdownMenu.Item>
           ))}
+          <DropdownMenu.Item style={{ padding: 0 }}>
+            <div
+              data-test-id="frontier-sdk-remove-project-member-btn"
+              className={styles.dropdownActionItem}
+              onClick={() => removeMember()}
+            >
+              <TrashIcon />
+              Remove from project
+            </div>
+          </DropdownMenu.Item>
         </DropdownMenu.Group>
       </DropdownMenu.Content>
     </DropdownMenu>

--- a/sdks/js/packages/core/react/components/organization/project/members/remove.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/members/remove.tsx
@@ -1,21 +1,59 @@
-import { Dialog, Image, Separator } from '@raystack/apsara/*';
+import { Dialog, Image, Separator, toast } from '@raystack/apsara';
 import styles from '../../organization.module.css';
-import { Flex, Text } from '@raystack/apsara/v1';
+import { Button, Flex, Text } from '@raystack/apsara/v1';
 import cross from '~/react/assets/cross.svg';
 import { useNavigate, useParams } from '@tanstack/react-router';
+import { useFrontier } from '~/react/contexts/FrontierContext';
+import { useState } from 'react';
+import { V1Beta1Policy } from '~/api-client';
 
 export const RemoveProjectMember = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { client } = useFrontier();
   const navigate = useNavigate({
     from: '/projects/$projectId/$membertype/$memberId/remove'
   });
 
-  const { projectId } = useParams({
+  const { projectId, memberId } = useParams({
     from: '/projects/$projectId/$membertype/$memberId/remove'
   });
+
+  async function onConfirm() {
+    setIsLoading(true);
+    try {
+      const {
+        // @ts-ignore
+        data: { policies = [] }
+      } = await client?.frontierServiceListPolicies({
+        project_id: projectId,
+        user_id: memberId
+      });
+
+      const deletePromises = policies.map((p: V1Beta1Policy) =>
+        client?.frontierServiceDeletePolicy(p.id as string)
+      );
+
+      await Promise.all(deletePromises);
+      navigate({
+        to: '/projects/$projectId',
+        params: { projectId },
+        state: { refetch: true }
+      });
+      toast.success('Member removed');
+    } catch (err: any) {
+      toast.error('Something went wrong', {
+        description: err.message
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
   return (
     <Dialog open={true}>
       <Dialog.Content
-        style={{ padding: 0, maxWidth: '600px', width: '100%', zIndex: '60' }}
+        style={{ padding: 0, maxWidth: '400px', width: '100%', zIndex: '60' }}
         overlayClassname={styles.overlay}
       >
         <Flex justify="between" style={{ padding: '16px 24px' }}>
@@ -37,6 +75,34 @@ export const RemoveProjectMember = () => {
           />
         </Flex>
         <Separator />
+        <Flex direction="column" gap="medium" style={{ padding: '24px' }}>
+          <Text size={4}>
+            Are you sure you want to remove this member from the project?
+          </Text>
+        </Flex>
+        <Separator />
+        <Flex justify="end" style={{ padding: 'var(--pd-16)' }} gap="medium">
+          <Button
+            size="normal"
+            variant="secondary"
+            onClick={() => navigate({ to: '/members' })}
+            data-test-id="frontier-sdk-remove-project-member-cancel-btn"
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="normal"
+            variant="danger"
+            onClick={onConfirm}
+            data-test-id="frontier-sdk-remove-project-member-confirm-btn"
+            disabled={isLoading}
+            loading={isLoading}
+            loaderText="Removing"
+          >
+            Remove
+          </Button>
+        </Flex>
       </Dialog.Content>
     </Dialog>
   );

--- a/sdks/js/packages/core/react/components/organization/project/members/remove.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/members/remove.tsx
@@ -1,0 +1,43 @@
+import { Dialog, Image, Separator } from '@raystack/apsara/*';
+import styles from '../../organization.module.css';
+import { Flex, Text } from '@raystack/apsara/v1';
+import cross from '~/react/assets/cross.svg';
+import { useNavigate, useParams } from '@tanstack/react-router';
+
+export const RemoveProjectMember = () => {
+  const navigate = useNavigate({
+    from: '/projects/$projectId/$membertype/$memberId/remove'
+  });
+
+  const { projectId } = useParams({
+    from: '/projects/$projectId/$membertype/$memberId/remove'
+  });
+  return (
+    <Dialog open={true}>
+      <Dialog.Content
+        style={{ padding: 0, maxWidth: '600px', width: '100%', zIndex: '60' }}
+        overlayClassname={styles.overlay}
+      >
+        <Flex justify="between" style={{ padding: '16px 24px' }}>
+          <Text size={6} weight={500}>
+            Remove project member
+          </Text>
+          <Image
+            data-test-id="frontier-sdk-remove-project-member-close-btn"
+            alt="cross"
+            // @ts-ignore
+            src={cross}
+            onClick={() =>
+              navigate({
+                to: '/projects/$projectId',
+                params: { projectId }
+              })
+            }
+            style={{ cursor: 'pointer' }}
+          />
+        </Flex>
+        <Separator />
+      </Dialog.Content>
+    </Dialog>
+  );
+};

--- a/sdks/js/packages/core/react/components/organization/project/project.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/project.tsx
@@ -3,6 +3,7 @@ import { Flex, Image, Text } from '@raystack/apsara';
 import { Tabs } from '@raystack/apsara';
 import {
   Outlet,
+  useLocation,
   useNavigate,
   useParams,
   useRouterState
@@ -35,6 +36,9 @@ export const ProjectPage = () => {
   const { client, activeOrganization: organization } = useFrontier();
   let navigate = useNavigate({ from: '/projects/$projectId' });
   const routeState = useRouterState();
+
+  const location = useLocation();
+  const refetch = location?.state?.refetch;
 
   const isDeleteRoute = useMemo(() => {
     return routeState.matches.some(
@@ -130,7 +134,13 @@ export const ProjectPage = () => {
     getProjectMembers();
     getProjectTeams();
     getProjectRoles();
-  }, [getProjectDetails, getProjectMembers, getProjectTeams, getProjectRoles]);
+  }, [
+    getProjectDetails,
+    getProjectMembers,
+    getProjectTeams,
+    getProjectRoles,
+    refetch
+  ]);
 
   const isLoading =
     isProjectLoading ||

--- a/sdks/js/packages/core/react/components/organization/routes.tsx
+++ b/sdks/js/packages/core/react/components/organization/routes.tsx
@@ -24,6 +24,7 @@ import { default as WorkspaceProjects } from './project';
 import { AddProject } from './project/add';
 import { DeleteProject } from './project/delete';
 import { ProjectPage } from './project/project';
+import { RemoveProjectMember } from './project/members/remove';
 
 import WorkspaceSecurity from './security';
 import { Sidebar } from './sidebar';
@@ -46,7 +47,6 @@ import { AddServiceAccount } from './api-keys/add';
 import ServiceUserPage from './api-keys/service-user';
 import { DeleteServiceAccount } from './api-keys/delete';
 import { DeleteServiceAccountKey } from './api-keys/service-user/delete';
-
 export interface CustomScreen {
   name: string;
   path: string;
@@ -256,6 +256,12 @@ const deleteProjectRoute = createRoute({
   component: DeleteProject
 });
 
+const removeProjectMemberRoute = createRoute({
+  getParentRoute: () => projectPageRoute,
+  path: '/$membertype/$memberId/remove',
+  component: RemoveProjectMember
+});
+
 const profileRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/profile',
@@ -345,7 +351,10 @@ export function getRootTree({ customScreens = [] }: getRootTreeOptions) {
     ]),
     teamRoute.addChildren([deleteTeamRoute, inviteTeamMembersRoute]),
     projectsRoute.addChildren([addProjectRoute]),
-    projectPageRoute.addChildren([deleteProjectRoute]),
+    projectPageRoute.addChildren([
+      deleteProjectRoute,
+      removeProjectMemberRoute
+    ]),
     profileRoute,
     preferencesRoute,
     billingRoute.addChildren([switchBillingCycleModalRoute]),


### PR DESCRIPTION
This PR will add functionality to remove a member from a project.
a member can be an individual user or a team.
a dialog box will open for confirmation when the user clicks on the remove options.
<img width="1345" alt="Screenshot 2025-01-16 at 3 31 08 PM" src="https://github.com/user-attachments/assets/272bc66e-22d1-4537-a024-a617edfbde15" />
once the user confirms the member removal, all policies for that member and project will be deleted.

This PR also adds support for search users via email in the invite flow.