### PR TITLE
fix(admin-ui): replace V1Beta1Organization to proton OrganizationSchema

### DIFF
--- a/ui/src/pages/organizations/details/contexts/organization-context.tsx
+++ b/ui/src/pages/organizations/details/contexts/organization-context.tsx
@@ -1,7 +1,8 @@
+import { Organization, OrganizationSchema } from "@raystack/proton/frontier";
+import { create } from "@bufbuild/protobuf";
 import { createContext } from "react";
 import type {
   V1Beta1Role,
-  V1Beta1Organization,
   V1Beta1BillingAccount,
   V1Beta1User,
   V1Beta1OrganizationKyc,
@@ -17,8 +18,8 @@ export interface SearchConfig {
 
 interface OrganizationContextType {
   roles: V1Beta1Role[];
-  organization?: V1Beta1Organization;
-  updateOrganization: (organization: V1Beta1Organization) => Promise<void>;
+  organization?: Organization;
+  updateOrganization: (organization: Organization) => Promise<void>;
   search: SearchConfig;
   billingAccount?: V1Beta1BillingAccount;
   billingAccountDetails?: V1Beta1BillingAccountDetails;
@@ -37,7 +38,7 @@ interface OrganizationContextType {
 
 export const OrganizationContext = createContext<OrganizationContextType>({
   roles: [],
-  organization: {},
+  organization: create(OrganizationSchema),
   updateOrganization: async () => {},
   setBillingAccountDetails: async () => {},
   billingAccount: {},

--- a/ui/src/pages/organizations/details/index.tsx
+++ b/ui/src/pages/organizations/details/index.tsx
@@ -1,7 +1,6 @@
 import type {
   V1Beta1BillingAccount,
   V1Beta1BillingAccountDetails,
-  V1Beta1Organization,
   V1Beta1OrganizationKyc,
   V1Beta1Role,
   V1Beta1User,
@@ -15,7 +14,10 @@ import { OrganizationDetailsLayout } from "./layout";
 import { ORG_NAMESPACE } from "./types";
 import { OrganizationContext } from "./contexts/organization-context";
 import { AxiosError } from "axios";
-import { FrontierServiceQueries } from "@raystack/proton/frontier";
+import {
+  FrontierServiceQueries,
+  type Organization,
+} from "@raystack/proton/frontier";
 import { queryClient } from "~/contexts/ConnectProvider";
 
 export const OrganizationDetails = () => {
@@ -68,7 +70,7 @@ export const OrganizationDetails = () => {
     await refetch();
   }
 
-  async function updateOrganization(org: V1Beta1Organization) {
+  async function updateOrganization(org: Organization) {
     queryClient.setQueryData(getOrganizationQueryKey, { organization: org });
   }
 
@@ -199,7 +201,7 @@ export const OrganizationDetails = () => {
   return (
     <OrganizationContext.Provider
       value={{
-        organization,
+        organization: organization,
         updateOrganization,
         roles: orgRoles,
         billingAccount,

--- a/ui/src/pages/organizations/details/layout/index.tsx
+++ b/ui/src/pages/organizations/details/layout/index.tsx
@@ -2,7 +2,6 @@ import { OrganizationsDetailsNavabar } from "./navbar";
 import styles from "./layout.module.css";
 import { EmptyState, Flex } from "@raystack/apsara";
 import { OrgSidePanel } from "../side-panel/";
-import { V1Beta1Organization } from "~/api/frontier";
 import React, { useState } from "react";
 import LoadingState from "~/components/states/Loading";
 import { OrganizationIcon } from "@raystack/apsara/icons";
@@ -10,10 +9,11 @@ import PageTitle from "~/components/page-title";
 import { EditKYCPanel } from "../edit/kyc";
 import { EditOrganizationPanel } from "../edit/organization";
 import { EditBillingPanel } from "../edit/billing";
+import type { Organization } from "@raystack/proton/frontier";
 
 interface OrganizationDetailsLayoutProps {
   isLoading: boolean;
-  organization?: V1Beta1Organization;
+  organization?: Organization;
   children: React.ReactNode;
 }
 

--- a/ui/src/pages/organizations/details/layout/navbar.tsx
+++ b/ui/src/pages/organizations/details/layout/navbar.tsx
@@ -14,8 +14,7 @@ import {
 } from "@raystack/apsara";
 
 import styles from "./layout.module.css";
-import { ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons";
-import type { V1Beta1Organization } from "~/api/frontier";
+import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { NavLink, useLocation } from "react-router-dom";
 import { InviteUsersDialog } from "./invite-users-dialog";
 import { AddTokensDialog } from "./add-tokens-dialog";
@@ -24,6 +23,7 @@ import { useContext, useState } from "react";
 import { OrganizationContext } from "../contexts/organization-context";
 import { CollapsableSearch } from "~/components/collapsable-search";
 import { api } from "~/api";
+import type { Organization } from "@raystack/proton/frontier";
 
 const downloadFile = (data: File, filename: string) => {
   const link = document.createElement("a");
@@ -281,7 +281,7 @@ const NavLinks = ({ organizationId }: { organizationId: string }) => {
 };
 
 interface OrganizationDetailsNavbarProps {
-  organization: V1Beta1Organization;
+  organization: Organization;
   toggleSidePanel: () => void;
   openKYCPanel: () => void;
   openEditOrgPanel: () => void;

--- a/ui/src/pages/organizations/details/side-panel/index.tsx
+++ b/ui/src/pages/organizations/details/side-panel/index.tsx
@@ -1,10 +1,10 @@
 import { Avatar, getAvatarColor, SidePanel } from "@raystack/apsara";
-import { V1Beta1Organization } from "~/api/frontier";
 import { OrganizationDetailsSection } from "./org-details-section";
 import { KYCDetailsSection } from "./kyc-section";
 import { PlanDetailsSection } from "./plan-details-section";
 import { TokensDetailsSection } from "./tokens-details-section";
 import { BillingDetailsSection } from "./billing-details-section";
+import type { Organization } from "@raystack/proton/frontier";
 
 export const SUBSCRIPTION_STATES = {
   active: "Active",
@@ -15,7 +15,7 @@ export const SUBSCRIPTION_STATES = {
 } as const;
 
 interface SidePanelProps {
-  organization: V1Beta1Organization;
+  organization: Organization;
 }
 
 export function OrgSidePanel({ organization }: SidePanelProps) {

--- a/ui/src/pages/organizations/details/side-panel/org-details-section.tsx
+++ b/ui/src/pages/organizations/details/side-panel/org-details-section.tsx
@@ -1,13 +1,14 @@
-import { V1Beta1Organization } from "@raystack/frontier";
 import { CalendarIcon } from "@radix-ui/react-icons";
 import { Flex, List, Text, CopyButton, Tooltip } from "@raystack/apsara";
 import styles from "./side-panel.module.css";
 import dayjs from "dayjs";
 import { useContext } from "react";
 import { AppContext } from "~/contexts/App";
+import type { Organization } from "@raystack/proton/frontier";
+import { timestampToDate } from "~/utils/connect-timestamp";
 
 interface OrganizationDetailsSectionProps {
-  organization: V1Beta1Organization;
+  organization: Organization;
 }
 
 type Metadata = Record<string, any>;
@@ -55,7 +56,11 @@ export const OrganizationDetailsSection = ({
         <List.Value>
           <Flex gap={3}>
             <CalendarIcon />
-            <Text>{dayjs(organization?.created_at).format("DD MMM YYYY")}</Text>
+            <Text>
+              {dayjs(timestampToDate(organization.createdAt)).format(
+                "DD MMM YYYY",
+              )}
+            </Text>
           </Flex>
         </List.Value>
       </List.Item>

--- a/ui/src/pages/organizations/details/types.ts
+++ b/ui/src/pages/organizations/details/types.ts
@@ -1,8 +1,9 @@
-import { V1Beta1Organization, V1Beta1Role } from "~/api/frontier";
+import { type Organization } from "@raystack/proton/frontier";
+import { type V1Beta1Role } from "~/api/frontier";
 
 export interface OutletContext {
   organizationId: string;
-  organization: V1Beta1Organization;
+  organization: Organization;
   fetchOrganization: (id: string) => Promise<void>;
   roles: V1Beta1Role[];
 }

--- a/ui/src/pages/organizations/list/columns.tsx
+++ b/ui/src/pages/organizations/list/columns.tsx
@@ -6,7 +6,7 @@ import {
   getAvatarColor,
   Text,
 } from "@raystack/apsara";
-import { V1Beta1Organization, V1Beta1Plan } from "@raystack/frontier";
+import { V1Beta1Plan } from "@raystack/frontier";
 import type { SearchOrganizationsResponse_OrganizationResult } from "@raystack/proton/frontier";
 import {
   isNullTimestamp,
@@ -15,7 +15,6 @@ import {
 } from "~/utils/connect-timestamp";
 import dayjs from "dayjs";
 import styles from "./list.module.css";
-import { NULL_DATE } from "~/utils/constants";
 
 export const SUBSCRIPTION_STATES = {
   active: "Active",

--- a/ui/src/pages/organizations/list/index.tsx
+++ b/ui/src/pages/organizations/list/index.tsx
@@ -7,12 +7,15 @@ import styles from "./list.module.css";
 import { getColumns } from "./columns";
 import { api } from "~/api";
 import { useInfiniteQuery } from "@connectrpc/connect-query";
-import { AdminServiceQueries } from "@raystack/proton/frontier";
+import {
+  AdminServiceQueries,
+  SearchOrganizationsResponse_OrganizationResult,
+} from "@raystack/proton/frontier";
 
 import { useNavigate } from "react-router-dom";
 import PageTitle from "~/components/page-title";
 import { CreateOrganizationPanel } from "./create";
-import type { V1Beta1Organization, V1Beta1Plan } from "~/api/frontier";
+import type { V1Beta1Plan } from "~/api/frontier";
 import {
   getConnectNextPageParam,
   getGroupCountMapFromFirstPage,
@@ -52,13 +55,13 @@ export const OrganizationList = () => {
   // Transform the DataTableQuery to RQLRequest format
   const query = transformDataTableQueryToRQLRequest(tableQuery, {
     fieldNameMapping: {
-      "createdBy": "created_by",
-      "planName": "plan_name",
-      "subscriptionCycleEndAt": "subscription_cycle_end_at",
-      "paymentMode": "payment_mode",
-      "subscriptionState": "subscription_state",
-      "createdAt": "created_at"
-    }
+      createdBy: "created_by",
+      planName: "plan_name",
+      subscriptionCycleEndAt: "subscription_cycle_end_at",
+      paymentMode: "payment_mode",
+      subscriptionState: "subscription_state",
+      createdAt: "created_at",
+    },
   });
 
   const {
@@ -81,8 +84,6 @@ export const OrganizationList = () => {
       retryDelay: 1000,
     },
   );
-
-  console.log(infiniteData);
 
   const data =
     infiniteData?.pages?.flatMap((page) => page?.organizations || []) || [];
@@ -158,7 +159,7 @@ export const OrganizationList = () => {
   const tableClassName =
     data.length || loading ? styles["table"] : styles["table-empty"];
 
-  function onRowClick(row: V1Beta1Organization) {
+  function onRowClick(row: SearchOrganizationsResponse_OrganizationResult) {
     naviagte(`/organizations/${row.id}`);
   }
   return (


### PR DESCRIPTION
This PR updates the `V1Beta1Organization` type to the `Organization` type from proton.
We have already migrated the `getOrganization` api to connect RPC, which gives `Organization` as the response.
But in component props, we were using `V1Beta1Organization` as a type, which we used to get from the REST API.
The fields were snake_case in the REST response and in camelCase in the Connect TS client. 
Thus, we get an undefined value when we use multi-word keys like `createdAt`.

This PR fixes that issue.