### PR TITLE
fix: make org and project name case insensitive

### DIFF
--- a/core/authenticate/service.go
+++ b/core/authenticate/service.go
@@ -23,6 +23,7 @@ import (
 	frontiersession "github.com/raystack/frontier/core/authenticate/session"
 	"github.com/raystack/frontier/core/serviceuser"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/internal/metrics"
 	"github.com/raystack/frontier/pkg/errors"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -739,6 +740,11 @@ func (s Service) getOrCreateUser(ctx context.Context, email, title string) (user
 }
 
 func (s Service) GetPrincipal(ctx context.Context, assertions ...ClientAssertion) (Principal, error) {
+	if metrics.ServiceOprLatency != nil {
+		promCollect := metrics.ServiceOprLatency("authenticate", "GetPrincipal")
+		defer promCollect()
+	}
+
 	var currentPrincipal Principal
 	if len(assertions) == 0 {
 		// check all assertions

--- a/core/organization/service.go
+++ b/core/organization/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/internal/metrics"
 )
 
 type Repository interface {
@@ -229,6 +230,11 @@ func (s Service) Update(ctx context.Context, org Organization) (Organization, er
 }
 
 func (s Service) ListByUser(ctx context.Context, principal authenticate.Principal, filter Filter) ([]Organization, error) {
+	if metrics.ServiceOprLatency != nil {
+		promCollect := metrics.ServiceOprLatency("organization", "ListByUser")
+		defer promCollect()
+	}
+
 	subjectIDs, err := s.relationService.LookupResources(ctx, relation.Relation{
 		Object: relation.Object{
 			Namespace: schema.OrganizationNamespace,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 func Init() {
 	initStripe()
 	initDB()
+	initService()
 }
 
 type HistogramFunc func(labelValue ...string) func()

--- a/internal/metrics/service.go
+++ b/internal/metrics/service.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var ServiceOprLatency HistogramFunc
+
+func initService() {
+	ServiceOprLatency = createMeasureTime(promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "service_operation_latency",
+		Help:    "Time taken for service operation to complete",
+		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"service", "operation"}))
+}

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -146,6 +146,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 	if strings.TrimSpace(org.Name) == "" {
 		return organization.Organization{}, organization.ErrInvalidDetail
 	}
+	org.Name = strings.ToLower(org.Name)
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {

--- a/internal/store/postgres/organization_repository_test.go
+++ b/internal/store/postgres/organization_repository_test.go
@@ -237,6 +237,14 @@ func (s *OrganizationRepositoryTestSuite) TestCreate() {
 			ErrString: organization.ErrConflict.Error(),
 		},
 		{
+			Description: "should return error if organization name already exist case sensitive",
+			OrganizationToCreate: organization.Organization{
+				Name:     "ORG-1",
+				Metadata: metadata.Metadata{},
+			},
+			ErrString: organization.ErrConflict.Error(),
+		},
+		{
 			Description: "should return error if organization name is empty",
 			OrganizationToCreate: organization.Organization{
 				Metadata: metadata.Metadata{},

--- a/internal/store/postgres/project_repository.go
+++ b/internal/store/postgres/project_repository.go
@@ -108,6 +108,7 @@ func (r ProjectRepository) Create(ctx context.Context, prj project.Project) (pro
 	if strings.TrimSpace(prj.Name) == "" {
 		return project.Project{}, project.ErrInvalidDetail
 	}
+	prj.Name = strings.ToLower(prj.Name)
 
 	marshaledMetadata, err := json.Marshal(prj.Metadata)
 	if err != nil {

--- a/internal/store/postgres/project_repository_test.go
+++ b/internal/store/postgres/project_repository_test.go
@@ -251,6 +251,16 @@ func (s *ProjectRepositoryTestSuite) TestCreate() {
 			ErrString: project.ErrConflict.Error(),
 		},
 		{
+			Description: "should return error if project slug already exist case sensitive",
+			ProjectToCreate: project.Project{
+				Name: "PROJECT-2",
+				Organization: organization.Organization{
+					ID: s.orgs[0].ID,
+				},
+			},
+			ErrString: project.ErrConflict.Error(),
+		},
+		{
 			Description: "should return error if org id not an uuid",
 			ProjectToCreate: project.Project{
 				Name: "project-2",


### PR DESCRIPTION
All org and project slugs will be converted to lower case before they are created. Existing org and projects will continue to work as usual.

- Added additional metrics latency for authenticate GetPrincipal and organization ListByUser methods.