### PR TITLE
fix: make like and notlike case insensitive in User Search API

### DIFF
--- a/internal/store/postgres/user_repository.go
+++ b/internal/store/postgres/user_repository.go
@@ -658,9 +658,12 @@ func (r UserRepository) addFilter(query *goqu.SelectDataset, filter rql.Filter) 
 		return query.Where(goqu.Or(goqu.I(field).IsNull(), goqu.I(field).Eq("")))
 	case "notempty":
 		return query.Where(goqu.And(goqu.I(field).IsNotNull(), goqu.I(field).Neq("")))
-	case "like", "notlike":
+	case "like":
 		value := "%" + filter.Value.(string) + "%"
-		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: value}})
+		return query.Where(goqu.Ex{field: goqu.Op{"ilike": value}})
+	case "notlike":
+		value := "%" + filter.Value.(string) + "%"
+		return query.Where(goqu.Ex{field: goqu.Op{"notilike": value}})
 	default:
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: filter.Value}})
 	}

--- a/internal/store/postgres/user_repository_test.go
+++ b/internal/store/postgres/user_repository_test.go
@@ -651,7 +651,7 @@ func TestUserRepository_PrepareDataQuery(t *testing.T) {
 				Offset: 10,
 				Limit:  20,
 			},
-			wantSQL:    `SELECT "id", "name", "email", "state", "avatar", "title", "created_at", "updated_at" FROM "users" WHERE (("CAST(users"."id AS TEXT)" = $1) AND ("users"."state" LIKE $2) AND (("users"."email" IS NULL) OR ("users"."email" = $3)) AND ((CAST("id" AS TEXT) ILIKE $4) OR ("title" ILIKE $5) OR ("name" ILIKE $6) OR ("state" ILIKE $7))) ORDER BY "name" ASC, "created_at" DESC LIMIT $8 OFFSET $9`,
+			wantSQL:    `SELECT "id", "name", "email", "state", "avatar", "title", "created_at", "updated_at" FROM "users" WHERE (("CAST(users"."id AS TEXT)" = $1) AND ("users"."state" ILIKE $2) AND (("users"."email" IS NULL) OR ("users"."email" = $3)) AND ((CAST("id" AS TEXT) ILIKE $4) OR ("title" ILIKE $5) OR ("name" ILIKE $6) OR ("state" ILIKE $7))) ORDER BY "name" ASC, "created_at" DESC LIMIT $8 OFFSET $9`,
 			wantParams: []interface{}{int64(123), "%active%", "", "%john%", "%john%", "%john%", "%john%", int64(20), int64(10)},
 		},
 		{


### PR DESCRIPTION
## Description

- Make user search filter case insensitive by using postgres ilike/notilike operators                                                                                                                        
  - Improves UX by allowing case-insensitive text matching when filtering users                                                                                                                                  

## Testing                                                                                                                                                                             
  - Test user search with mixed case input matches users regardless of case                                                                                                                                      
  - Verify notlike operator also works case-insensitively                                                                                                                                                        
 - Check existing test cases pass with updated SQL queries