### PR TITLE
feat: setup connect rpc for admin ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,12 +8,16 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "@connectrpc/connect-query": "^1.4.2",
+        "@connectrpc/connect-web": "^1.6.1",
         "@hookform/resolvers": "^3.0.1",
         "@radix-ui/react-form": "^0.0.2",
         "@radix-ui/react-icons": "^1.3.0",
-        "@raystack/apsara": "^0.48.3",
-        "@raystack/frontier": "^0.66.0",
+        "@raystack/apsara": "^0.48.5",
+        "@raystack/frontier": "^0.68.0",
+        "@raystack/proton": "^0.1.0-09b6d3e7c1e4b03bb30db032380c04e0524ac701",
         "@stitches/react": "^1.2.8",
+        "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-table": "^8.9.3",
         "@tanstack/table-core": "^8.21.3",
         "axios": "^1.8.4",
@@ -331,6 +335,43 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ=="
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.6.1.tgz",
+      "integrity": "sha512-KchMDNtU4CDTdkyf0qG7ugJ6qHTOR/aI7XebYn3OTCNagaDYWiZUVKgRgwH79yeMkpNgvEUaXSK7wKjaBK9b/Q==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-query": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-query/-/connect-query-1.4.2.tgz",
+      "integrity": "sha512-ZjBLtaGoBPDMtdRu4KiX7KpSigifiZiVaenhXHUsmNRjLj9r4OxQM+O2OqvTQ1YJhP4/h1xL+HX7YB0gcQ0FoA==",
+      "dependencies": {
+        "stable-hash": "^0.0.4"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "^1.1.2",
+        "@tanstack/react-query": "5.x",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.6.1.tgz",
+      "integrity": "sha512-GVfxQOmt3TtgTaKeXLS/EA2IHa3nHxwe2BCHT7X0Q/0hohM+nP5DDnIItGEjGrGdt3LTTqWqE4s70N4h+qIMlQ==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.6.1"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -672,6 +713,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ=="
+    },
+    "node_modules/@protobuf-ts/runtime-rpc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5141,9 +5195,9 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
     "node_modules/@raystack/apsara": {
-      "version": "0.48.3",
-      "resolved": "https://registry.npmjs.org/@raystack/apsara/-/apsara-0.48.3.tgz",
-      "integrity": "sha512-cUBU/JYqBTgHIHY8VWPKtsPo+Fc9ouC3aF1q6/QOQzhJK8NQVvqcDd5DQ1CAkK2PD2mGT3WnoniDufz90PXqgg==",
+      "version": "0.48.5",
+      "resolved": "https://registry.npmjs.org/@raystack/apsara/-/apsara-0.48.5.tgz",
+      "integrity": "sha512-UJM1mgqtY7WphnI0uZNDofjCmtpV6OGfjO5JEBfBTUI+aRfJ1YLWFDP7d+S8c2qZxc9wvupyrvqGWRJB+jMxeQ==",
       "dependencies": {
         "@ariakit/react": "^0.4.16",
         "@radix-ui/react-icons": "^1.3.0",
@@ -5163,9 +5217,9 @@
       }
     },
     "node_modules/@raystack/frontier": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@raystack/frontier/-/frontier-0.66.0.tgz",
-      "integrity": "sha512-E7XVBUIa3P65f14pYyGosuqKIneSOG73W+LuQTcKb08v2VL7ISV+29iH6u54rcciGY8eTQVUKDl9/pxNZOjrIA==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@raystack/frontier/-/frontier-0.68.0.tgz",
+      "integrity": "sha512-vdWfjc4pvEZYKEmaozqtSuxguIvw9csz4loNjrQFA8SB+nTH7pHjXVlBU1MEpmiIE8NQC9WijBjpps/qvYoWlw==",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-router": "1.58.17",
@@ -5196,6 +5250,26 @@
           "optional": true
         },
         "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@raystack/proton": {
+      "version": "0.1.0-09b6d3e7c1e4b03bb30db032380c04e0524ac701",
+      "resolved": "https://registry.npmjs.org/@raystack/proton/-/proton-0.1.0-09b6d3e7c1e4b03bb30db032380c04e0524ac701.tgz",
+      "integrity": "sha512-jYjhPF5Vd/HeWxCht4nKPMlf81FRgq7/PIteyD1kf/WvSa/djR2lQEZME2OiwC/wQGbdDg0UBpwqBvynhYZFQg==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.6.0",
+        "@connectrpc/connect": "^1.2.0",
+        "@connectrpc/connect-query": "^1.2.0",
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-query": {
           "optional": true
         }
       }
@@ -5539,6 +5613,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
+      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
+      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {
@@ -7766,9 +7864,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
-      "integrity": "sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7797,15 +7895,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-zaKdLBftQJnvb7FtDIpZtsAIb2MZU087RM8bRDZU8LVCCFYjPTsDZJNFUWPcVz3HFSN1n/caxi0ca4B/aaVQGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.1"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.3.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-hook-form": {
@@ -8208,6 +8306,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
+      "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g=="
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5775,7 +5775,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -6458,7 +6458,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -7226,7 +7226,7 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7511,7 +7511,7 @@
     },
     "node_modules/postcss": {
       "version": "8.4.31",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8139,7 +8139,7 @@
     },
     "node_modules/rollup": {
       "version": "3.29.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -8291,7 +8291,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8524,7 +8524,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8669,7 +8669,7 @@
       "version": "4.5.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
       "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,12 +11,16 @@
     "build:client": "node scripts/gen-swagger-client.mjs"
   },
   "dependencies": {
+    "@connectrpc/connect-query": "^1.4.2",
+    "@connectrpc/connect-web": "^1.6.1",
     "@hookform/resolvers": "^3.0.1",
     "@radix-ui/react-form": "^0.0.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "^0.48.5",
     "@raystack/frontier": "^0.68.0",
+    "@raystack/proton": "^0.1.0-09b6d3e7c1e4b03bb30db032380c04e0524ac701",
     "@stitches/react": "^1.2.8",
+    "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-table": "^8.9.3",
     "@tanstack/table-core": "^8.21.3",
     "axios": "^1.8.4",

--- a/ui/src/components/Sidebar/index.tsx
+++ b/ui/src/components/Sidebar/index.tsx
@@ -8,7 +8,8 @@ import {
   Text,
   useTheme,
 } from "@raystack/apsara/v1";
-import { api } from "~/api";
+import { useMutation } from "@connectrpc/connect-query";
+import { FrontierServiceQueries } from "@raystack/proton/frontier";
 
 import styles from "./sidebar.module.css";
 import { OrganizationIcon } from "@raystack/apsara/icons";
@@ -170,12 +171,12 @@ export default function IAMSidebar() {
 function UserDropdown() {
   const { user } = useContext(AppContext);
   const { theme, setTheme } = useTheme();
-
-  async function logout() {
-    await api?.frontierServiceAuthLogout();
-    window.location.href = "/";
-    window.location.reload();
-  }
+  const logoutMutation = useMutation(FrontierServiceQueries.authLogout, {
+    onSuccess: () => {
+      window.location.href = "/";
+      window.location.reload();
+    },
+  });
 
   const toggleTheme = () => {
     if (theme === "dark") {
@@ -209,7 +210,7 @@ function UserDropdown() {
           data-test-id="admin-ui-toggle-theme">
           {themeData.icon} {themeData.label}
         </DropdownMenu.Item>
-        <DropdownMenu.Item onClick={logout} data-test-id="admin-ui-logout-btn">
+        <DropdownMenu.Item onClick={() => logoutMutation.mutate({})} data-test-id="admin-ui-logout-btn">
           Logout
         </DropdownMenu.Item>
       </DropdownMenu.Content>

--- a/ui/src/components/states/Unauthorized.tsx
+++ b/ui/src/components/states/Unauthorized.tsx
@@ -1,13 +1,15 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { Button, EmptyState, Flex } from "@raystack/apsara/v1";
-import { api } from "~/api";
+import { useMutation } from "@connectrpc/connect-query";
+import { FrontierServiceQueries } from "@raystack/proton/frontier";
 
 export default function UnauthorizedState() {
-  async function logout() {
-    await api?.frontierServiceAuthLogout();
-    window.location.href = "/";
-    window.location.reload();
-  }
+  const logoutMutation = useMutation(FrontierServiceQueries.authLogout, {
+    onSuccess: () => {
+      window.location.href = "/";
+      window.location.reload();
+    },
+  });
   return (
     <Flex style={{ height: "100vh" }}>
       <EmptyState
@@ -16,7 +18,7 @@ export default function UnauthorizedState() {
         subHeading="You dont have access to view this page"
         primaryAction={
           <Button
-            onClick={logout}
+            onClick={() => logoutMutation.mutate({})}
             data-test-id="admin-ui-unauthorized-screen-logout-btn"
           >
             Logout

--- a/ui/src/contexts/ConnectProvider.tsx
+++ b/ui/src/contexts/ConnectProvider.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TransportProvider } from "@connectrpc/connect-query";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { ReactNode } from "react";
+
+const frontierConnectEndpoint = process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL || "/frontier-connect";
+
+// Create the transport for Connect RPC
+const transport = createConnectTransport({
+  baseUrl: frontierConnectEndpoint,
+  useBinaryFormat: false,
+  interceptors: [],
+});
+
+// Create a QueryClient instance
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 2,
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000, // 5 minutes
+    },
+  },
+});
+
+interface ConnectProviderProps {
+  children: ReactNode;
+}
+
+export function ConnectProvider({ children }: ConnectProviderProps) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>
+        {children}
+      </TransportProvider>
+    </QueryClientProvider>
+  );
+}
+
+export { queryClient };

--- a/ui/src/contexts/ConnectProvider.tsx
+++ b/ui/src/contexts/ConnectProvider.tsx
@@ -16,9 +16,8 @@ const transport = createConnectTransport({
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 2,
+      retry: false,
       refetchOnWindowFocus: false,
-      staleTime: 5 * 60 * 1000, // 5 minutes
     },
   },
 });

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from "react-router-dom";
 
 import Routes from "./routes";
 import { AppContextProvider } from "./contexts/App";
+import { ConnectProvider } from "./contexts/ConnectProvider";
 import { themeConfig } from "~/configs/theme";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
@@ -16,10 +17,12 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
           highlightColor="var(--rs-color-background-base-primary)"
           baseColor="var(--rs-color-background-base-primary-hover)"
         >
-          <AppContextProvider>
-            <Routes />
-          </AppContextProvider>
-          <ToastContainer richColors />
+          <ConnectProvider>
+            <AppContextProvider>
+              <Routes />
+            </AppContextProvider>
+            <ToastContainer richColors />
+          </ConnectProvider>
         </SkeletonTheme>
       </ThemeProvider>
     </BrowserRouter>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig(() => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/frontier-api/, ""),
         },
+        "/frontier-connect": {
+          target: process.env.FRONTIER_CONNECTRPC_URL,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/frontier-connect/, ""),
+        },
       },
       fs: {
         // Allow serving files from one level up to the project root


### PR DESCRIPTION
This PR sets up the RPC for the admin UI.
This is making 2 major changes.

### 1. UI
In UI, we are adding connect-query and the raytack proton package.
We are updating the GetOrganization and AuthLogout API to use connect RPC calls.
The admin UI will need 2 endpoints to connect to the backend. 
- one for REST server
- another one for Connect Server.

Vite will proxy both API while developing locally.

### 2. Backend
We are adding 1 more proxy in serveUI. This will proxy all the calls coming from the admin UI to the connect port.