### PR TITLE
fix: add check for datetime operators in Org User Search API

### DIFF
--- a/internal/store/postgres/org_users_repository.go
+++ b/internal/store/postgres/org_users_repository.go
@@ -325,8 +325,11 @@ func (r OrgUsersRepository) buildHasAnyRoleSubquery(orgID string) *goqu.SelectDa
 }
 
 func (r OrgUsersRepository) buildNonRoleFilterCondition(filter rql.Filter) (goqu.Expression, error) {
+	//this list will always be a subset of all RQL supported operators
 	supportedStringOperators := []string{"eq", "neq", "like", "in", "notin", "notlike", "empty", "notempty"}
-	if !slices.Contains(supportedStringOperators, filter.Operator) {
+	supportedDateTimeOperators := []string{"eq", "neq", "gt", "lt", "gte", "lte"}
+
+	if !slices.Contains(supportedStringOperators, filter.Operator) && !slices.Contains(supportedDateTimeOperators, filter.Operator) {
 		return nil, wrapBadOperatorError(filter.Operator, filter.Name)
 	}
 


### PR DESCRIPTION
**Add datetime operator support for OrgUsersRepository filters**

Changes:
- Extended operator validation in buildNonRoleFilterCondition to support datetime operators
- Added support for comparison operators (gt, lt, gte, lte) for datetime fields
- Maintained existing string operator support while clearly separating operator types