### PR TITLE
feat: add audit logs for billing account details update and kyc update

### DIFF
--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -80,6 +80,7 @@ const (
 	OrgDisabledEvent      EventName = "app.organization.disabled"
 	OrgMemberCreatedEvent EventName = "app.organization.member.created"
 	OrgMemberDeletedEvent EventName = "app.organization.member.deleted"
+	OrgKycUpdatedEvent    EventName = "app.organization.kyc.updated"
 
 	ProjectCreatedEvent EventName = "app.project.created"
 	ProjectUpdatedEvent EventName = "app.project.updated"
@@ -88,6 +89,8 @@ const (
 	ResourceCreatedEvent EventName = "app.resource.created"
 	ResourceUpdatedEvent EventName = "app.resource.updated"
 	ResourceDeletedEvent EventName = "app.resource.deleted"
+
+	BillingAccountDetailsUpdatedEvent EventName = "app.billing.account.details.updated"
 )
 
 var systemEvents = []EventName{

--- a/internal/api/v1beta1/billing_customer.go
+++ b/internal/api/v1beta1/billing_customer.go
@@ -388,7 +388,7 @@ func (h Handler) UpdateBillingAccountDetails(ctx context.Context,
 	request *frontierv1beta1.UpdateBillingAccountDetailsRequest) (*frontierv1beta1.UpdateBillingAccountDetailsResponse, error) {
 	if request.GetDueInDays() < 0 {
 		return nil, status.Errorf(codes.FailedPrecondition,
-			"cannot create predated invoices: due in days should be greated than 0")
+			"cannot create predated invoices: due in days should be greater than 0")
 	}
 
 	details, err := h.customerService.UpdateDetails(ctx, request.GetId(), customer.Details{

--- a/internal/api/v1beta1/billing_customer.go
+++ b/internal/api/v1beta1/billing_customer.go
@@ -388,7 +388,7 @@ func (h Handler) UpdateBillingAccountDetails(ctx context.Context,
 	request *frontierv1beta1.UpdateBillingAccountDetailsRequest) (*frontierv1beta1.UpdateBillingAccountDetailsResponse, error) {
 	if request.GetDueInDays() < 0 {
 		return nil, status.Errorf(codes.FailedPrecondition,
-			"cannot create predated invoices: due in days shoule be greated than 0")
+			"cannot create predated invoices: due in days should be greated than 0")
 	}
 
 	details, err := h.customerService.UpdateDetails(ctx, request.GetId(), customer.Details{

--- a/internal/api/v1beta1/billing_customer.go
+++ b/internal/api/v1beta1/billing_customer.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/raystack/frontier/billing/customer"
+	"github.com/raystack/frontier/core/audit"
 	"github.com/raystack/frontier/pkg/metadata"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -390,13 +391,23 @@ func (h Handler) UpdateBillingAccountDetails(ctx context.Context,
 			"cannot create predated invoices: due in days shoule be greated than 0")
 	}
 
-	_, err := h.customerService.UpdateDetails(ctx, request.GetId(), customer.Details{
+	details, err := h.customerService.UpdateDetails(ctx, request.GetId(), customer.Details{
 		CreditMin: request.GetCreditMin(),
 		DueInDays: request.GetDueInDays(),
 	})
 	if err != nil {
 		return nil, err
 	}
+
+	// Add audit log
+	audit.GetAuditor(ctx, request.GetOrgId()).
+		LogWithAttrs(audit.BillingAccountDetailsUpdatedEvent, audit.Target{
+			ID:   request.GetId(),
+			Type: "billing_account",
+		}, map[string]string{
+			"credit_min":  fmt.Sprintf("%d", details.CreditMin),
+			"due_in_days": fmt.Sprintf("%d", details.DueInDays),
+		})
 
 	return &frontierv1beta1.UpdateBillingAccountDetailsResponse{}, nil
 }

--- a/internal/api/v1beta1/billing_customer_test.go
+++ b/internal/api/v1beta1/billing_customer_test.go
@@ -2,12 +2,15 @@ package v1beta1
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/raystack/frontier/billing/customer"
+	"github.com/raystack/frontier/core/audit"
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	"github.com/raystack/frontier/pkg/metadata"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -87,6 +90,118 @@ func TestHandler_GetRequestCustomerID(t *testing.T) {
 			resp, err := handler.GetRequestCustomerID(context.Background(), tt.req)
 			assert.Equal(t, tt.want, resp)
 			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestUpdateBillingAccountDetails(t *testing.T) {
+	tests := []struct {
+		name              string
+		request           *frontierv1beta1.UpdateBillingAccountDetailsRequest
+		mockGetCustomer   customer.Customer
+		mockGetError      error
+		mockUpdateDetails customer.Details
+		mockUpdateError   error
+		expectError       bool
+		expectedError     error
+	}{
+		{
+			name: "successful billing account details update",
+			request: &frontierv1beta1.UpdateBillingAccountDetailsRequest{
+				Id:        "billing-account-id",
+				CreditMin: -100,
+				DueInDays: 30,
+			},
+			mockGetCustomer: customer.Customer{
+				ID:       "billing-account-id",
+				OrgID:    "org-id",
+				State:    customer.ActiveState,
+				Name:     "Test Customer",
+				Email:    "test@example.com",
+				Metadata: metadata.Metadata{},
+			},
+			mockGetError: nil,
+			mockUpdateDetails: customer.Details{
+				CreditMin: -100,
+				DueInDays: 30,
+			},
+			mockUpdateError: nil,
+			expectError:     false,
+		},
+		{
+			name: "negative due in days error",
+			request: &frontierv1beta1.UpdateBillingAccountDetailsRequest{
+				Id:        "billing-account-id",
+				CreditMin: -100,
+				DueInDays: -1, // Negative due_in_days not allowed
+			},
+			expectError: true,
+		},
+		{
+			name: "get customer error",
+			request: &frontierv1beta1.UpdateBillingAccountDetailsRequest{
+				Id:        "billing-account-id",
+				CreditMin: -100,
+				DueInDays: 30,
+			},
+			mockGetCustomer: customer.Customer{},
+			mockGetError:    errors.New("failed to get customer"),
+			expectError:     true,
+			expectedError:   errors.New("failed to get customer"),
+		},
+		{
+			name: "update details error",
+			request: &frontierv1beta1.UpdateBillingAccountDetailsRequest{
+				Id:        "billing-account-id",
+				CreditMin: -100,
+				DueInDays: 30,
+			},
+			mockGetCustomer: customer.Customer{
+				ID:       "billing-account-id",
+				OrgID:    "org-id",
+				State:    customer.ActiveState,
+				Name:     "Test Customer",
+				Email:    "test@example.com",
+				Metadata: metadata.Metadata{},
+			},
+			mockGetError:    nil,
+			mockUpdateError: errors.New("failed to update details"),
+			expectError:     true,
+			expectedError:   errors.New("failed to update details"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCustomerService := mocks.NewCustomerService(t)
+
+			if tt.request.GetDueInDays() >= 0 {
+				mockCustomerService.EXPECT().GetByID(mock.Anything, tt.request.GetId()).
+					Return(tt.mockGetCustomer, tt.mockGetError).Maybe()
+
+				if tt.mockGetError == nil {
+					mockCustomerService.EXPECT().UpdateDetails(mock.Anything, tt.request.GetId(), mock.Anything).
+						Return(tt.mockUpdateDetails, tt.mockUpdateError).Maybe()
+				}
+			}
+
+			handler := Handler{
+				customerService: mockCustomerService,
+			}
+
+			ctx := context.Background()
+			ctx = audit.SetContextWithService(ctx, audit.NewService("test", audit.NewNoopRepository(), audit.NewNoopWebhookService()))
+
+			_, err := handler.UpdateBillingAccountDetails(ctx, tt.request)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedError != nil {
+					assert.Equal(t, tt.expectedError.Error(), err.Error())
+				}
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/api/v1beta1/kyc.go
+++ b/internal/api/v1beta1/kyc.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	"github.com/raystack/frontier/core/audit"
 	"github.com/raystack/frontier/core/kyc"
@@ -42,7 +43,7 @@ func (h Handler) SetOrganizationKyc(ctx context.Context, request *frontierv1beta
 	// Add audit log
 	audit.GetAuditor(ctx, orgKyc.OrgID).
 		LogWithAttrs(audit.OrgKycUpdatedEvent, audit.OrgTarget(orgKyc.OrgID), map[string]string{
-			"status": boolToString(orgKyc.Status),
+			"status": strconv.FormatBool(orgKyc.Status),
 			"link":   orgKyc.Link,
 		})
 
@@ -88,12 +89,4 @@ func transformOrgKycToPB(k kyc.KYC) *frontierv1beta1.OrganizationKyc {
 		CreatedAt: timestamppb.New(k.CreatedAt),
 		UpdatedAt: timestamppb.New(k.UpdatedAt),
 	}
-}
-
-// Helper function to convert boolean to string
-func boolToString(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
 }

--- a/internal/api/v1beta1/kyc_test.go
+++ b/internal/api/v1beta1/kyc_test.go
@@ -119,9 +119,9 @@ func TestSetOrganizationKyc(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, response)
-				assert.Equal(t, tt.mockResponse.OrgID, response.OrganizationKyc.OrgId)
-				assert.Equal(t, tt.mockResponse.Status, response.OrganizationKyc.Status)
-				assert.Equal(t, tt.mockResponse.Link, response.OrganizationKyc.Link)
+				assert.Equal(t, tt.mockResponse.OrgID, response.GetOrganizationKyc().GetOrgId())
+				assert.Equal(t, tt.mockResponse.Status, response.GetOrganizationKyc().GetStatus())
+				assert.Equal(t, tt.mockResponse.Link, response.GetOrganizationKyc().GetLink())
 			}
 		})
 	}

--- a/internal/api/v1beta1/kyc_test.go
+++ b/internal/api/v1beta1/kyc_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/raystack/frontier/core/audit"
 	"github.com/raystack/frontier/core/kyc"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -90,16 +91,37 @@ func TestSetOrganizationKyc(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := Handler{orgKycService: tt.mockService}
-			tt.mockService.On("SetKyc", mock.Anything, mock.Anything).Return(tt.mockResponse, tt.mockError)
-			resp, err := h.SetOrganizationKyc(context.Background(), tt.request)
+			// Setup mock behavior
+			if tt.mockError != nil {
+				tt.mockService.EXPECT().SetKyc(mock.Anything, mock.Anything).Return(kyc.KYC{}, tt.mockError)
+			} else {
+				tt.mockService.EXPECT().SetKyc(mock.Anything, mock.Anything).Return(tt.mockResponse, nil)
+			}
 
+			// Create handler with mock service
+			handler := Handler{
+				orgKycService: tt.mockService,
+			}
+
+			// Create context with audit service
+			ctx := context.Background()
+			ctx = audit.SetContextWithService(ctx, audit.NewService("test", audit.NewNoopRepository(), audit.NewNoopWebhookService()))
+
+			// Call the handler method
+			response, err := handler.SetOrganizationKyc(ctx, tt.request)
+
+			// Verify results
 			if tt.expectError {
 				assert.Error(t, err)
-				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				if tt.expectedError != nil {
+					assert.Equal(t, tt.expectedError.Error(), err.Error())
+				}
 			} else {
 				assert.NoError(t, err)
-				assert.NotNil(t, resp)
+				assert.NotNil(t, response)
+				assert.Equal(t, tt.mockResponse.OrgID, response.OrganizationKyc.OrgId)
+				assert.Equal(t, tt.mockResponse.Status, response.OrganizationKyc.Status)
+				assert.Equal(t, tt.mockResponse.Link, response.OrganizationKyc.Link)
 			}
 		})
 	}

--- a/pkg/server/interceptors/authorization.go
+++ b/pkg/server/interceptors/authorization.go
@@ -1044,9 +1044,17 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 		return handler.IsSuperUser(ctx)
 	},
 	"/raystack.frontier.v1beta1.AdminService/GetBillingAccountDetails": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
+		pbReq := req.(*frontierv1beta1.GetBillingAccountDetailsRequest)
+		if err := ensureBillingAccountBelongToOrg(ctx, handler, pbReq.GetOrgId(), pbReq.GetId()); err != nil {
+			return err
+		}
 		return handler.IsSuperUser(ctx)
 	},
 	"/raystack.frontier.v1beta1.AdminService/UpdateBillingAccountDetails": func(ctx context.Context, handler *v1beta1.Handler, req any) error {
+		pbReq := req.(*frontierv1beta1.UpdateBillingAccountDetailsRequest)
+		if err := ensureBillingAccountBelongToOrg(ctx, handler, pbReq.GetOrgId(), pbReq.GetId()); err != nil {
+			return err
+		}
 		return handler.IsSuperUser(ctx)
 	},
 	"/raystack.frontier.v1beta1.AdminService/RevertBillingUsage": func(ctx context.Context, handler *v1beta1.Handler, req any) error {


### PR DESCRIPTION
This pull request introduces new audit logging functionality for billing account updates and organization KYC updates, along with corresponding test cases and authorization enhancements. The most significant changes include the addition of audit events, integration of these events into existing handlers, and updates to tests and authorization logic to support the new functionality.

### Audit Logging Enhancements:
* Added `OrgKycUpdatedEvent` and `BillingAccountDetailsUpdatedEvent` to the `EventName` constants in `core/audit/audit.go` to support logging for organization KYC updates and billing account detail updates. [[1]](diffhunk://#diff-0bf1f762614bb3cb4dfa09ae2cc80f4125c305b90f3bdc3f2a5dca61d5e2db76R83) [[2]](diffhunk://#diff-0bf1f762614bb3cb4dfa09ae2cc80f4125c305b90f3bdc3f2a5dca61d5e2db76R92-R93)
* Integrated audit logging into the `UpdateBillingAccountDetails` and `SetOrganizationKyc` handlers to log relevant attributes such as `credit_min`, `due_in_days`, `status`, and `link`. [[1]](diffhunk://#diff-ecd00430067c9c7c08d85d288c128f32f728c58356f12e9cb983eeadd633f69fL390-R411) [[2]](diffhunk://#diff-7a1405fa3dbc5dad3e8bd1d786800efd9bd6ce983d78f59a9b156db2a3c6ccf8R42-R49)

### Test Coverage Improvements:
* Added a comprehensive test case `TestUpdateBillingAccountDetails` in `billing_customer_test.go` to validate the behavior of the `UpdateBillingAccountDetails` handler, including scenarios for successful updates, negative `due_in_days`, and service errors.
* Updated `TestSetOrganizationKyc` in `kyc_test.go` to include audit logging context and verify handler behavior with mock services.

### Authorization Enhancements:
* Enhanced authorization logic in `authorization.go` to ensure that billing account operations (`GetBillingAccountDetails` and `UpdateBillingAccountDetails`) are scoped to the correct organization.

These changes improve the system's auditability, robustness, and security by ensuring that critical updates are logged and properly authorized.