### PR TITLE
feat: create invoices for zero credit overdraft billing accounts

### DIFF
--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -517,7 +517,7 @@ func (s *Service) GenerateForCredits(ctx context.Context) error {
 			errs = append(errs, fmt.Errorf("failed to get balance for customer %s: %w", c.ID, err))
 			continue
 		}
-		if balance >= 0 {
+		if balance > 0 {
 			continue
 		}
 

--- a/sdks/js/packages/core/react/components/organization/billing/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/billing/index.tsx
@@ -137,7 +137,7 @@ export default function Billing() {
         const resp = await client?.frontierServiceListInvoices(
           organizationId,
           billingId,
-          { nonzero_amount_only: true }
+          {}
         );
         const newInvoices = resp?.data?.invoices || [];
         setInvoices(newInvoices);


### PR DESCRIPTION
- [x] Create overdraft invoices for billing accounts even if usage is zero.
- [x] Show zero value invoices in sdk billing page.