### PR TITLE
feat(sdk): setup connect query and migrate authn calls

### DIFF
--- a/sdks/js/packages/core/hooks/index.ts
+++ b/sdks/js/packages/core/hooks/index.ts
@@ -1,0 +1,5 @@
+// Re-export Connect Query hooks for convenience
+export { useQuery, useMutation, useInfiniteQuery } from '@connectrpc/connect-query';
+
+// Re-export Frontier service queries for convenience  
+export { FrontierServiceQueries } from '@raystack/proton/frontier';

--- a/sdks/js/packages/core/package.json
+++ b/sdks/js/packages/core/package.json
@@ -52,6 +52,12 @@
       "module": "./react/dist/index.mjs",
       "require": "./react/dist/index.js"
     },
+    "./hooks": {
+      "types": "./hooks/dist/index.d.ts",
+      "import": "./hooks/dist/index.mjs",
+      "module": "./hooks/dist/index.mjs",
+      "require": "./hooks/dist/index.js"
+    },
     "./api-client": {
       "types": "./api-client/dist/index.d.ts",
       "import": "./api-client/dist/index.mjs",

--- a/sdks/js/packages/core/package.json
+++ b/sdks/js/packages/core/package.json
@@ -91,7 +91,7 @@
     "@connectrpc/connect-query": "^2.1.1",
     "@connectrpc/connect-web": "^2.0.2",
     "@hookform/resolvers": "^3.10.0",
-    "@raystack/proton": "0.1.0-35dd68d487bfa7e7339c40e9b103ee7377aac6e6",
+    "@raystack/proton": "0.1.0-881c92a4cab2490e6c680462a94660b551b1040f",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "1.58.17",
     "axios": "^1.9.0",

--- a/sdks/js/packages/core/react/components/onboarding/signin.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signin.tsx
@@ -30,13 +30,15 @@ export const SignIn = ({
   );
   const strategies = strategiesData?.strategies || [];
 
-  const authenticateMutation = useMutation(FrontierServiceQueries.authenticate);
+  const { mutateAsync: authenticate } = useMutation(
+    FrontierServiceQueries.authenticate
+  );
 
   const clickHandler = useCallback(
     async (name?: string) => {
       if (!name) return;
       try {
-        const response = await authenticateMutation.mutateAsync({
+        const response = await authenticate({
           strategyName: name,
           callbackUrl: config.callbackUrl
         });
@@ -47,7 +49,7 @@ export const SignIn = ({
         console.error('Authentication failed:', error);
       }
     },
-    [authenticateMutation, config.callbackUrl]
+    [authenticate, config.callbackUrl]
   );
 
   const mailotp = strategies.find(s => s.name === 'mailotp');

--- a/sdks/js/packages/core/react/components/onboarding/signin.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signin.tsx
@@ -1,6 +1,8 @@
 import { Link, Text, Flex } from '@raystack/apsara/v1';
 import React, { ComponentPropsWithRef, useCallback } from 'react';
 import { useFrontier } from '~/react/contexts/FrontierContext';
+import { useQuery } from '@connectrpc/connect-query';
+import { FrontierServiceQueries } from '@raystack/proton/frontier';
 import { Container } from '../Container';
 import { Header } from '../Header';
 import { MagicLink } from './magiclink';
@@ -22,7 +24,12 @@ export const SignIn = ({
   footer = true,
   ...props
 }: SignedInProps) => {
-  const { config, client, strategies = [] } = useFrontier();
+  const { config, client } = useFrontier();
+
+  const { data: strategiesData } = useQuery(
+    FrontierServiceQueries.listAuthStrategies
+  );
+  const strategies = strategiesData?.strategies || [];
 
   const clickHandler = useCallback(
     async (name?: string) => {
@@ -46,7 +53,7 @@ export const SignIn = ({
   return (
     <Container {...props}>
       <Header logo={logo} title={title} />
-      <Flex direction="column" style={{ width: '100%', gap: 'var(--rs-space-5)' }}>
+      <Flex direction="column" width="full" gap={5}>
         {filteredOIDC.map((s, index) => {
           return (
             <OIDCButton

--- a/sdks/js/packages/core/react/components/onboarding/signin.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signin.tsx
@@ -1,8 +1,7 @@
 import { Link, Text, Flex } from '@raystack/apsara/v1';
 import React, { ComponentPropsWithRef, useCallback } from 'react';
 import { useFrontier } from '~/react/contexts/FrontierContext';
-import { useQuery, useMutation } from '@connectrpc/connect-query';
-import { FrontierServiceQueries } from '@raystack/proton/frontier';
+import { useQuery, useMutation, FrontierServiceQueries } from '~hooks';
 import { Container } from '../Container';
 import { Header } from '../Header';
 import { MagicLink } from './magiclink';

--- a/sdks/js/packages/core/react/components/onboarding/signup.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signup.tsx
@@ -28,13 +28,15 @@ export const SignUp = ({
   );
   const strategies = strategiesData?.strategies || [];
 
-  const authenticateMutation = useMutation(FrontierServiceQueries.authenticate);
+  const { mutateAsync: authenticate } = useMutation(
+    FrontierServiceQueries.authenticate
+  );
 
   const clickHandler = useCallback(
     async (name?: string) => {
       if (!name) return;
       try {
-        const response = await authenticateMutation.mutateAsync({
+        const response = await authenticate({
           strategyName: name,
           callbackUrl: config.callbackUrl
         });
@@ -45,7 +47,7 @@ export const SignUp = ({
         console.error('Authentication failed:', error);
       }
     },
-    [authenticateMutation, config.callbackUrl]
+    [authenticate, config.callbackUrl]
   );
 
   const mailotp = strategies.find(s => s.name === 'mailotp');

--- a/sdks/js/packages/core/react/components/onboarding/signup.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signup.tsx
@@ -8,6 +8,8 @@ import { OIDCButton } from './oidc';
 
 // @ts-ignore
 import styles from './onboarding.module.css';
+import { FrontierServiceQueries } from '@raystack/proton/frontier';
+import { useQuery } from '@connectrpc/connect-query';
 
 type SignUpProps = ComponentPropsWithRef<typeof Container> & {
   logo?: React.ReactNode;
@@ -20,8 +22,12 @@ export const SignUp = ({
   excludes = [],
   ...props
 }: SignUpProps) => {
-  const { config } = useFrontier();
-  const { client, strategies = [] } = useFrontier();
+  const { config, client } = useFrontier();
+
+  const { data: strategiesData } = useQuery(
+    FrontierServiceQueries.listAuthStrategies
+  );
+  const strategies = strategiesData?.strategies || [];
 
   const clickHandler = useCallback(
     async (name?: string) => {
@@ -47,7 +53,7 @@ export const SignUp = ({
   return (
     <Container {...props}>
       <Header logo={logo} title={title} />
-      <Flex direction="column" gap={3} style={{ width: '100%' }}>
+      <Flex direction="column" gap={3} width="full">
         {filteredOIDC.map((s, index) => {
           return (
             <OIDCButton

--- a/sdks/js/packages/core/react/components/onboarding/signup.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signup.tsx
@@ -1,6 +1,7 @@
 import { Link, Text, Flex } from '@raystack/apsara/v1';
 import React, { ComponentPropsWithRef, useCallback } from 'react';
 import { useFrontier } from '~/react/contexts/FrontierContext';
+import { useQuery, useMutation, FrontierServiceQueries } from '~hooks';
 import { Container } from '../Container';
 import { Header } from '../Header';
 import { MagicLink } from './magiclink';
@@ -8,8 +9,6 @@ import { OIDCButton } from './oidc';
 
 // @ts-ignore
 import styles from './onboarding.module.css';
-import { FrontierServiceQueries } from '@raystack/proton/frontier';
-import { useQuery, useMutation } from '@connectrpc/connect-query';
 
 type SignUpProps = ComponentPropsWithRef<typeof Container> & {
   logo?: React.ReactNode;

--- a/sdks/js/packages/core/react/components/onboarding/signup.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/signup.tsx
@@ -9,7 +9,7 @@ import { OIDCButton } from './oidc';
 // @ts-ignore
 import styles from './onboarding.module.css';
 import { FrontierServiceQueries } from '@raystack/proton/frontier';
-import { useQuery } from '@connectrpc/connect-query';
+import { useQuery, useMutation } from '@connectrpc/connect-query';
 
 type SignUpProps = ComponentPropsWithRef<typeof Container> & {
   logo?: React.ReactNode;
@@ -22,27 +22,31 @@ export const SignUp = ({
   excludes = [],
   ...props
 }: SignUpProps) => {
-  const { config, client } = useFrontier();
+  const { config } = useFrontier();
 
   const { data: strategiesData } = useQuery(
     FrontierServiceQueries.listAuthStrategies
   );
   const strategies = strategiesData?.strategies || [];
 
+  const authenticateMutation = useMutation(FrontierServiceQueries.authenticate);
+
   const clickHandler = useCallback(
     async (name?: string) => {
       if (!name) return;
-      if (!client) return;
-
-      const {
-        data: { endpoint = '' }
-      } = await client.frontierServiceAuthenticate(name, {
-        callback_url: config.callbackUrl
-      });
-
-      window.location.href = endpoint;
+      try {
+        const response = await authenticateMutation.mutateAsync({
+          strategyName: name,
+          callbackUrl: config.callbackUrl
+        });
+        if (response.endpoint) {
+          window.location.href = response.endpoint;
+        }
+      } catch (error) {
+        console.error('Authentication failed:', error);
+      }
     },
-    [client, config.callbackUrl]
+    [authenticateMutation, config.callbackUrl]
   );
 
   const mailotp = strategies.find(s => s.name === 'mailotp');

--- a/sdks/js/packages/core/react/contexts/FrontierContext.tsx
+++ b/sdks/js/packages/core/react/contexts/FrontierContext.tsx
@@ -25,7 +25,7 @@ import {
   V1Beta1Plan,
   V1Beta1Subscription,
   V1Beta1User,
-  V1Beta1BillingAccountDetails,
+  V1Beta1BillingAccountDetails
 } from '../../api-client/data-contracts';
 import {
   getActiveSubscription,
@@ -49,9 +49,6 @@ interface FrontierContextProviderProps {
 
   groups: V1Beta1Group[];
   setGroups: Dispatch<SetStateAction<V1Beta1Group[]>>;
-
-  strategies: V1Beta1AuthStrategy[];
-  setStrategies: Dispatch<SetStateAction<V1Beta1AuthStrategy[]>>;
 
   user: V1Beta1User | undefined;
   setUser: Dispatch<SetStateAction<V1Beta1User | undefined>>;
@@ -103,13 +100,17 @@ interface FrontierContextProviderProps {
   basePlan?: V1Beta1Plan;
 
   organizationKyc: V1Beta1OrganizationKyc | undefined;
-  setOrganizationKyc: Dispatch<SetStateAction<V1Beta1OrganizationKyc | undefined>>;
+  setOrganizationKyc: Dispatch<
+    SetStateAction<V1Beta1OrganizationKyc | undefined>
+  >;
 
   isOrganizationKycLoading: boolean;
   setIsOrganizationKycLoading: Dispatch<SetStateAction<boolean>>;
 
   billingDetails: V1Beta1BillingAccountDetails | undefined;
-  setBillingDetails: Dispatch<SetStateAction<V1Beta1BillingAccountDetails | undefined>>;
+  setBillingDetails: Dispatch<
+    SetStateAction<V1Beta1BillingAccountDetails | undefined>
+  >;
 }
 
 const defaultConfig: FrontierClientOptions = {
@@ -137,9 +138,6 @@ const initialValues: FrontierContextProviderProps = {
 
   groups: [],
   setGroups: () => undefined,
-
-  strategies: [],
-  setStrategies: () => undefined,
 
   user: undefined,
   setUser: () => undefined,
@@ -191,7 +189,7 @@ const initialValues: FrontierContextProviderProps = {
   setIsOrganizationKycLoading: () => false,
 
   billingDetails: undefined,
-  setBillingDetails: () => undefined,
+  setBillingDetails: () => undefined
 };
 
 export const FrontierContext =
@@ -225,14 +223,14 @@ export const FrontierContextProvider = ({
 
   const [organizations, setOrganizations] = useState<V1Beta1Organization[]>([]);
   const [groups, setGroups] = useState<V1Beta1Group[]>([]);
-  const [strategies, setStrategies] = useState<V1Beta1AuthStrategy[]>([]);
   const [user, setUser] = useState<V1Beta1User>();
 
   const [isUserLoading, setIsUserLoading] = useState(false);
 
   const [billingAccount, setBillingAccount] = useState<V1Beta1BillingAccount>();
   const [paymentMethod, setPaymentMethod] = useState<V1Beta1PaymentMethod>();
-  const [billingDetails, setBillingDetails] = useState<V1Beta1BillingAccountDetails>();
+  const [billingDetails, setBillingDetails] =
+    useState<V1Beta1BillingAccountDetails>();
   const [isBillingAccountLoading, setIsBillingAccountLoading] = useState(false);
 
   const [isActiveSubscriptionLoading, setIsActiveSubscriptionLoading] =
@@ -254,25 +252,10 @@ export const FrontierContextProvider = ({
 
   const [basePlan, setBasePlan] = useState<V1Beta1Plan>();
 
-  const [organizationKyc, setOrganizationKyc] = useState<V1Beta1OrganizationKyc>();
-  const [isOrganizationKycLoading, setIsOrganizationKycLoading] = useState(false);
-
-
-  useEffect(() => {
-    async function getFrontierInformation() {
-      try {
-        const {
-          data: { strategies = [] }
-        } = await frontierClient.frontierServiceListAuthStrategies();
-        setStrategies(strategies);
-      } catch (error) {
-        console.error(
-          'frontier:sdk:: There is problem with fetching auth strategies'
-        );
-      }
-    }
-    getFrontierInformation();
-  }, []);
+  const [organizationKyc, setOrganizationKyc] =
+    useState<V1Beta1OrganizationKyc>();
+  const [isOrganizationKycLoading, setIsOrganizationKycLoading] =
+    useState(false);
 
   useEffect(() => {
     async function getFrontierCurrentUser() {
@@ -465,23 +448,30 @@ export const FrontierContextProvider = ({
     }
   }, [config?.billing?.basePlan]);
 
-  const fetchOrganizationKyc = useCallback(async (orgId: string) => {
-    try {
-      setIsOrganizationKycLoading(true);
-      const resp = await frontierClient.frontierServiceGetOrganizationKyc(orgId);
-      setOrganizationKyc(resp?.data?.organization_kyc);
-    } catch (err: unknown) {
-      if (err instanceof AxiosError && err.response?.status === 404) {
-        console.warn("frontier:sdk:: org kyc details not found");
-        setOrganizationKyc({ org_id: orgId, status: false, link: '' });
-      } else {
-        console.error('frontier:sdk:: There is problem with fetching org kyc');
-        console.error(err);
+  const fetchOrganizationKyc = useCallback(
+    async (orgId: string) => {
+      try {
+        setIsOrganizationKycLoading(true);
+        const resp = await frontierClient.frontierServiceGetOrganizationKyc(
+          orgId
+        );
+        setOrganizationKyc(resp?.data?.organization_kyc);
+      } catch (err: unknown) {
+        if (err instanceof AxiosError && err.response?.status === 404) {
+          console.warn('frontier:sdk:: org kyc details not found');
+          setOrganizationKyc({ org_id: orgId, status: false, link: '' });
+        } else {
+          console.error(
+            'frontier:sdk:: There is problem with fetching org kyc'
+          );
+          console.error(err);
+        }
+      } finally {
+        setIsOrganizationKycLoading(false);
       }
-    } finally {
-      setIsOrganizationKycLoading(false);
-    }
-  }, [frontierClient, activeOrganization?.id]);
+    },
+    [frontierClient, activeOrganization?.id]
+  );
 
   useEffect(() => {
     if (activeOrganization?.id) {
@@ -502,8 +492,6 @@ export const FrontierContextProvider = ({
         setOrganizations,
         groups,
         setGroups,
-        strategies,
-        setStrategies,
         user,
         setUser,
         activeOrganization,
@@ -537,7 +525,7 @@ export const FrontierContextProvider = ({
         isOrganizationKycLoading,
         setIsOrganizationKycLoading,
         billingDetails,
-        setBillingDetails,
+        setBillingDetails
       }}
     >
       {children}

--- a/sdks/js/packages/core/react/contexts/FrontierProvider.tsx
+++ b/sdks/js/packages/core/react/contexts/FrontierProvider.tsx
@@ -2,20 +2,35 @@ import { ThemeProvider } from '@raystack/apsara/v1';
 import { FrontierProviderProps } from '../../shared/types';
 import { FrontierContextProvider } from './FrontierContext';
 import { withMaxAllowedInstancesGuard } from './useMaxAllowedInstancesGuard';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TransportProvider } from '@connectrpc/connect-query';
+import { createConnectTransport } from '@connectrpc/connect-web';
+import { useMemo } from 'react';
 
 export const multipleFrontierProvidersError =
   "Frontier: You've added multiple <FrontierProvider> components in your React component tree. Wrap your components in a single <FrontierProvider>.";
 
+const queryClient = new QueryClient();
+
 export const FrontierProvider = (props: FrontierProviderProps) => {
   const { children, initialState, config, theme, ...options } = props;
+  
+  const transport = useMemo(() => createConnectTransport({
+    baseUrl: config.connectEndpoint || '/frontier-connect',
+  }), [config.connectEndpoint]);
+  
   return (
-    <FrontierContextProvider
-      initialState={initialState}
-      config={config}
-      {...options}
-    >
-      <ThemeProvider {...theme}>{children}</ThemeProvider>
-    </FrontierContextProvider>
+    <QueryClientProvider client={queryClient}>
+      <TransportProvider transport={transport}>
+        <FrontierContextProvider
+          initialState={initialState}
+          config={config}
+          {...options}
+        >
+          <ThemeProvider {...theme}>{children}</ThemeProvider>
+        </FrontierContextProvider>
+      </TransportProvider>
+    </QueryClientProvider>
   );
 };
 FrontierProvider.displayName = 'FrontierProvider';

--- a/sdks/js/packages/core/shared/types.ts
+++ b/sdks/js/packages/core/shared/types.ts
@@ -21,6 +21,7 @@ export interface FrontierClientAPIPlatformOptions {
 
 export interface FrontierClientOptions {
   endpoint: string;
+  connectEndpoint?: string;
   redirectSignup?: string;
   redirectLogin?: string;
   redirectMagicLinkVerify?: string;

--- a/sdks/js/packages/core/tsconfig.json
+++ b/sdks/js/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@raystack/frontier-tsconfig/react-library.json",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "paths": {
       "~/*": ["./*"]
     },

--- a/sdks/js/packages/core/tsconfig.json
+++ b/sdks/js/packages/core/tsconfig.json
@@ -3,10 +3,11 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "paths": {
-      "~/*": ["./*"]
+      "~/*": ["./*"],
+      "~hooks": ["./hooks/index.ts"]
     },
     "types": ["jest"]
   },
   "include": ["."],
-  "exclude": ["dist", "react/dist", "node_modules"]
+  "exclude": ["dist", "react/dist", "hooks/dist", "node_modules"]
 }

--- a/sdks/js/packages/core/tsup.config.ts
+++ b/sdks/js/packages/core/tsup.config.ts
@@ -24,6 +24,17 @@ export default defineConfig(() => [
     },
     esbuildPlugins: [cssModulesPlugin()]
   },
+  // Hooks APIs
+  {
+    entry: ['hooks/index.ts'],
+    outDir: 'hooks/dist',
+    banner: {
+      js: "'use client'"
+    },
+    format: ['cjs', 'esm'],
+    external: ['react'],
+    dts: true
+  },
   {
     entry: ['api-client/index.ts'],
     format: ['cjs', 'esm'],

--- a/sdks/js/packages/sdk-demo/src/pages/Home.tsx
+++ b/sdks/js/packages/sdk-demo/src/pages/Home.tsx
@@ -1,14 +1,16 @@
 import AuthContext from '@/contexts/auth';
 import { Button, Flex } from '@raystack/apsara/v1';
 import { useFrontier } from '@raystack/frontier/react';
+import { useMutation, FrontierServiceQueries } from '@raystack/frontier/hooks';
 import { Link, useNavigate } from 'react-router-dom';
 import { useContext, useEffect } from 'react';
-import frontierClient from '@/api/frontier';
 
 export default function Home() {
   const { isAuthorized } = useContext(AuthContext);
   const { organizations } = useFrontier();
   const navigate = useNavigate();
+
+  const logoutMutation = useMutation(FrontierServiceQueries.authLogout);
 
   useEffect(() => {
     if (!isAuthorized) {
@@ -17,9 +19,11 @@ export default function Home() {
   }, [isAuthorized, navigate]);
 
   async function logout() {
-    const resp = await frontierClient?.frontierServiceAuthLogout();
-    if (resp?.status === 200) {
+    try {
+      await logoutMutation.mutateAsync({});
       window.location.reload();
+    } catch (error) {
+      console.error('Logout failed:', error);
     }
   }
 

--- a/sdks/js/packages/sdk-demo/vite.config.ts
+++ b/sdks/js/packages/sdk-demo/vite.config.ts
@@ -5,6 +5,8 @@ import path from 'path';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const frontierUrl = env.FRONTIER_ENDPOINT || 'http://localhost:8080';
+  const frontierConnectUrl =
+    env.FRONTIER_CONNECT_ENDPOINT || 'http://localhost:8080';
 
   return {
     plugins: [react()],
@@ -20,6 +22,11 @@ export default defineConfig(({ mode }) => {
           target: frontierUrl,
           changeOrigin: true,
           rewrite: path => path.replace(/^\/api/, '')
+        },
+        '/frontier-connect': {
+          target: frontierConnectUrl,
+          changeOrigin: true,
+          rewrite: path => path.replace(/^\/frontier-connect/, '')
         }
       }
     }

--- a/sdks/js/pnpm-lock.yaml
+++ b/sdks/js/pnpm-lock.yaml
@@ -35,16 +35,16 @@ importers:
     dependencies:
       '@connectrpc/connect-query':
         specifier: ^2.1.1
-        version: 2.1.1(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.1.1(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@connectrpc/connect-web':
         specifier: ^2.0.2
-        version: 2.0.2(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))
+        version: 2.0.2(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.57.0(react@18.3.1))
       '@raystack/proton':
-        specifier: 0.1.0-35dd68d487bfa7e7339c40e9b103ee7377aac6e6
-        version: 0.1.0-35dd68d487bfa7e7339c40e9b103ee7377aac6e6(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.1.0-881c92a4cab2490e6c680462a94660b551b1040f
+        version: 0.1.0-881c92a4cab2490e6c680462a94660b551b1040f(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.83.0
         version: 5.83.0(react@18.3.1)
@@ -494,8 +494,8 @@ packages:
   '@biomejs/wasm-nodejs@2.0.0-beta.6':
     resolution: {integrity: sha512-UI8uhz8YUjROBqr8OX3M8aK5Dw+MQfpE3D8sODCoE1CHH/4lvYdYksO/hU6qUe7qOYTI/Dyf2/DOQA5XRvRtAg==}
 
-  '@bufbuild/protobuf@1.10.1':
-    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
+  '@bufbuild/protobuf@2.6.2':
+    resolution: {integrity: sha512-vLu7SRY84CV/Dd+NUdgtidn2hS5hSMUC1vDBY0VcviTdgRYkU43vIz3vIFbmx14cX1r+mM7WjzE5Fl1fGEM0RQ==}
 
   '@changesets/apply-release-plan@6.1.4':
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
@@ -556,15 +556,6 @@ packages:
       '@connectrpc/connect': ^2.0.1
       '@tanstack/query-core': '>=5.62.0'
 
-  '@connectrpc/connect-query@1.4.2':
-    resolution: {integrity: sha512-ZjBLtaGoBPDMtdRu4KiX7KpSigifiZiVaenhXHUsmNRjLj9r4OxQM+O2OqvTQ1YJhP4/h1xL+HX7YB0gcQ0FoA==}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.10.0
-      '@connectrpc/connect': ^1.1.2
-      '@tanstack/react-query': 5.x
-      react: ^18.3.1
-      react-dom: ^18.3.1
-
   '@connectrpc/connect-query@2.1.1':
     resolution: {integrity: sha512-tDSEJ8J2FV9NsAl8z/e9MrbgeauOw45As/FUfiPpzm64aB+JfeQVXnqThS4ueB6fHfoKDHMxUtaQ7xx7oRCX3Q==}
     peerDependencies:
@@ -580,10 +571,10 @@ packages:
       '@bufbuild/protobuf': ^2.2.0
       '@connectrpc/connect': 2.0.2
 
-  '@connectrpc/connect@1.6.1':
-    resolution: {integrity: sha512-KchMDNtU4CDTdkyf0qG7ugJ6qHTOR/aI7XebYn3OTCNagaDYWiZUVKgRgwH79yeMkpNgvEUaXSK7wKjaBK9b/Q==}
+  '@connectrpc/connect@2.0.3':
+    resolution: {integrity: sha512-jAbVMHVtDCydGt2P20VpmLjbLtERqSV0RMSyQF3k2zhK8pzQ2QaCAcyVhufClqrOAFZUKL5BqVYtttaxvhmRgg==}
     peerDependencies:
-      '@bufbuild/protobuf': ^1.10.0
+      '@bufbuild/protobuf': ^2.2.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2104,8 +2095,8 @@ packages:
     resolution: {integrity: sha512-UJM1mgqtY7WphnI0uZNDofjCmtpV6OGfjO5JEBfBTUI+aRfJ1YLWFDP7d+S8c2qZxc9wvupyrvqGWRJB+jMxeQ==}
     engines: {node: '>=18'}
 
-  '@raystack/proton@0.1.0-35dd68d487bfa7e7339c40e9b103ee7377aac6e6':
-    resolution: {integrity: sha512-uP5AfxGceYeRh0T0zkOZUUnJel7NexY0eQUIxjyhZrK2DVqz7dkYy/kn2e5RmWw50gn3zsuglXueLi8FQecnkw==}
+  '@raystack/proton@0.1.0-881c92a4cab2490e6c680462a94660b551b1040f':
+    resolution: {integrity: sha512-UawStxGaThAzN8sQ43bIw2PO8HUAI7C1mdBevE1w+tdEryd5v5RR0cIg3ah+BrrRTY6iLSU/FTmH5IxEZ3oWNA==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -6485,9 +6476,6 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
-  stable-hash@0.0.4:
-    resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
-
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -7649,7 +7637,7 @@ snapshots:
 
   '@biomejs/wasm-nodejs@2.0.0-beta.6': {}
 
-  '@bufbuild/protobuf@1.10.1': {}
+  '@bufbuild/protobuf@2.6.2': {}
 
   '@changesets/apply-release-plan@6.1.4':
     dependencies:
@@ -7800,40 +7788,31 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
-  '@connectrpc/connect-query-core@2.1.1(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@tanstack/query-core@5.83.0)':
+  '@connectrpc/connect-query-core@2.1.1(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))(@tanstack/query-core@5.83.0)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.1
-      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.1)
+      '@bufbuild/protobuf': 2.6.2
+      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.2)
       '@tanstack/query-core': 5.83.0
 
-  '@connectrpc/connect-query@1.4.2(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@connectrpc/connect-query@2.1.1(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.1
-      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.1)
-      '@tanstack/react-query': 5.83.0(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      stable-hash: 0.0.4
-
-  '@connectrpc/connect-query@2.1.1(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@bufbuild/protobuf': 1.10.1
-      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.1)
-      '@connectrpc/connect-query-core': 2.1.1(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@tanstack/query-core@5.83.0)
+      '@bufbuild/protobuf': 2.6.2
+      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.2)
+      '@connectrpc/connect-query-core': 2.1.1(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))(@tanstack/query-core@5.83.0)
       '@tanstack/react-query': 5.83.0(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@tanstack/query-core'
 
-  '@connectrpc/connect-web@2.0.2(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))':
+  '@connectrpc/connect-web@2.0.2(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))':
     dependencies:
-      '@bufbuild/protobuf': 1.10.1
-      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.1)
+      '@bufbuild/protobuf': 2.6.2
+      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.2)
 
-  '@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1)':
+  '@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.1
+      '@bufbuild/protobuf': 2.6.2
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -9369,16 +9348,17 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@raystack/proton@0.1.0-35dd68d487bfa7e7339c40e9b103ee7377aac6e6(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@raystack/proton@0.1.0-881c92a4cab2490e6c680462a94660b551b1040f(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.1
-      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.1)
-      '@connectrpc/connect-query': 1.4.2(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@bufbuild/protobuf': 2.6.2
+      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.2)
+      '@connectrpc/connect-query': 2.1.1(@bufbuild/protobuf@2.6.2)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.2))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
     optionalDependencies:
       '@tanstack/react-query': 5.83.0(react@18.3.1)
     transitivePeerDependencies:
+      - '@tanstack/query-core'
       - react
       - react-dom
 
@@ -14634,8 +14614,6 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
-
-  stable-hash@0.0.4: {}
 
   stack-utils@2.0.6:
     dependencies:


### PR DESCRIPTION
This PR sets up the connect-rpc client with [connect-query](https://github.com/connectrpc/connect-query-es) (wrapper of react-query).
The method definitions are coming from the `@raystack/proton/frontier` package.
The  `@raystack/proton/frontier` package is TypeScript code generated from the https://github.com/raystack/proton repo.

Following methods are migrated to connect-rpc method instead of fetch calls.
  1. ListAuthStrategies
  2. Authenticate
  3. AuthCallback
  4. GetOrganization
  5. AuthLogout

This PR also added `/hooks` entry path in `@raystack/frontier`, which exports the connect-query hooks and frontier service methods, so the consumer apps don't need to install `@raystack/proton` and `@connectrpc/connect-query` packages and just use the export from `@raystack/frontier/hooks`

The SDK demo app is also updated to use this. A proxy from `/frontier-connect` to the Frontier Connect server is also added in the Vite config.