### PR TITLE
fix(sdk): pass credentials to connect query fetch

### DIFF
--- a/sdks/js/packages/core/react/contexts/FrontierProvider.tsx
+++ b/sdks/js/packages/core/react/contexts/FrontierProvider.tsx
@@ -11,6 +11,13 @@ import { useMemo } from 'react';
 export const multipleFrontierProvidersError =
   "Frontier: You've added multiple <FrontierProvider> components in your React component tree. Wrap your components in a single <FrontierProvider>.";
 
+const fetchWithCreds: typeof fetch = (input, init) => {
+  return fetch(input, {
+    ...init,
+    credentials: 'include'
+  });
+};
+
 const queryClient = new QueryClient();
 
 export const FrontierProvider = (props: FrontierProviderProps) => {
@@ -19,7 +26,8 @@ export const FrontierProvider = (props: FrontierProviderProps) => {
   const transport = useMemo(
     () =>
       createConnectTransport({
-        baseUrl: config.connectEndpoint || '/frontier-connect'
+        baseUrl: config.connectEndpoint || '/frontier-connect',
+        fetch: fetchWithCreds
       }),
     [config.connectEndpoint]
   );


### PR DESCRIPTION
This PR adds a custom fetch to transport in connect-query.
Custom fetch is needed to pass credentials in the api calls as mentioned [here](https://github.com/connectrpc/connect-es/blob/main/packages/connect-web/src/connect-transport.ts#L110)