### PR TITLE
fix: handle context canceled error in AuthToken handler

### DIFF
--- a/internal/api/v1beta1/authenticate.go
+++ b/internal/api/v1beta1/authenticate.go
@@ -238,11 +238,11 @@ func (h Handler) AuthToken(ctx context.Context, request *frontierv1beta1.AuthTok
 
 	token, err := h.getAccessToken(ctx, principal)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	if err := setUserContextTokenInHeaders(ctx, string(token)); err != nil {
 		logger.Error(fmt.Errorf("error setting token in context: %w", err).Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	return &frontierv1beta1.AuthTokenResponse{


### PR DESCRIPTION
This PR fix the `Internal` status code for context cancelled error in AuthToken.
Once the client cancels the request, we get context canceled in our code.
we should return the `Canceled` status code for this request. But here we are returning an `Internal` error.

we already have an [interceptor](https://github.com/raystack/frontier/blob/main/pkg/server/interceptors/errors.go#L30), which checks the following.
1. if the error is context canceled, then return `Canceled` status.
2. If the error is already a grpc error, then return as it is.
3. return everything else as an `Internal` error.

The problem is that the `AuthToken` handler already wraps the error grpc error with the status `Internal`. Thus, the interceptor is ignoring it.
This PR removes that wrapper and lets the interceptor handle that.



