### PR TITLE
fix: invalid otp internal error

### DIFF
--- a/internal/api/v1beta1/authenticate.go
+++ b/internal/api/v1beta1/authenticate.go
@@ -139,7 +139,7 @@ func (h Handler) AuthCallback(ctx context.Context, request *frontierv1beta1.Auth
 		StateConfig: request.GetStateOptions().AsMap(),
 	})
 	if err != nil {
-		if errors.Is(err, authenticate.ErrInvalidMailOTP) || errors.Is(err, authenticate.ErrMissingOIDCCode) || errors.Is(err, authenticate.ErrInvalidOIDCState) {
+		if errors.Is(err, authenticate.ErrInvalidMailOTP) || errors.Is(err, authenticate.ErrMissingOIDCCode) || errors.Is(err, authenticate.ErrInvalidOIDCState) || errors.Is(err, authenticate.ErrFlowInvalid) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Error(codes.Internal, err.Error())

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -193,6 +194,7 @@ func filterDefaultAppNamespacePermissions(permissions []schema.ResourcePermissio
 func (s Service) MakeSuperUsers(ctx context.Context) error {
 	logger := grpczap.Extract(ctx)
 	for _, userID := range s.adminConfig.Users {
+		userID = strings.TrimSpace(userID)
 		logger.Debug("promoting user to superuser", zap.String("user_id", userID))
 		if err := s.userService.Sudo(ctx, userID, schema.AdminRelationName); err != nil {
 			return err


### PR DESCRIPTION
This PR adds the following changes.
1. Return `BadRequest` for invalid flow otp error.
2. Return `BadRequest` instead of `Internal` if the flow data is not in the table.
3. Trim user emails in the superuser bootstrap function.