### PR TITLE
fix: remove extra `$` from org variable

### DIFF
--- a/sdks/js/packages/core/react/components/organization/general/delete.tsx
+++ b/sdks/js/packages/core/react/components/organization/general/delete.tsx
@@ -66,7 +66,7 @@ export const DeleteOrganization = () => {
       <Dialog.Content overlayClassName={styles.overlay} width={600}>
         <Dialog.Header>
           <Dialog.Title>
-            Verify ${t.organization({ case: 'lower' })} deletion
+            Verify {t.organization({ case: 'lower' })} deletion
           </Dialog.Title>
           <Dialog.CloseButton
             onClick={() => navigate({ to: '/' })}


### PR DESCRIPTION
This PR removes the extra `$` from the organization terminology variable.
It happened due to confusion between JS literals and JSX string variables. 
