### PR TITLE
fix (sidebar): resize handle visible when collapse/expand is disabled

### DIFF
--- a/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
@@ -89,7 +89,7 @@ export const Sidebar = () => {
   );
 
   return (
-    <SidebarComponent open={true} className={styles.sidebarWrapper} disableResize>
+    <SidebarComponent open={true} className={styles.sidebarWrapper} collapsible={false}>
       <div className={styles.scrollArea}>
         <Flex direction="column" gap={4} style={{ marginTop: '64px' }}>
           <Search

--- a/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
@@ -2,7 +2,7 @@ import {
   Image,
   Sidebar as SidebarComponent,
   Flex,
-  InputField
+  Search
 } from '@raystack/apsara/v1';
 import { Link, useRouteContext, useRouterState } from '@tanstack/react-router';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -10,8 +10,6 @@ import organization from '~/react/assets/organization.png';
 import user from '~/react/assets/user.png';
 import { getOrganizationNavItems, getUserNavItems } from './helpers';
 
-// @ts-ignore
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { usePermissions } from '~/react/hooks/usePermissions';
 import { PERMISSIONS, shouldShowComponent } from '~/utils';
 import styles from './sidebar.module.css';
@@ -93,8 +91,8 @@ export const Sidebar = () => {
   return (
     <SidebarComponent open={true} className={styles.sidebarWrapper} disableResize>
       <div className={styles.scrollArea}>
-        <Flex direction="column" gap={7} style={{ marginTop: '40px' }}>
-          <InputField
+        <Flex direction="column" gap={4} style={{ marginTop: '64px' }}>
+          {/* <InputField
             size="large"
             leadingIcon={
               <MagnifyingGlassIcon
@@ -104,7 +102,18 @@ export const Sidebar = () => {
             placeholder="Search"
             onChange={event => setSearch(event.target.value)}
             data-test-id="frontier-sdk-sidebar-search-field"
+          /> */}
+
+          <Search
+            size="large"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            placeholder="Search pages"
+            showClearButton
+            onClear={() => setSearch('')}
+            data-test-id="frontier-sdk-sidebar-search-field"
           />
+
           <SidebarComponent.Main>
             <SidebarComponent.Group
               name="Organization"

--- a/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
@@ -91,7 +91,7 @@ export const Sidebar = () => {
   );
 
   return (
-    <SidebarComponent open={true} className={styles.sidebarWrapper}>
+    <SidebarComponent open={true} className={styles.sidebarWrapper} disableResize>
       <div className={styles.scrollArea}>
         <Flex direction="column" gap={7} style={{ marginTop: '40px' }}>
           <InputField

--- a/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/sidebar/index.tsx
@@ -92,18 +92,6 @@ export const Sidebar = () => {
     <SidebarComponent open={true} className={styles.sidebarWrapper} disableResize>
       <div className={styles.scrollArea}>
         <Flex direction="column" gap={4} style={{ marginTop: '64px' }}>
-          {/* <InputField
-            size="large"
-            leadingIcon={
-              <MagnifyingGlassIcon
-                style={{ color: 'var(--rs-color-foreground-base-primary)' }}
-              />
-            }
-            placeholder="Search"
-            onChange={event => setSearch(event.target.value)}
-            data-test-id="frontier-sdk-sidebar-search-field"
-          /> */}
-
           <Search
             size="large"
             value={search}


### PR DESCRIPTION
fix (Sidebar): Resize handle visible even though Sidebar is not collapsible
fix (Sidebar): Sidebar Search top margin
refactor (Sidebar): Replace Inputfield with Search and add clear button

**Note: Merge this PR after [PR-428](https://github.com/raystack/apsara/pull/428) is merged and released.**