### PR TITLE
fix(sdk): use Org URL instead of name in delete form

### DIFF
--- a/sdks/js/packages/core/react/components/organization/general/delete.tsx
+++ b/sdks/js/packages/core/react/components/organization/general/delete.tsx
@@ -44,7 +44,7 @@ export const DeleteOrganization = () => {
     if (!organization?.id) return;
     if (data.name !== organization.name)
       return setError('name', {
-        message: `${t.organization({ case: 'lower' })} name is not same`
+        message: `The ${t.organization({ case: 'lower' })} URL is not same`
       });
 
     try {
@@ -82,15 +82,15 @@ export const DeleteOrganization = () => {
                 <b>{organization?.title}</b>.
               </Text>
               <InputField
-                label={`Please type name of the ${t.organization({
+                label={`Please type the URL of the ${t.organization({
                   case: 'lower'
                 })} to confirm.`}
                 size="large"
                 error={errors.name && String(errors.name?.message)}
                 {...register('name')}
-                placeholder={`Provide ${t.organization({
+                placeholder={`Provide the ${t.organization({
                   case: 'lower'
-                })} name`}
+                })} URL`}
               />
             </Flex>
           </Dialog.Body>
@@ -102,7 +102,7 @@ export const DeleteOrganization = () => {
                 data-test-id="frontier-sdk-delete-organization-checkbox"
               />
               <Text size="small">
-                I acknowledge I understand that all of the{' '}
+                I acknowledge and understand that all of the{' '}
                 {t.organization({ case: 'lower' })} data will be deleted and
                 want to proceed.
               </Text>

--- a/sdks/js/packages/core/react/components/organization/members/invite.tsx
+++ b/sdks/js/packages/core/react/components/organization/members/invite.tsx
@@ -157,7 +157,10 @@ export const InviteMember = () => {
               ) : (
                 <TextArea
                   label="Email"
+                  required
                   {...register('emails')}
+                  //  TODO: Fix placeholder prop in apsara TextAreaProps
+                  //  @ts-expect-error placeholder prop exists on textarea but not in apsara TextAreaProps type definition
                   placeholder="Enter comma separated emails like abc@domain.com, bcd@domain.com"
                   error={Boolean(errors.emails?.message)}
                   helperText={


### PR DESCRIPTION
This PR updates the `organization name` to `organization URL` in the delete form.
We are already using `organization URL` everywhere; this will make it consistent.

This PR also fixes some grammatical issues in the delete form text.
In the invite member modal, the emails field is required, but the Label shows (optional). This PR also fixes that.
