### PR TITLE
feat: enforce json name in connect RPC response

### DIFF
--- a/pkg/server/codecs.go
+++ b/pkg/server/codecs.go
@@ -16,16 +16,16 @@ var (
 	ErrNotProto = fmt.Errorf("error not proto")
 )
 
-// conectCodec implements https://pkg.go.dev/github.com/bufbuild/connect-go#Codec
+// connectCodec implements https://pkg.go.dev/github.com/bufbuild/connect-go#Codec
 // by overriding the default implementation with extra option: protojson.MarshalOptions{UseProtoNames: true}
-type conectCodec struct {
+type connectCodec struct {
 }
 
-func (c conectCodec) Name() string {
+func (c connectCodec) Name() string {
 	return jsonCodec
 }
 
-func (c conectCodec) Marshal(message any) ([]byte, error) {
+func (c connectCodec) Marshal(message any) ([]byte, error) {
 	protoMessage, ok := message.(proto.Message)
 	if !ok {
 		return nil, ErrNotProto
@@ -33,7 +33,7 @@ func (c conectCodec) Marshal(message any) ([]byte, error) {
 	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(protoMessage)
 }
 
-func (c conectCodec) Unmarshal(binary []byte, message any) error {
+func (c connectCodec) Unmarshal(binary []byte, message any) error {
 	protoMessage, ok := message.(proto.Message)
 	if !ok {
 		return ErrNotProto

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -199,8 +199,8 @@ func ServeConnect(ctx context.Context, logger log.Logger, cfg Config, deps api.D
 		authZInterceptor,
 		sessionInterceptor.UnaryConnectResponseInterceptor())
 
-	frontierPath, frontierHandler := frontierv1beta1connect.NewFrontierServiceHandler(frontierService, interceptors, connect.WithCodec(conectCodec{}))
-	adminPath, adminHandler := frontierv1beta1connect.NewAdminServiceHandler(frontierService, interceptors, connect.WithCodec(conectCodec{}))
+	frontierPath, frontierHandler := frontierv1beta1connect.NewFrontierServiceHandler(frontierService, interceptors, connect.WithCodec(connectCodec{}))
+	adminPath, adminHandler := frontierv1beta1connect.NewAdminServiceHandler(frontierService, interceptors, connect.WithCodec(connectCodec{}))
 
 	// Create mux and register handlers
 	mux := http.NewServeMux()


### PR DESCRIPTION
# Description

This PR enforces the connect server to follow the json names, the same as the proto field names in the json response of RPC APIs. 

Here is an example:

For this response schema proto:

```proto
message Organization {
  string id = 1;
  string name = 2;
  string title = 3;
  google.protobuf.Struct metadata = 4;
  google.protobuf.Timestamp created_at = 5;
  google.protobuf.Timestamp updated_at = 6;
  string state = 7;
  string avatar = 8;
}
```

By default, the ConnectRPC follows CamelCase naming, resulting in a behaviour like this:

```sh
curl -v  'http://localhost:8002/raystack.frontier.v1beta1.FrontierService/GetOrganization' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header "Cookie: sid=${COOKIE}" \
--data '{"id":"test"}'
```

```json
{
  "organization": {
    "id": "07fd033e-e670-40bf-a63d-b3f9713183a2",
    "name": "test",
    "title": "Test",
    "metadata": {},
    "createdAt": "2023-11-02T11:53:25.010002Z",
    "updatedAt": "2024-07-12T04:16:03.926110Z",
    "state": "enabled",
    "avatar": ""
  }
}
```
(Notice the camel case used in timestamp key names.)

With the current changes, the results will be :

```json
{
  "organization": {
    "id": "07fd033e-e670-40bf-a63d-b3f9713183a2",
    "name": "test",
    "title": "Test",
    "metadata": {},
    "created_at": "2023-11-02T11:53:25.010002Z",
    "updated_at": "2024-07-12T04:16:03.926110Z",
    "state": "enabled",
    "avatar": ""
  }
}
```

