### PR TITLE
fix: dont call stripe upcoming invoice if provider id not available

### DIFF
--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -311,6 +311,11 @@ func (s *Service) GetUpcoming(ctx context.Context, customerID string) (Invoice, 
 		return Invoice{}, fmt.Errorf("failed to find customer: %w", err)
 	}
 
+	if custmr.ProviderID == "" {
+		logger.Debug(fmt.Sprintf("no customer provider id found"))
+		return Invoice{}, nil
+	}
+
 	stripeInvoice, err := s.stripeClient.Invoices.Upcoming(&stripe.InvoiceUpcomingParams{
 		Customer: stripe.String(custmr.ProviderID),
 		Params: stripe.Params{


### PR DESCRIPTION
This PR will fix the issue when the upcoming invoice API is called for a customer who is on no-plan and doesn't have an account created in Stripe.

For that customer, the provider ID is empty.
We should return an empty invoice object to them instead of an error.