### PR TITLE
fix: add check for disable org for service users in AuthToken Calls.

### DIFF
--- a/internal/api/v1beta1/authenticate.go
+++ b/internal/api/v1beta1/authenticate.go
@@ -238,6 +238,15 @@ func (h Handler) AuthToken(ctx context.Context, request *frontierv1beta1.AuthTok
 		return nil, err
 	}
 
+	if principal.Type == schema.ServiceUserPrincipal {
+		orgId := principal.ServiceUser.OrgID
+		_, err := h.orgService.Get(ctx, orgId)
+		if err != nil {
+			logger.Error(fmt.Errorf("error while fetching service user org: %w", err).Error())
+			return nil, err
+		}
+	}
+
 	token, err := h.getAccessToken(ctx, principal)
 	if err != nil {
 		logger.Debug(fmt.Sprintf("unable to get accessToken: %v", err))

--- a/internal/api/v1beta1/authenticate_test.go
+++ b/internal/api/v1beta1/authenticate_test.go
@@ -135,15 +135,13 @@ func TestHandler_Authenticate(t *testing.T) {
 }
 
 func TestHandler_AuthToken_ServiceUser(t *testing.T) {
-	expectedErr := errors.New("Internal error")
-	
 	tests := []struct {
-		name            string
-		setup           func(authn *mocks.AuthnService, org *mocks.OrganizationService)
-		request         *frontierv1beta1.AuthTokenRequest
-		want            *frontierv1beta1.AuthTokenResponse
-		wantErr         bool
-		expectedErr     error
+		name        string
+		setup       func(authn *mocks.AuthnService, org *mocks.OrganizationService)
+		request     *frontierv1beta1.AuthTokenRequest
+		want        *frontierv1beta1.AuthTokenResponse
+		wantErr     bool
+		expectedErr error
 	}{
 		{
 			name: "should return error when service user org is disabled",
@@ -166,42 +164,10 @@ func TestHandler_AuthToken_ServiceUser(t *testing.T) {
 				org.EXPECT().Get(mock.Anything, orgID).Return(
 					organization.Organization{}, organization.ErrDisabled)
 			},
-			request: &frontierv1beta1.AuthTokenRequest{},
+			request:     &frontierv1beta1.AuthTokenRequest{},
 			wantErr:     true,
 			expectedErr: organization.ErrDisabled,
 			want:        nil,
-		},
-		{
-			name: "should pass org check when service user org is enabled",
-			setup: func(authn *mocks.AuthnService, org *mocks.OrganizationService) {
-				orgID := "test-org-id"
-				serviceUserID := "test-service-user-id"
-				expectedToken := []byte("test-access-token")
-
-				authn.EXPECT().GetPrincipal(mock.Anything,
-					authenticate.SessionClientAssertion,
-					authenticate.ClientCredentialsClientAssertion,
-					authenticate.JWTGrantClientAssertion).Return(authenticate.Principal{
-					ID:   serviceUserID,
-					Type: schema.ServiceUserPrincipal,
-					ServiceUser: &serviceuser.ServiceUser{
-						ID:    serviceUserID,
-						OrgID: orgID,
-					},
-				}, nil)
-
-				org.EXPECT().Get(mock.Anything, orgID).Return(
-					organization.Organization{
-						ID:    orgID,
-						State: organization.Enabled,
-					}, nil)
-
-				authn.EXPECT().BuildToken(mock.Anything, mock.AnythingOfType("authenticate.Principal"), mock.AnythingOfType("map[string]string")).Return(expectedToken, nil)
-			},
-			request: &frontierv1beta1.AuthTokenRequest{},
-			want:        nil,
-			wantErr:     true,
-			expectedErr: expectedErr,
 		},
 	}
 
@@ -212,7 +178,7 @@ func TestHandler_AuthToken_ServiceUser(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(mockAuthnSrv, mockOrgSrv)
 			}
-			
+
 			handler := Handler{
 				authnService: mockAuthnSrv,
 				orgService:   mockOrgSrv,
@@ -226,7 +192,7 @@ func TestHandler_AuthToken_ServiceUser(t *testing.T) {
 			}
 
 			resp, err := handler.AuthToken(context.Background(), tt.request)
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.expectedErr != nil {

--- a/internal/api/v1beta1/authenticate_test.go
+++ b/internal/api/v1beta1/authenticate_test.go
@@ -205,8 +205,8 @@ func TestHandler_AuthToken_ServiceUser(t *testing.T) {
 				assert.Nil(t, resp)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.want.AccessToken, resp.AccessToken)
-				assert.Equal(t, tt.want.TokenType, resp.TokenType)
+				assert.Equal(t, tt.want.GetAccessToken(), resp.GetAccessToken())
+				assert.Equal(t, tt.want.GetTokenType(), resp.GetTokenType())
 			}
 		})
 	}

--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -156,6 +156,15 @@ func (h *ConnectHandler) AuthToken(ctx context.Context, request *connect.Request
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
+	if principal.Type == schema.ServiceUserPrincipal {
+		orgId := principal.ServiceUser.OrgID
+		_, err := h.orgService.Get(ctx, orgId)
+		if err != nil {
+			logger.Error(fmt.Sprintf("error while fetching service user org: %v", err))
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+	}
+
 	token, err := h.getAccessToken(ctx, principal, request.Header().Values(consts.ProjectRequestKey))
 	if err != nil {
 		logger.Debug(fmt.Sprintf("unable to get accessToken: %v", err))

--- a/internal/api/v1beta1connect/authenticate_test.go
+++ b/internal/api/v1beta1connect/authenticate_test.go
@@ -18,12 +18,12 @@ import (
 
 func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 	tests := []struct {
-		name            string
-		setup           func(authn *mocks.AuthnService, org *mocks.OrganizationService)
-		request         *connect.Request[frontierv1beta1.AuthTokenRequest]
-		want            *connect.Response[frontierv1beta1.AuthTokenResponse]
-		wantErr         bool
-		expectedErr     error
+		name        string
+		setup       func(authn *mocks.AuthnService, org *mocks.OrganizationService)
+		request     *connect.Request[frontierv1beta1.AuthTokenRequest]
+		want        *connect.Response[frontierv1beta1.AuthTokenResponse]
+		wantErr     bool
+		expectedErr error
 	}{
 		{
 			name: "should return error when service user org is disabled",
@@ -46,7 +46,7 @@ func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 				org.EXPECT().Get(mock.Anything, orgID).Return(
 					organization.Organization{}, organization.ErrDisabled)
 			},
-			request: connect.NewRequest(&frontierv1beta1.AuthTokenRequest{}),
+			request:     connect.NewRequest(&frontierv1beta1.AuthTokenRequest{}),
 			wantErr:     true,
 			expectedErr: organization.ErrDisabled,
 			want:        nil,
@@ -95,7 +95,7 @@ func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(mockAuthnSrv, mockOrgSrv)
 			}
-			
+
 			handler := &ConnectHandler{
 				authnService: mockAuthnSrv,
 				orgService:   mockOrgSrv,
@@ -111,7 +111,7 @@ func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 			logger := zap.NewNop()
 			ctx := context.WithValue(context.Background(), "logger", logger)
 			resp, err := handler.AuthToken(ctx, tt.request)
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.expectedErr != nil {

--- a/internal/api/v1beta1connect/authenticate_test.go
+++ b/internal/api/v1beta1connect/authenticate_test.go
@@ -1,0 +1,136 @@
+package v1beta1connect
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/authenticate"
+	"github.com/raystack/frontier/core/organization"
+	"github.com/raystack/frontier/core/serviceuser"
+	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	"github.com/raystack/frontier/internal/bootstrap/schema"
+	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(authn *mocks.AuthnService, org *mocks.OrganizationService)
+		request         *connect.Request[frontierv1beta1.AuthTokenRequest]
+		want            *connect.Response[frontierv1beta1.AuthTokenResponse]
+		wantErr         bool
+		expectedErr     error
+	}{
+		{
+			name: "should return error when service user org is disabled",
+			setup: func(authn *mocks.AuthnService, org *mocks.OrganizationService) {
+				orgID := "test-org-id"
+				serviceUserID := "test-service-user-id"
+
+				authn.EXPECT().GetPrincipal(mock.Anything,
+					authenticate.SessionClientAssertion,
+					authenticate.ClientCredentialsClientAssertion,
+					authenticate.JWTGrantClientAssertion).Return(authenticate.Principal{
+					ID:   serviceUserID,
+					Type: schema.ServiceUserPrincipal,
+					ServiceUser: &serviceuser.ServiceUser{
+						ID:    serviceUserID,
+						OrgID: orgID,
+					},
+				}, nil)
+
+				org.EXPECT().Get(mock.Anything, orgID).Return(
+					organization.Organization{}, organization.ErrDisabled)
+			},
+			request: connect.NewRequest(&frontierv1beta1.AuthTokenRequest{}),
+			wantErr:     true,
+			expectedErr: organization.ErrDisabled,
+			want:        nil,
+		},
+		{
+			name: "should return token when service user org is enabled",
+			setup: func(authn *mocks.AuthnService, org *mocks.OrganizationService) {
+				orgID := "test-org-id"
+				serviceUserID := "test-service-user-id"
+				expectedToken := []byte("test-access-token")
+
+				authn.EXPECT().GetPrincipal(mock.Anything,
+					authenticate.SessionClientAssertion,
+					authenticate.ClientCredentialsClientAssertion,
+					authenticate.JWTGrantClientAssertion).Return(authenticate.Principal{
+					ID:   serviceUserID,
+					Type: schema.ServiceUserPrincipal,
+					ServiceUser: &serviceuser.ServiceUser{
+						ID:    serviceUserID,
+						OrgID: orgID,
+					},
+				}, nil)
+
+				org.EXPECT().Get(mock.Anything, orgID).Return(
+					organization.Organization{
+						ID:    orgID,
+						State: organization.Enabled,
+					}, nil)
+
+				authn.EXPECT().BuildToken(mock.Anything, mock.AnythingOfType("authenticate.Principal"), mock.AnythingOfType("map[string]string")).Return(expectedToken, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.AuthTokenRequest{}),
+			want: connect.NewResponse(&frontierv1beta1.AuthTokenResponse{
+				AccessToken: "test-access-token",
+				TokenType:   "Bearer",
+			}),
+			wantErr:     false,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAuthnSrv := new(mocks.AuthnService)
+			mockOrgSrv := new(mocks.OrganizationService)
+			if tt.setup != nil {
+				tt.setup(mockAuthnSrv, mockOrgSrv)
+			}
+			
+			handler := &ConnectHandler{
+				authnService: mockAuthnSrv,
+				orgService:   mockOrgSrv,
+				authConfig: authenticate.Config{
+					Token: authenticate.TokenConfig{
+						Claims: authenticate.TokenClaimConfig{
+							AddOrgIDsClaim: false,
+						},
+					},
+				},
+			}
+
+			logger := zap.NewNop()
+			ctx := context.WithValue(context.Background(), "logger", logger)
+			resp, err := handler.AuthToken(ctx, tt.request)
+			
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					if tt.expectedErr == organization.ErrDisabled {
+						connectErr := err.(*connect.Error)
+						assert.Equal(t, connect.CodeInternal, connectErr.Code())
+						assert.Contains(t, connectErr.Message(), "org is disabled")
+					} else {
+						connectErr := err.(*connect.Error)
+						assert.Equal(t, connect.CodeInternal, connectErr.Code())
+					}
+				}
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, tt.want.Msg.AccessToken, resp.Msg.AccessToken)
+				assert.Equal(t, tt.want.Msg.TokenType, resp.Msg.TokenType)
+			}
+		})
+	}
+}

--- a/internal/api/v1beta1connect/authenticate_test.go
+++ b/internal/api/v1beta1connect/authenticate_test.go
@@ -128,8 +128,8 @@ func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, resp)
-				assert.Equal(t, tt.want.Msg.AccessToken, resp.Msg.AccessToken)
-				assert.Equal(t, tt.want.Msg.TokenType, resp.Msg.TokenType)
+				assert.Equal(t, tt.want.Msg.GetAccessToken(), resp.Msg.GetAccessToken())
+				assert.Equal(t, tt.want.Msg.GetTokenType(), resp.Msg.GetTokenType())
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a check for disabled org in AuthToken Calls for service users.

A normal user can exist without any org, and their token can have no org IDs.
But a service user belongs to only one organization, and if an organization is disabled, then all auth token calls for its service users should fail.