### PR TITLE
fix: return status unauthenticated for service user with disabled org

### DIFF
--- a/internal/api/v1beta1/authenticate.go
+++ b/internal/api/v1beta1/authenticate.go
@@ -289,6 +289,14 @@ func (h Handler) getAccessToken(ctx context.Context, principal authenticate.Prin
 			return nil, err
 		}
 
+		// For service users, ensure their organization is not disabled
+		// ListByUser filters out disabled organizations, so empty list means disabled org
+		if principal.Type == schema.ServiceUserPrincipal && len(orgs) == 0 {
+			logger.Info("service user authentication failed: organization is disabled",
+				zap.String("service_user_id", principal.ID))
+			return nil, errors.ErrUnauthenticated
+		}
+
 		var orgIds []string
 		for _, o := range orgs {
 			orgIds = append(orgIds, o.ID)

--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -183,6 +183,14 @@ func (h *ConnectHandler) getAccessToken(ctx context.Context, principal authentic
 			return nil, err
 		}
 
+		// For service users, ensure their organization is not disabled
+		// ListByUser filters out disabled organizations, so empty list means disabled org
+		if principal.Type == schema.ServiceUserPrincipal && len(orgs) == 0 {
+			logger.Info("service user authentication failed: organization is disabled",
+				zap.String("service_user_id", principal.ID))
+			return nil, errors.ErrUnauthenticated
+		}
+
 		var orgIds []string
 		for _, o := range orgs {
 			orgIds = append(orgIds, o.ID)


### PR DESCRIPTION
Fix: Prevent service user authentication when organization is disabled

 Problem:
  Service users could successfully authenticate and generate access tokens even when their associated organization was disabled. The GetPrincipal() method validated service user credentials but didn't check organization state.

  Root Cause:
  - Service user authentication in GetPrincipal() only validated credentials, not organization state
  - getAccessToken() called orgService.ListByUser() which filtered disabled organizations, but still generated tokens with empty org claims

  Solution:
  Added organization state validation in getAccessToken() method for service users:

  - After calling orgService.ListByUser(), check if principal is a service user and organization list is empty
  - Empty list indicates disabled organization (since ListByUser filters disabled orgs via notDisabledOrgExp)
  - Return ErrUnauthenticated to prevent token generation when organization is disabled

  Files Changed:
  - internal/api/v1beta1/authenticate.go - Added validation in getAccessToken()
  - internal/api/v1beta1connect/authenticate.go - Added validation in getAccessToken()
