### PR TITLE
feat: support multiple reverts on same transaction

### DIFF
--- a/billing/credit/credit.go
+++ b/billing/credit/credit.go
@@ -72,6 +72,7 @@ type Filter struct {
 	CustomerID string
 	StartRange time.Time
 	EndRange   time.Time
+	Metadata   metadata.Metadata
 }
 
 func TxUUID(tags ...string) string {

--- a/billing/usage/service.go
+++ b/billing/usage/service.go
@@ -69,6 +69,8 @@ func (s Service) Revert(ctx context.Context, customerID, usageID string, amount 
 	}
 
 	reversedTxTillNow, err := s.creditService.List(ctx, credit.Filter{
+		CustomerID: customerID,
+		StartRange: creditTx.CreatedAt,
 		Metadata: metadata.FromString(map[string]string{
 			"revert_request_using": creditTx.ID,
 		}),

--- a/billing/usage/service.go
+++ b/billing/usage/service.go
@@ -63,6 +63,11 @@ func (s Service) Revert(ctx context.Context, customerID, usageID string, amount 
 		return ErrRevertAmountExceeds
 	}
 
+	// a revert can't be reverted
+	if strings.HasPrefix(creditTx.Source, credit.SourceSystemRevertEvent) {
+		return ErrExistingRevertedUsage
+	}
+
 	reversedTxTillNow, err := s.creditService.List(ctx, credit.Filter{
 		Metadata: metadata.FromString(map[string]string{
 			"revert_request_using": creditTx.ID,
@@ -82,10 +87,6 @@ func (s Service) Revert(ctx context.Context, customerID, usageID string, amount 
 		return ErrRevertAmountExceeds
 	}
 
-	// a revert can't be reverted
-	if strings.HasPrefix(creditTx.Source, credit.SourceSystemRevertEvent) {
-		return ErrExistingRevertedUsage
-	}
 	revertMeta := creditTx.Metadata
 	revertMeta["revert_request_using"] = creditTx.ID
 

--- a/internal/store/postgres/billing_transactions_repository.go
+++ b/internal/store/postgres/billing_transactions_repository.go
@@ -321,6 +321,11 @@ func (r BillingTransactionRepository) List(ctx context.Context, filter credit.Fi
 			"created_at": goqu.Op{"lte": filter.EndRange},
 		})
 	}
+	if len(filter.Metadata) != 0 {
+		for k, v := range filter.Metadata {
+			stmt = stmt.Where(goqu.L("metadata->>? = ?", k, v))
+		}
+	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", parseErr, err)


### PR DESCRIPTION
This approach does not use any locks/transactions, instead relies on creating a chain of revert transactions for the original transaction.