### PR TITLE
feat: add request id header if available to application log

### DIFF
--- a/core/webhook/service.go
+++ b/core/webhook/service.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/raystack/frontier/pkg/server/consts"
+
 	"golang.org/x/exp/slices"
 
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -139,6 +141,9 @@ func (s Service) Publish(ctx context.Context, evt Event) error {
 			requestHeaders := make(map[string]string)
 			for k, v := range endpoint.Headers {
 				requestHeaders[k] = v
+			}
+			if id, ok := consts.GetRequestIDFromCtx(ctx); ok {
+				requestHeaders[consts.RequestIDHeader] = id
 			}
 			requestHeaders[SignatureHeader] = signatureHeader(signature, secret.ID)
 			if err := post(endpoint.URL, requestHeaders, payload); err != nil {

--- a/pkg/server/consts/gateway.go
+++ b/pkg/server/consts/gateway.go
@@ -48,4 +48,6 @@ const (
 
 	// StripeWebhookSignature is used to store stripe webhook signature
 	StripeWebhookSignature = "stripe-signature"
+
+	RequestIDHeader = "x-request-id"
 )

--- a/pkg/server/consts/gateway.go
+++ b/pkg/server/consts/gateway.go
@@ -1,5 +1,9 @@
 package consts
 
+import (
+	"context"
+)
+
 type contextKey struct {
 	name string
 }
@@ -19,6 +23,9 @@ var (
 
 	// BillingStripeWebhookSignatureContextKey is context key that contains the stripe webhook signature
 	BillingStripeWebhookSignatureContextKey = contextKey{name: "billing-stripe-webhook-signature"}
+
+	// RequestIDContextKey is context key that contains the request id
+	RequestIDContextKey = contextKey{name: "request-id"}
 )
 
 const (
@@ -49,5 +56,15 @@ const (
 	// StripeWebhookSignature is used to store stripe webhook signature
 	StripeWebhookSignature = "stripe-signature"
 
+	// RequestIDHeader is the key to store request id from http headers
 	RequestIDHeader = "x-request-id"
 )
+
+func GetRequestIDFromCtx(ctx context.Context) (string, bool) {
+	u, ok := ctx.Value(RequestIDContextKey).(string)
+	return u, ok
+}
+
+func WithRequestIDInCtx(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, RequestIDContextKey, id)
+}

--- a/pkg/server/interceptors/authorization.go
+++ b/pkg/server/interceptors/authorization.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/raystack/frontier/internal/metrics"
+
 	"github.com/raystack/frontier/core/relation"
 
 	"github.com/raystack/frontier/core/preference"
@@ -42,6 +44,10 @@ func UnaryAuthorizationCheck() grpc.UnaryServerInterceptor {
 			return handler(ctx, req)
 		}
 
+		if metrics.ServiceOprLatency != nil {
+			promCollect := metrics.ServiceOprLatency("authenticate", "UnaryAuthorizationCheck")
+			defer promCollect()
+		}
 		serverHandler, ok := info.Server.(*v1beta1.Handler)
 		if !ok {
 			return nil, errors.New("miss-configured server handler")

--- a/pkg/server/interceptors/enrich.go
+++ b/pkg/server/interceptors/enrich.go
@@ -34,9 +34,10 @@ func UnaryAPIRequestEnrich() grpc.UnaryServerInterceptor {
 
 		// add request id header to log ctx if available
 		if md, ok := metadata.FromIncomingContext(ctx); ok {
-			if values := md.Get(consts.RequestIDHeader); len(values) > 0 {
-				logger := grpczap.Extract(ctx).With(zap.String(consts.RequestIDHeader, values[0]))
-				ctx = grpczap.ToContext(ctx, logger)
+			if values := md.Get(consts.RequestIDHeader); len(values) > 0 && values[0] != "" {
+				id := values[0]
+				logger := grpczap.Extract(ctx).With(zap.String(consts.RequestIDHeader, id))
+				ctx = consts.WithRequestIDInCtx(grpczap.ToContext(ctx, logger), id)
 			}
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -174,6 +174,7 @@ func Serve(
 					consts.ProjectRequestKey:                 true,
 					consts.StripeTestClockRequestKey:         true,
 					consts.StripeWebhookSignature:            true,
+					consts.RequestIDHeader:                   true,
 				},
 			),
 		),

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/raystack/frontier/pkg/server/consts"
+
 	"github.com/raystack/frontier/core/invitation"
 
 	"github.com/raystack/frontier/pkg/webhook"
@@ -2590,6 +2592,7 @@ func (s *APIRegressionTestSuite) TestOrganizationDomainsAPI() {
 func (s *APIRegressionTestSuite) TestWebhookAPI() {
 	ctxOrgAdminAuth := metadata.NewOutgoingContext(context.Background(), metadata.New(map[string]string{
 		testbench.IdentityHeader: testbench.OrgAdminEmail,
+		consts.RequestIDHeader:   "test-request-id",
 	}))
 	s.Run("1. create and list webhooks successfully", func() {
 		createWebhookResp, err := s.testBench.AdminClient.CreateWebhook(ctxOrgAdminAuth, &frontierv1beta1.CreateWebhookRequest{


### PR DESCRIPTION
Header with name "X-Request-Id" if available in request headers will be added as field in frontier logs.