### PR TITLE
fix(sdk): validation message when number of tokens to be added is left empty

### DIFF
--- a/sdks/js/packages/core/react/components/organization/tokens/add-tokens.tsx
+++ b/sdks/js/packages/core/react/components/organization/tokens/add-tokens.tsx
@@ -35,11 +35,11 @@ export const AddTokens = () => {
     .object({
       tokens: yup
         .number()
-        .required()
+        .required("Please enter valid number")
         .min(minQuantity, `Minimum ${minQuantity} token is required`)
         .max(maxQuantity, `Maximum ${maxQuantity} tokens are allowed`)
+        .typeError('Please enter valid number of tokens')
     })
-    .typeError('Please enter a valid number')
     .required();
 
   type FormData = yup.InferType<typeof tokensSchema>;


### PR DESCRIPTION
This pull request makes a small update to the validation logic for adding tokens in the `AddTokens` component. The main change is to provide more specific and user-friendly error messages for invalid token inputs.

- Improved error messaging for invalid token input in the `AddTokens` form, ensuring users see clearer instructions when entering an incorrect value.