### PR TITLE
fix(sdk): update search bar placeholders to match the table column name

### DIFF
--- a/sdks/js/packages/core/react/components/organization/project/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/project/index.tsx
@@ -153,7 +153,7 @@ const ProjectsTable = ({
             {isLoading ? (
                 <Skeleton height='34px' width='500px' />
             ) : (
-              <DataTable.Search placeholder="Search by name " size="medium" />
+              <DataTable.Search placeholder="Search by title " size="medium" />
             )}
             {canListOrgProjects ? (
               <Select

--- a/sdks/js/packages/core/react/components/organization/teams/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/teams/index.tsx
@@ -155,7 +155,7 @@ const TeamsTable = ({
             {isLoading ? (
               <Skeleton height='34px' width='500px' />
             ) : (
-              <DataTable.Search placeholder="Search by name " size="medium" />
+              <DataTable.Search placeholder="Search by title" size="medium" />
             )}
             {canListOrgGroups ? (
               <Select


### PR DESCRIPTION
This pull request makes a minor update to the search placeholders in the organization projects and teams tables, improving clarity by changing "Search by name" to "Search by title".

- UI Text Consistency:
  * Updated the `DataTable.Search` placeholder in `ProjectsTable` to "Search by title" for clearer intent. (`sdks/js/packages/core/react/components/organization/project/index.tsx`)
  * Updated the `DataTable.Search` placeholder in `TeamsTable` to "Search by title" for consistency with the projects table. (`sdks/js/packages/core/react/components/organization/teams/index.tsx`)