### PR TITLE
feat: Implement export audit records rpc with streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG := $(shell git rev-list --tags --max-count=1)
 VERSION := $(shell git describe --tags ${TAG})
 .PHONY: build check fmt lint test test-race vet test-cover-html help install proto ui compose-up-dev
 .DEFAULT_GOAL := build
-PROTON_COMMIT := "8ed47f838ba78a1d4af80e3a52dc873d40181a42"
+PROTON_COMMIT := "c8a089a76adfdc1312c3ffda43b76fa7203bf6bb"
 
 ui:
 	@echo " > generating ui build"

--- a/core/auditrecord/mocks/repository.go
+++ b/core/auditrecord/mocks/repository.go
@@ -7,6 +7,8 @@ import (
 
 	auditrecord "github.com/raystack/frontier/core/auditrecord"
 
+	io "io"
+
 	mock "github.com/stretchr/testify/mock"
 
 	rql "github.com/raystack/salt/rql"
@@ -78,6 +80,72 @@ func (_c *Repository_Create_Call) Return(_a0 auditrecord.AuditRecord, _a1 error)
 }
 
 func (_c *Repository_Create_Call) RunAndReturn(run func(context.Context, auditrecord.AuditRecord) (auditrecord.AuditRecord, error)) *Repository_Create_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Export provides a mock function with given fields: ctx, query
+func (_m *Repository) Export(ctx context.Context, query *rql.Query) (io.Reader, string, error) {
+	ret := _m.Called(ctx, query)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Export")
+	}
+
+	var r0 io.Reader
+	var r1 string
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *rql.Query) (io.Reader, string, error)); ok {
+		return rf(ctx, query)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *rql.Query) io.Reader); ok {
+		r0 = rf(ctx, query)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(io.Reader)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *rql.Query) string); ok {
+		r1 = rf(ctx, query)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *rql.Query) error); ok {
+		r2 = rf(ctx, query)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// Repository_Export_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Export'
+type Repository_Export_Call struct {
+	*mock.Call
+}
+
+// Export is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query *rql.Query
+func (_e *Repository_Expecter) Export(ctx interface{}, query interface{}) *Repository_Export_Call {
+	return &Repository_Export_Call{Call: _e.mock.On("Export", ctx, query)}
+}
+
+func (_c *Repository_Export_Call) Run(run func(ctx context.Context, query *rql.Query)) *Repository_Export_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*rql.Query))
+	})
+	return _c
+}
+
+func (_c *Repository_Export_Call) Return(_a0 io.Reader, _a1 string, _a2 error) *Repository_Export_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *Repository_Export_Call) RunAndReturn(run func(context.Context, *rql.Query) (io.Reader, string, error)) *Repository_Export_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/auditrecord/service.go
+++ b/core/auditrecord/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/google/uuid"
@@ -21,6 +22,7 @@ type Repository interface {
 	Create(ctx context.Context, auditRecord AuditRecord) (AuditRecord, error)
 	GetByIdempotencyKey(ctx context.Context, idempotencyKey string) (AuditRecord, error)
 	List(ctx context.Context, query *rql.Query) (AuditRecordsList, error)
+	Export(ctx context.Context, query *rql.Query) (io.Reader, string, error)
 }
 
 type UserService interface {
@@ -106,6 +108,10 @@ func (s *Service) Create(ctx context.Context, auditRecord AuditRecord) (AuditRec
 
 func (s *Service) List(ctx context.Context, query *rql.Query) (AuditRecordsList, error) {
 	return s.repository.List(ctx, query)
+}
+
+func (s *Service) Export(ctx context.Context, query *rql.Query) (io.Reader, string, error) {
+	return s.repository.Export(ctx, query)
 }
 
 func computeHash(auditRecord AuditRecord) string {

--- a/internal/api/v1beta1connect/audit_record.go
+++ b/internal/api/v1beta1connect/audit_record.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	IdempotencyReplyHeader = "X-Idempotency-Replayed"
-	HttpChunkSize          = 200 * 1024 // 200KB
+	HttpChunkSize          = 204800 // 200KB
 )
 
 type AuditRecordService interface {

--- a/internal/api/v1beta1connect/audit_record.go
+++ b/internal/api/v1beta1connect/audit_record.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 
 	"connectrpc.com/connect"
@@ -14,17 +15,20 @@ import (
 	"github.com/raystack/frontier/pkg/utils"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/raystack/salt/rql"
+	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
 	IdempotencyReplyHeader = "X-Idempotency-Replayed"
+	HttpChunkSize          = 200 * 1024 // 200KB
 )
 
 type AuditRecordService interface {
 	Create(ctx context.Context, record auditrecord.AuditRecord) (auditrecord.AuditRecord, bool, error)
 	List(ctx context.Context, query *rql.Query) (auditrecord.AuditRecordsList, error)
+	Export(ctx context.Context, query *rql.Query) (io.Reader, string, error)
 }
 
 func (h *ConnectHandler) CreateAuditRecord(ctx context.Context, request *connect.Request[frontierv1beta1.CreateAuditRecordRequest]) (*connect.Response[frontierv1beta1.CreateAuditRecordResponse], error) {
@@ -153,6 +157,30 @@ func (h *ConnectHandler) ListAuditRecords(ctx context.Context, request *connect.
 	return connect.NewResponse(&frontierv1beta1.ListAuditRecordsResponse{AuditRecords: pbRecords, Group: pbGroups, Pagination: pagination}), nil
 }
 
+func (h *ConnectHandler) ExportAuditRecords(ctx context.Context, request *connect.Request[frontierv1beta1.ExportAuditRecordsRequest], stream *connect.ServerStream[httpbody.HttpBody]) error {
+	requestQuery, err := utils.TransformExportProtoToRQL(request.Msg.GetQuery(), auditrecord.AuditRecordRQLSchema{})
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("failed to transform rql query: %v", err))
+	}
+	err = rql.ValidateQuery(requestQuery, auditrecord.AuditRecordRQLSchema{})
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("failed to validate rql query: %v", err))
+	}
+	reader, contentType, err := h.auditRecordService.Export(ctx, requestQuery)
+	if err != nil {
+		switch {
+		case errors.Is(err, auditrecord.ErrInvalidUUID) || errors.Is(err, auditrecord.ErrRepositoryBadInput):
+			return connect.NewError(connect.CodeInvalidArgument, err)
+		case errors.Is(err, auditrecord.ErrNotFound):
+			return connect.NewError(connect.CodeNotFound, err)
+		default:
+			return connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+	}
+	// Stream the data using io.Reader
+	return streamReaderInChunks(reader, contentType, stream)
+}
+
 func TransformAuditRecordToPB(record auditrecord.AuditRecord) (*frontierv1beta1.CreateAuditRecordResponse, error) {
 	actorMetaData, err := record.Actor.Metadata.ToStructPB()
 	if err != nil {
@@ -213,4 +241,30 @@ func TransformAuditRecordToPB(record auditrecord.AuditRecord) (*frontierv1beta1.
 			Metadata:   metaData,
 		},
 	}, nil
+}
+
+// streamReaderInChunks reads from io.Reader and streams data in HTTP-friendly chunks
+func streamReaderInChunks(reader io.Reader, contentType string, stream *connect.ServerStream[httpbody.HttpBody]) error {
+	buffer := make([]byte, HttpChunkSize)
+
+	for {
+		n, err := reader.Read(buffer)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+		if n > 0 {
+			msg := &httpbody.HttpBody{
+				ContentType: contentType,
+				Data:        buffer[:n],
+			}
+			if sendErr := stream.Send(msg); sendErr != nil {
+				return connect.NewError(connect.CodeInternal, ErrInternalServerError)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/api/v1beta1connect/mocks/audit_record_service.go
+++ b/internal/api/v1beta1connect/mocks/audit_record_service.go
@@ -7,6 +7,8 @@ import (
 
 	auditrecord "github.com/raystack/frontier/core/auditrecord"
 
+	io "io"
+
 	mock "github.com/stretchr/testify/mock"
 
 	rql "github.com/raystack/salt/rql"
@@ -85,6 +87,72 @@ func (_c *AuditRecordService_Create_Call) Return(_a0 auditrecord.AuditRecord, _a
 }
 
 func (_c *AuditRecordService_Create_Call) RunAndReturn(run func(context.Context, auditrecord.AuditRecord) (auditrecord.AuditRecord, bool, error)) *AuditRecordService_Create_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Export provides a mock function with given fields: ctx, query
+func (_m *AuditRecordService) Export(ctx context.Context, query *rql.Query) (io.Reader, string, error) {
+	ret := _m.Called(ctx, query)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Export")
+	}
+
+	var r0 io.Reader
+	var r1 string
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *rql.Query) (io.Reader, string, error)); ok {
+		return rf(ctx, query)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *rql.Query) io.Reader); ok {
+		r0 = rf(ctx, query)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(io.Reader)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *rql.Query) string); ok {
+		r1 = rf(ctx, query)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *rql.Query) error); ok {
+		r2 = rf(ctx, query)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// AuditRecordService_Export_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Export'
+type AuditRecordService_Export_Call struct {
+	*mock.Call
+}
+
+// Export is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query *rql.Query
+func (_e *AuditRecordService_Expecter) Export(ctx interface{}, query interface{}) *AuditRecordService_Export_Call {
+	return &AuditRecordService_Export_Call{Call: _e.mock.On("Export", ctx, query)}
+}
+
+func (_c *AuditRecordService_Export_Call) Run(run func(ctx context.Context, query *rql.Query)) *AuditRecordService_Export_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*rql.Query))
+	})
+	return _c
+}
+
+func (_c *AuditRecordService_Export_Call) Return(_a0 io.Reader, _a1 string, _a2 error) *AuditRecordService_Export_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *AuditRecordService_Export_Call) RunAndReturn(run func(context.Context, *rql.Query) (io.Reader, string, error)) *AuditRecordService_Export_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/store/postgres/audit_record_repository.go
+++ b/internal/store/postgres/audit_record_repository.go
@@ -257,7 +257,6 @@ func (r AuditRecordRepository) Export(ctx context.Context, rqlQuery *rql.Query) 
 		goqu.L(`COALESCE(metadata::text, '{}') AS "Metadata"`),
 	)
 
-	// Apply sorting after selecting columns for export
 	csvQuery, err = utils.AddRQLSortInQuery(csvQuery, rqlQuery)
 	if err != nil {
 		return nil, "", wrapValidationError(err)
@@ -288,7 +287,7 @@ func (r AuditRecordRepository) executeCursorQuery(ctx context.Context, selectQue
 			if err != nil {
 				return fmt.Errorf("failed to begin transaction: %w", err)
 			}
-			defer tx.Rollback() // Always rollback
+			defer tx.Rollback()
 
 			// Generate unique cursor name
 			cursorName, err := r.generateCursorName()

--- a/internal/store/postgres/audit_record_repository.go
+++ b/internal/store/postgres/audit_record_repository.go
@@ -235,26 +235,26 @@ func (r AuditRecordRepository) Export(ctx context.Context, rqlQuery *rql.Query) 
 	}
 
 	csvQuery := baseStmt.Select(
-		goqu.L(`id AS "Record ID"`),
-		goqu.L(`COALESCE(idempotency_key::text, '') AS "Idempotency Key"`),
-		goqu.L(`event AS "Event"`),
-		goqu.L(`actor_id AS "Actor ID"`),
-		goqu.L(`actor_type AS "Actor Type"`),
-		goqu.L(`actor_name AS "Actor Name"`),
-		goqu.L(`COALESCE(actor_metadata::text, '{}') AS "Actor Metadata"`),
-		goqu.L(`resource_id AS "Resource ID"`),
-		goqu.L(`resource_type AS "Resource Type"`),
-		goqu.L(`resource_name AS "Resource Name"`),
-		goqu.L(`COALESCE(resource_metadata::text, '{}') AS "Resource Metadata"`),
-		goqu.L(`COALESCE(target_id, '') AS "Target ID"`),
-		goqu.L(`COALESCE(target_type, '') AS "Target Type"`),
-		goqu.L(`COALESCE(target_name, '') AS "Target Name"`),
-		goqu.L(`COALESCE(target_metadata::text, '{}') AS "Target Metadata"`),
-		goqu.L(`COALESCE(org_id::text, '') AS "Organization ID"`),
-		goqu.L(`COALESCE(request_id, '') AS "Request ID"`),
-		goqu.L(`to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.MS TZ') AS "Occurred At"`),
-		goqu.L(`to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.MS TZ') AS "Created At"`),
-		goqu.L(`COALESCE(metadata::text, '{}') AS "Metadata"`),
+		goqu.L(`id`),
+		goqu.L(`COALESCE(idempotency_key::text, '')`),
+		goqu.L(`event`),
+		goqu.L(`actor_id`),
+		goqu.L(`actor_type`),
+		goqu.L(`actor_name`),
+		goqu.L(`COALESCE(actor_metadata::text, '{}')`),
+		goqu.L(`resource_id`),
+		goqu.L(`resource_type`),
+		goqu.L(`resource_name`),
+		goqu.L(`COALESCE(resource_metadata::text, '{}')`),
+		goqu.L(`COALESCE(target_id, '')`),
+		goqu.L(`COALESCE(target_type, '')`),
+		goqu.L(`COALESCE(target_name, '')`),
+		goqu.L(`COALESCE(target_metadata::text, '{}')`),
+		goqu.L(`COALESCE(org_id::text, '')`),
+		goqu.L(`COALESCE(request_id, '')`),
+		goqu.L(`to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.MS TZ')`),
+		goqu.L(`to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.MS TZ')`),
+		goqu.L(`COALESCE(metadata::text, '{}')`),
 	)
 
 	csvQuery, err = utils.AddRQLSortInQuery(csvQuery, rqlQuery)
@@ -399,7 +399,7 @@ func (r AuditRecordRepository) streamCursorToCSV(ctx context.Context, tx *sql.Tx
 			for i := range values {
 				valuePtrs[i] = &values[i]
 			}
-
+			// scan values positionally
 			if err := rows.Scan(valuePtrs...); err != nil {
 				rows.Close()
 				return fmt.Errorf("failed to scan row: %w", err)

--- a/internal/store/postgres/audit_record_repository.go
+++ b/internal/store/postgres/audit_record_repository.go
@@ -1,10 +1,15 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/csv"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/doug-martin/goqu/v9"
@@ -12,6 +17,11 @@ import (
 	"github.com/raystack/frontier/pkg/db"
 	"github.com/raystack/frontier/pkg/utils"
 	"github.com/raystack/salt/rql"
+)
+
+const (
+	BATCH_SIZE         = 1000
+	ContentTypeTextCSV = "text/csv"
 )
 
 func wrapValidationError(err error) error {
@@ -42,7 +52,7 @@ func NewAuditRecordRepository(dbc *db.Client) *AuditRecordRepository {
 
 var (
 	auditRecordRQLFilterSupportedColumns = []string{
-		"event", "actor_id", "actor_type", "actor_name", "resource_id", "resource_type", "resource_name",
+		"id", "event", "actor_id", "actor_type", "actor_name", "resource_id", "resource_type", "resource_name",
 		"target_id", "target_type", "target_name", "occurred_at", "org_id", "request_id", "created_at", "idempotency_key",
 	}
 	auditRecordRQLSearchSupportedColumns = []string{
@@ -126,22 +136,10 @@ func (r AuditRecordRepository) getByField(ctx context.Context, field string, val
 }
 
 func (r AuditRecordRepository) List(ctx context.Context, rqlQuery *rql.Query) (auditrecord.AuditRecordsList, error) {
-	if rqlQuery == nil {
-		rqlQuery = utils.NewRQLQuery("", utils.DefaultOffset, utils.DefaultLimit, []rql.Filter{}, []rql.Sort{}, []string{})
-	}
-
-	baseStmt := dialect.From(TABLE_AUDITRECORDS).Where(goqu.Ex{"deleted_at": nil})
-
-	// apply filters
-	baseStmt, err := utils.AddRQLFiltersInQuery(baseStmt, rqlQuery, auditRecordRQLFilterSupportedColumns, auditrecord.AuditRecordRQLSchema{})
+	baseStmt, err := r.buildFilteredQuery(rqlQuery)
 	if err != nil {
-		return auditrecord.AuditRecordsList{}, wrapValidationError(err)
-	}
-
-	// apply search
-	baseStmt, err = utils.AddRQLSearchInQuery(baseStmt, rqlQuery, auditRecordRQLSearchSupportedColumns)
-	if err != nil {
-		return auditrecord.AuditRecordsList{}, wrapValidationError(err)
+		fmt.Println("err", err)
+		return auditrecord.AuditRecordsList{}, err
 	}
 
 	listStmt := baseStmt
@@ -230,6 +228,115 @@ func (r AuditRecordRepository) List(ctx context.Context, rqlQuery *rql.Query) (a
 	}, nil
 }
 
+func (r AuditRecordRepository) Export(ctx context.Context, rqlQuery *rql.Query) (io.Reader, string, error) {
+	baseStmt, err := r.buildFilteredQuery(rqlQuery)
+	if err != nil {
+		return nil, "", err
+	}
+
+	csvQuery := baseStmt.Select(
+		goqu.L(`id AS "Record ID"`),
+		goqu.L(`COALESCE(idempotency_key::text, '') AS "Idempotency Key"`),
+		goqu.L(`event AS "Event"`),
+		goqu.L(`actor_id AS "Actor ID"`),
+		goqu.L(`actor_type AS "Actor Type"`),
+		goqu.L(`actor_name AS "Actor Name"`),
+		goqu.L(`COALESCE(actor_metadata::text, '{}') AS "Actor Metadata"`),
+		goqu.L(`resource_id AS "Resource ID"`),
+		goqu.L(`resource_type AS "Resource Type"`),
+		goqu.L(`resource_name AS "Resource Name"`),
+		goqu.L(`COALESCE(resource_metadata::text, '{}') AS "Resource Metadata"`),
+		goqu.L(`COALESCE(target_id, '') AS "Target ID"`),
+		goqu.L(`COALESCE(target_type, '') AS "Target Type"`),
+		goqu.L(`COALESCE(target_name, '') AS "Target Name"`),
+		goqu.L(`COALESCE(target_metadata::text, '{}') AS "Target Metadata"`),
+		goqu.L(`COALESCE(org_id::text, '') AS "Organization ID"`),
+		goqu.L(`COALESCE(request_id, '') AS "Request ID"`),
+		goqu.L(`to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.MS TZ') AS "Occurred At"`),
+		goqu.L(`to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.MS TZ') AS "Created At"`),
+		goqu.L(`COALESCE(metadata::text, '{}') AS "Metadata"`),
+	)
+
+	// Apply sorting after selecting columns for export
+	csvQuery, err = utils.AddRQLSortInQuery(csvQuery, rqlQuery)
+	if err != nil {
+		return nil, "", wrapValidationError(err)
+	}
+
+	reader, err := r.executeCursorQuery(ctx, csvQuery)
+	if err != nil {
+		_, err2 := r.handleListDatabaseError(err)
+		return nil, "", err2
+	}
+	return reader, ContentTypeTextCSV, nil
+}
+
+func (r AuditRecordRepository) executeCursorQuery(ctx context.Context, selectQuery *goqu.SelectDataset) (io.Reader, error) {
+	query, params, err := selectQuery.ToSQL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build SQL query: %w", err)
+	}
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer pw.Close()
+
+		err := r.dbc.WithTimeout(ctx, TABLE_AUDITRECORDS, "Export", func(ctx context.Context) error {
+			// Start a read-only transaction for cursor
+			tx, err := r.dbc.DB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+			if err != nil {
+				return fmt.Errorf("failed to begin transaction: %w", err)
+			}
+			defer tx.Rollback() // Always rollback
+
+			// Generate unique cursor name
+			cursorName, err := r.generateCursorName()
+			if err != nil {
+				return fmt.Errorf("failed to generate cursor name: %w", err)
+			}
+
+			// Declare cursor with the SELECT query
+			declareSQL := fmt.Sprintf("DECLARE %s CURSOR FOR %s", cursorName, query)
+			_, err = tx.ExecContext(ctx, declareSQL, params...)
+			if err != nil {
+				return fmt.Errorf("failed to declare cursor: %w", err)
+			}
+
+			// Stream data using cursor
+			return r.streamCursorToCSV(ctx, tx, cursorName, pw)
+		})
+
+		if err != nil {
+			pw.CloseWithError(fmt.Errorf("cursor export failed: %w", err))
+		}
+	}()
+
+	return pr, nil
+}
+
+func (r AuditRecordRepository) buildFilteredQuery(rqlQuery *rql.Query) (*goqu.SelectDataset, error) {
+	if rqlQuery == nil {
+		rqlQuery = utils.NewRQLQuery("", utils.DefaultOffset, utils.DefaultLimit, []rql.Filter{}, []rql.Sort{}, []string{})
+	}
+
+	baseStmt := dialect.From(TABLE_AUDITRECORDS).Where(goqu.Ex{"deleted_at": nil})
+
+	// Apply filters
+	baseStmt, err := utils.AddRQLFiltersInQuery(baseStmt, rqlQuery, auditRecordRQLFilterSupportedColumns, auditrecord.AuditRecordRQLSchema{})
+	if err != nil {
+		return nil, wrapValidationError(err)
+	}
+
+	// Apply search
+	baseStmt, err = utils.AddRQLSearchInQuery(baseStmt, rqlQuery, auditRecordRQLSearchSupportedColumns)
+	if err != nil {
+		return nil, wrapValidationError(err)
+	}
+
+	return baseStmt, nil
+}
+
 func (r AuditRecordRepository) handleListDatabaseError(err error) (auditrecord.AuditRecordsList, error) {
 	err = checkPostgresError(err)
 	switch {
@@ -240,4 +347,104 @@ func (r AuditRecordRepository) handleListDatabaseError(err error) (auditrecord.A
 	default:
 		return auditrecord.AuditRecordsList{}, err
 	}
+}
+
+// generateCursorName creates a unique cursor name for the export operation
+func (r AuditRecordRepository) generateCursorName() (string, error) {
+	randomBytes := make([]byte, 8)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return "", err
+	}
+	return "export_cursor_" + hex.EncodeToString(randomBytes), nil
+}
+
+// streamCursorToCSV fetches data from cursor in batches and streams as CSV
+func (r AuditRecordRepository) streamCursorToCSV(ctx context.Context, tx *sql.Tx, cursorName string, pw *io.PipeWriter) error {
+	csvBuffer := &bytes.Buffer{}
+	csvWriter := csv.NewWriter(csvBuffer)
+
+	// Write CSV headers first
+	headers := []string{
+		"Record ID", "Idempotency Key", "Event", "Actor ID", "Actor Type", "Actor Name", "Actor Metadata",
+		"Resource ID", "Resource Type", "Resource Name", "Resource Metadata", "Target ID", "Target Type",
+		"Target name", "Target Metadata", "Organization ID", "Request ID", "Occurred At", "Created At", "Metadata",
+	}
+	if err := csvWriter.Write(headers); err != nil {
+		return fmt.Errorf("failed to write CSV headers: %w", err)
+	}
+	csvWriter.Flush()
+
+	// Send headers as first chunk
+	if _, err := pw.Write(csvBuffer.Bytes()); err != nil {
+		return fmt.Errorf("failed to write headers: %w", err)
+	}
+	csvBuffer.Reset()
+	csvWriter = csv.NewWriter(csvBuffer)
+
+	rowCount := 0
+	for {
+		// Fetch batch from cursor
+		fetchSQL := fmt.Sprintf("FETCH %d FROM %s", BATCH_SIZE, cursorName)
+		rows, err := tx.QueryContext(ctx, fetchSQL)
+		if err != nil {
+			return fmt.Errorf("failed to fetch from cursor: %w", err)
+		}
+
+		batchRowCount := 0
+		// Process batch rows
+		for rows.Next() {
+			// Scan all columns into string slice
+			values := make([]string, len(headers))
+			valuePtrs := make([]interface{}, len(headers))
+			for i := range values {
+				valuePtrs[i] = &values[i]
+			}
+
+			if err := rows.Scan(valuePtrs...); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to scan row: %w", err)
+			}
+
+			// Write row to CSV
+			if err := csvWriter.Write(values); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to write CSV row: %w", err)
+			}
+
+			batchRowCount++
+			rowCount++
+
+			// Send chunk every BATCH_SIZE rows
+			if rowCount%BATCH_SIZE == 0 {
+				csvWriter.Flush()
+				if _, err := pw.Write(csvBuffer.Bytes()); err != nil {
+					rows.Close()
+					return fmt.Errorf("failed to write batch: %w", err)
+				}
+				csvBuffer.Reset()
+			}
+		}
+
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("cursor iteration error: %w", err)
+		}
+
+		// If no more rows, break
+		if batchRowCount == 0 {
+			break
+		}
+	}
+
+	// Send final chunk if there's any remaining data
+	csvWriter.Flush()
+	if csvBuffer.Len() > 0 {
+		finalBytes := csvBuffer.Bytes()
+		if _, err := pw.Write(finalBytes); err != nil {
+			return fmt.Errorf("failed to write final batch: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/store/postgres/audit_record_repository_test.go
+++ b/internal/store/postgres/audit_record_repository_test.go
@@ -1135,7 +1135,6 @@ func (s *AuditRecordRepositoryTestSuite) TestList_EdgeCases() {
 			s.True(found, "Should find record with unicode characters")
 		}
 	})
-
 }
 
 // TestAuditRecordRepositoryTestSuite is the entry point for the test suite

--- a/internal/store/postgres/audit_record_repository_test.go
+++ b/internal/store/postgres/audit_record_repository_test.go
@@ -1136,12 +1136,6 @@ func (s *AuditRecordRepositoryTestSuite) TestList_EdgeCases() {
 		}
 	})
 
-	s.Run("nil query parameter", func() {
-		result, err := s.repository.List(s.ctx, nil)
-		s.NoError(err)
-		s.GreaterOrEqual(len(result.AuditRecords), 0)
-		s.GreaterOrEqual(result.Page.TotalCount, int64(0))
-	})
 }
 
 // TestAuditRecordRepositoryTestSuite is the entry point for the test suite

--- a/pkg/server/connect_interceptors/authorization.go
+++ b/pkg/server/connect_interceptors/authorization.go
@@ -718,6 +718,9 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 	frontierv1beta1connect.AdminServiceListAuditRecordsProcedure: func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {
 		return handler.IsSuperUser(ctx)
 	},
+	frontierv1beta1connect.AdminServiceExportAuditRecordsProcedure: func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {
+		return handler.IsSuperUser(ctx)
+	},
 
 	// preferences
 	"/raystack.frontier.v1beta1.FrontierService/CreateOrganizationPreferences": func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {

--- a/pkg/utils/rql.go
+++ b/pkg/utils/rql.go
@@ -90,6 +90,16 @@ func TransformProtoToRQL(q *frontierv1beta1.RQLRequest, checkStruct interface{})
 		q.GetGroupBy()), nil
 }
 
+func TransformExportProtoToRQL(q *frontierv1beta1.RQLExportRequest, checkStruct interface{}) (*rql.Query, error) {
+	// use TransformProtoToRQL by constructing an RQLRequest
+	rqlReq := &frontierv1beta1.RQLRequest{
+		Filters: q.GetFilters(),
+		Search:  q.GetSearch(),
+		Sort:    q.GetSort(),
+	}
+	return TransformProtoToRQL(rqlReq, checkStruct)
+}
+
 func AddRQLSortInQuery(query *goqu.SelectDataset, rql *rql.Query) (*goqu.SelectDataset, error) {
 	// If there is a group by parameter added then sort the result
 	// by group_by first key in asc order by default before any other sort column

--- a/proto/apidocs.swagger.yaml
+++ b/proto/apidocs.swagger.yaml
@@ -14750,6 +14750,21 @@ definitions:
       - STATUS_SUBSCRIBED
     default: STATUS_UNSPECIFIED
     title: subscription status
+  v1beta1RQLExportRequest:
+    type: object
+    properties:
+      filters:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1beta1RQLFilter'
+      search:
+        type: string
+      sort:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1beta1RQLSort'
   v1beta1RQLFilter:
     type: object
     properties:

--- a/proto/v1beta1/admin.pb.go
+++ b/proto/v1beta1/admin.pb.go
@@ -6152,6 +6152,53 @@ func (x *ListAuditRecordsRequest) GetQuery() *RQLRequest {
 	return nil
 }
 
+type ExportAuditRecordsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Query *RQLExportRequest `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+}
+
+func (x *ExportAuditRecordsRequest) Reset() {
+	*x = ExportAuditRecordsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[115]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ExportAuditRecordsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExportAuditRecordsRequest) ProtoMessage() {}
+
+func (x *ExportAuditRecordsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[115]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExportAuditRecordsRequest.ProtoReflect.Descriptor instead.
+func (*ExportAuditRecordsRequest) Descriptor() ([]byte, []int) {
+	return file_raystack_frontier_v1beta1_admin_proto_rawDescGZIP(), []int{115}
+}
+
+func (x *ExportAuditRecordsRequest) GetQuery() *RQLExportRequest {
+	if x != nil {
+		return x.Query
+	}
+	return nil
+}
+
 type ListAuditRecordsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -6165,7 +6212,7 @@ type ListAuditRecordsResponse struct {
 func (x *ListAuditRecordsResponse) Reset() {
 	*x = ListAuditRecordsResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[115]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[116]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6178,7 +6225,7 @@ func (x *ListAuditRecordsResponse) String() string {
 func (*ListAuditRecordsResponse) ProtoMessage() {}
 
 func (x *ListAuditRecordsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[115]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[116]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6191,7 +6238,7 @@ func (x *ListAuditRecordsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAuditRecordsResponse.ProtoReflect.Descriptor instead.
 func (*ListAuditRecordsResponse) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_admin_proto_rawDescGZIP(), []int{115}
+	return file_raystack_frontier_v1beta1_admin_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *ListAuditRecordsResponse) GetAuditRecords() []*AuditRecord {
@@ -6240,7 +6287,7 @@ type SearchOrganizationsResponse_OrganizationResult struct {
 func (x *SearchOrganizationsResponse_OrganizationResult) Reset() {
 	*x = SearchOrganizationsResponse_OrganizationResult{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[117]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[118]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6253,7 +6300,7 @@ func (x *SearchOrganizationsResponse_OrganizationResult) String() string {
 func (*SearchOrganizationsResponse_OrganizationResult) ProtoMessage() {}
 
 func (x *SearchOrganizationsResponse_OrganizationResult) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[117]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[118]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6395,7 +6442,7 @@ type SearchOrganizationUsersResponse_OrganizationUser struct {
 func (x *SearchOrganizationUsersResponse_OrganizationUser) Reset() {
 	*x = SearchOrganizationUsersResponse_OrganizationUser{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[118]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[119]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6408,7 +6455,7 @@ func (x *SearchOrganizationUsersResponse_OrganizationUser) String() string {
 func (*SearchOrganizationUsersResponse_OrganizationUser) ProtoMessage() {}
 
 func (x *SearchOrganizationUsersResponse_OrganizationUser) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[118]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[119]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6519,7 +6566,7 @@ type SearchOrganizationProjectsResponse_OrganizationProject struct {
 func (x *SearchOrganizationProjectsResponse_OrganizationProject) Reset() {
 	*x = SearchOrganizationProjectsResponse_OrganizationProject{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[119]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[120]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6532,7 +6579,7 @@ func (x *SearchOrganizationProjectsResponse_OrganizationProject) String() string
 func (*SearchOrganizationProjectsResponse_OrganizationProject) ProtoMessage() {}
 
 func (x *SearchOrganizationProjectsResponse_OrganizationProject) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[119]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[120]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6623,7 +6670,7 @@ type SearchProjectUsersResponse_ProjectUser struct {
 func (x *SearchProjectUsersResponse_ProjectUser) Reset() {
 	*x = SearchProjectUsersResponse_ProjectUser{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[120]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[121]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6636,7 +6683,7 @@ func (x *SearchProjectUsersResponse_ProjectUser) String() string {
 func (*SearchProjectUsersResponse_ProjectUser) ProtoMessage() {}
 
 func (x *SearchProjectUsersResponse_ProjectUser) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[120]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[121]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6732,7 +6779,7 @@ type SearchOrganizationInvoicesResponse_OrganizationInvoice struct {
 func (x *SearchOrganizationInvoicesResponse_OrganizationInvoice) Reset() {
 	*x = SearchOrganizationInvoicesResponse_OrganizationInvoice{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[121]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[122]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6745,7 +6792,7 @@ func (x *SearchOrganizationInvoicesResponse_OrganizationInvoice) String() string
 func (*SearchOrganizationInvoicesResponse_OrganizationInvoice) ProtoMessage() {}
 
 func (x *SearchOrganizationInvoicesResponse_OrganizationInvoice) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[121]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[122]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6828,7 +6875,7 @@ type SearchOrganizationTokensResponse_OrganizationToken struct {
 func (x *SearchOrganizationTokensResponse_OrganizationToken) Reset() {
 	*x = SearchOrganizationTokensResponse_OrganizationToken{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[122]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[123]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6841,7 +6888,7 @@ func (x *SearchOrganizationTokensResponse_OrganizationToken) String() string {
 func (*SearchOrganizationTokensResponse_OrganizationToken) ProtoMessage() {}
 
 func (x *SearchOrganizationTokensResponse_OrganizationToken) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[122]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[123]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6927,7 +6974,7 @@ type SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCre
 func (x *SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCredential) Reset() {
 	*x = SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCredential{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[123]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[124]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6941,7 +6988,7 @@ func (*SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserC
 }
 
 func (x *SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[123]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[124]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7005,7 +7052,7 @@ type SearchUserOrganizationsResponse_UserOrganization struct {
 func (x *SearchUserOrganizationsResponse_UserOrganization) Reset() {
 	*x = SearchUserOrganizationsResponse_UserOrganization{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[124]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[125]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7018,7 +7065,7 @@ func (x *SearchUserOrganizationsResponse_UserOrganization) String() string {
 func (*SearchUserOrganizationsResponse_UserOrganization) ProtoMessage() {}
 
 func (x *SearchUserOrganizationsResponse_UserOrganization) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[124]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[125]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7124,7 +7171,7 @@ type SearchUserProjectsResponse_UserProject struct {
 func (x *SearchUserProjectsResponse_UserProject) Reset() {
 	*x = SearchUserProjectsResponse_UserProject{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[125]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[126]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7137,7 +7184,7 @@ func (x *SearchUserProjectsResponse_UserProject) String() string {
 func (*SearchUserProjectsResponse_UserProject) ProtoMessage() {}
 
 func (x *SearchUserProjectsResponse_UserProject) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[125]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[126]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7240,7 +7287,7 @@ type AdminCreateOrganizationRequest_OrganizationRequestBody struct {
 func (x *AdminCreateOrganizationRequest_OrganizationRequestBody) Reset() {
 	*x = AdminCreateOrganizationRequest_OrganizationRequestBody{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[126]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[127]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7253,7 +7300,7 @@ func (x *AdminCreateOrganizationRequest_OrganizationRequestBody) String() string
 func (*AdminCreateOrganizationRequest_OrganizationRequestBody) ProtoMessage() {}
 
 func (x *AdminCreateOrganizationRequest_OrganizationRequestBody) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[126]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[127]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7323,7 +7370,7 @@ type SearchInvoicesResponse_Invoice struct {
 func (x *SearchInvoicesResponse_Invoice) Reset() {
 	*x = SearchInvoicesResponse_Invoice{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[127]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[128]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7336,7 +7383,7 @@ func (x *SearchInvoicesResponse_Invoice) String() string {
 func (*SearchInvoicesResponse_Invoice) ProtoMessage() {}
 
 func (x *SearchInvoicesResponse_Invoice) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[127]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[128]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7428,7 +7475,7 @@ type SearchOrganizationServiceUsersResponse_Project struct {
 func (x *SearchOrganizationServiceUsersResponse_Project) Reset() {
 	*x = SearchOrganizationServiceUsersResponse_Project{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[128]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[129]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7441,7 +7488,7 @@ func (x *SearchOrganizationServiceUsersResponse_Project) String() string {
 func (*SearchOrganizationServiceUsersResponse_Project) ProtoMessage() {}
 
 func (x *SearchOrganizationServiceUsersResponse_Project) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[128]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[129]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7493,7 +7540,7 @@ type SearchOrganizationServiceUsersResponse_OrganizationServiceUser struct {
 func (x *SearchOrganizationServiceUsersResponse_OrganizationServiceUser) Reset() {
 	*x = SearchOrganizationServiceUsersResponse_OrganizationServiceUser{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[129]
+		mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[130]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7506,7 +7553,7 @@ func (x *SearchOrganizationServiceUsersResponse_OrganizationServiceUser) String(
 func (*SearchOrganizationServiceUsersResponse_OrganizationServiceUser) ProtoMessage() {}
 
 func (x *SearchOrganizationServiceUsersResponse_OrganizationServiceUser) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[129]
+	mi := &file_raystack_frontier_v1beta1_admin_proto_msgTypes[130]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9027,6 +9074,12 @@ var file_raystack_frontier_v1beta1_admin_proto_rawDesc = []byte{
 	0x71, 0x75, 0x65, 0x72, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x72, 0x61,
 	0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e,
 	0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x52, 0x51, 0x4c, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x52, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x22, 0x5e, 0x0a, 0x19, 0x45, 0x78, 0x70,
+	0x6f, 0x72, 0x74, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x41, 0x0a, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2b, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b,
+	0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61,
+	0x31, 0x2e, 0x52, 0x51, 0x4c, 0x45, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x52, 0x65, 0x71, 0x75, 0x65,
 	0x73, 0x74, 0x52, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x22, 0x86, 0x02, 0x0a, 0x18, 0x4c, 0x69,
 	0x73, 0x74, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73, 0x52, 0x65,
 	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x4b, 0x0a, 0x0d, 0x61, 0x75, 0x64, 0x69, 0x74, 0x5f,
@@ -9044,7 +9097,7 @@ var file_raystack_frontier_v1beta1_admin_proto_rawDesc = []byte{
 	0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31,
 	0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65, 0x72, 0x79, 0x47, 0x72,
 	0x6f, 0x75, 0x70, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x52, 0x05, 0x67, 0x72, 0x6f,
-	0x75, 0x70, 0x32, 0xed, 0x7c, 0x0a, 0x0c, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x53, 0x65, 0x72, 0x76,
+	0x75, 0x70, 0x32, 0xd3, 0x7d, 0x0a, 0x0c, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x53, 0x65, 0x72, 0x76,
 	0x69, 0x63, 0x65, 0x12, 0xaf, 0x02, 0x0a, 0x0c, 0x4c, 0x69, 0x73, 0x74, 0x41, 0x6c, 0x6c, 0x55,
 	0x73, 0x65, 0x72, 0x73, 0x12, 0x2e, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e,
 	0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31,
@@ -10043,135 +10096,141 @@ var file_raystack_frontier_v1beta1_admin_proto_rawDesc = []byte{
 	0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e,
 	0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x41, 0x75, 0x64, 0x69,
 	0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
-	0x22, 0x00, 0x42, 0xf5, 0x0f, 0x92, 0x41, 0x84, 0x0e, 0x12, 0xfe, 0x06, 0x0a, 0x1b, 0x46, 0x72,
-	0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x69, 0x73, 0x74, 0x72,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x41, 0x50, 0x49, 0x12, 0xcf, 0x05, 0x54, 0x68, 0x65, 0x20,
-	0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x41, 0x50, 0x49, 0x73, 0x20, 0x61, 0x64,
-	0x68, 0x65, 0x72, 0x65, 0x20, 0x74, 0x6f, 0x20, 0x74, 0x68, 0x65, 0x20, 0x4f, 0x70, 0x65, 0x6e,
-	0x41, 0x50, 0x49, 0x20, 0x73, 0x70, 0x65, 0x63, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
-	0x6e, 0x2c, 0x20, 0x61, 0x6c, 0x73, 0x6f, 0x20, 0x6b, 0x6e, 0x6f, 0x77, 0x6e, 0x20, 0x61, 0x73,
-	0x20, 0x53, 0x77, 0x61, 0x67, 0x67, 0x65, 0x72, 0x2c, 0x20, 0x77, 0x68, 0x69, 0x63, 0x68, 0x20,
-	0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x73, 0x20, 0x61, 0x20, 0x73, 0x74, 0x61, 0x6e, 0x64,
-	0x61, 0x72, 0x64, 0x69, 0x7a, 0x65, 0x64, 0x20, 0x61, 0x70, 0x70, 0x72, 0x6f, 0x61, 0x63, 0x68,
-	0x20, 0x66, 0x6f, 0x72, 0x20, 0x64, 0x65, 0x73, 0x69, 0x67, 0x6e, 0x69, 0x6e, 0x67, 0x2c, 0x20,
-	0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x69, 0x6e, 0x67, 0x2c, 0x20, 0x61, 0x6e, 0x64,
-	0x20, 0x63, 0x6f, 0x6e, 0x73, 0x75, 0x6d, 0x69, 0x6e, 0x67, 0x20, 0x52, 0x45, 0x53, 0x54, 0x66,
-	0x75, 0x6c, 0x20, 0x41, 0x50, 0x49, 0x73, 0x2e, 0x20, 0x57, 0x69, 0x74, 0x68, 0x20, 0x4f, 0x70,
-	0x65, 0x6e, 0x41, 0x50, 0x49, 0x2c, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x67, 0x61, 0x69, 0x6e, 0x20,
-	0x61, 0x20, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x20, 0x75, 0x6e, 0x64, 0x65, 0x72, 0x73, 0x74, 0x61,
-	0x6e, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x41, 0x50, 0x49,
-	0x20, 0x65, 0x6e, 0x64, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73, 0x2c, 0x20, 0x72, 0x65, 0x71, 0x75,
-	0x65, 0x73, 0x74, 0x2f, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x20, 0x73, 0x74, 0x72,
-	0x75, 0x63, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2c, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x61, 0x75, 0x74,
-	0x68, 0x65, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x6d, 0x65, 0x63, 0x68,
-	0x61, 0x6e, 0x69, 0x73, 0x6d, 0x73, 0x20, 0x73, 0x75, 0x70, 0x70, 0x6f, 0x72, 0x74, 0x65, 0x64,
-	0x20, 0x62, 0x79, 0x20, 0x74, 0x68, 0x65, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72,
-	0x20, 0x41, 0x50, 0x49, 0x73, 0x2e, 0x20, 0x42, 0x79, 0x20, 0x6c, 0x65, 0x76, 0x65, 0x72, 0x61,
-	0x67, 0x69, 0x6e, 0x67, 0x20, 0x74, 0x68, 0x65, 0x20, 0x4f, 0x70, 0x65, 0x6e, 0x41, 0x50, 0x49,
-	0x20, 0x73, 0x70, 0x65, 0x63, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20,
-	0x64, 0x65, 0x76, 0x65, 0x6c, 0x6f, 0x70, 0x65, 0x72, 0x73, 0x20, 0x63, 0x61, 0x6e, 0x20, 0x65,
-	0x61, 0x73, 0x69, 0x6c, 0x79, 0x20, 0x65, 0x78, 0x70, 0x6c, 0x6f, 0x72, 0x65, 0x20, 0x61, 0x6e,
-	0x64, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x61, 0x63, 0x74, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20,
-	0x74, 0x68, 0x65, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x41, 0x50, 0x49,
-	0x73, 0x20, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x20, 0x61, 0x20, 0x76, 0x61, 0x72, 0x69, 0x65, 0x74,
-	0x79, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x6f, 0x6f, 0x6c, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x6c,
-	0x69, 0x62, 0x72, 0x61, 0x72, 0x69, 0x65, 0x73, 0x2e, 0x20, 0x54, 0x68, 0x65, 0x20, 0x4f, 0x70,
-	0x65, 0x6e, 0x41, 0x50, 0x49, 0x20, 0x73, 0x70, 0x65, 0x63, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74,
-	0x69, 0x6f, 0x6e, 0x20, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x20, 0x61, 0x75, 0x74, 0x6f,
-	0x6d, 0x61, 0x74, 0x69, 0x63, 0x20, 0x63, 0x6f, 0x64, 0x65, 0x20, 0x67, 0x65, 0x6e, 0x65, 0x72,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x61, 0x63, 0x74, 0x69,
-	0x76, 0x65, 0x20, 0x41, 0x50, 0x49, 0x20, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x61,
-	0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x73, 0x65, 0x61, 0x6d, 0x6c, 0x65,
-	0x73, 0x73, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x77,
-	0x69, 0x74, 0x68, 0x20, 0x41, 0x50, 0x49, 0x20, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x20,
-	0x66, 0x72, 0x61, 0x6d, 0x65, 0x77, 0x6f, 0x72, 0x6b, 0x73, 0x2c, 0x20, 0x6d, 0x61, 0x6b, 0x69,
-	0x6e, 0x67, 0x20, 0x69, 0x74, 0x20, 0x65, 0x61, 0x73, 0x69, 0x65, 0x72, 0x20, 0x74, 0x68, 0x61,
-	0x6e, 0x20, 0x65, 0x76, 0x65, 0x72, 0x20, 0x74, 0x6f, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x72,
-	0x61, 0x74, 0x65, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x69, 0x6e, 0x74,
-	0x6f, 0x20, 0x79, 0x6f, 0x75, 0x72, 0x20, 0x65, 0x78, 0x69, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x20,
-	0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x20, 0x61, 0x6e, 0x64,
-	0x20, 0x77, 0x6f, 0x72, 0x6b, 0x66, 0x6c, 0x6f, 0x77, 0x73, 0x2e, 0x22, 0x40, 0x0a, 0x13, 0x52,
-	0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x20, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69,
-	0x6f, 0x6e, 0x12, 0x15, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x72, 0x61, 0x79, 0x73,
-	0x74, 0x61, 0x63, 0x6b, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x1a, 0x12, 0x68, 0x65, 0x6c, 0x6c, 0x6f,
-	0x40, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x6f, 0x72, 0x67, 0x2a, 0x44, 0x0a,
-	0x0a, 0x41, 0x70, 0x61, 0x63, 0x68, 0x65, 0x20, 0x32, 0x2e, 0x30, 0x12, 0x36, 0x68, 0x74, 0x74,
-	0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f,
-	0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2f, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65,
-	0x72, 0x2f, 0x62, 0x6c, 0x6f, 0x62, 0x2f, 0x6d, 0x61, 0x69, 0x6e, 0x2f, 0x4c, 0x49, 0x43, 0x45,
-	0x4e, 0x53, 0x45, 0x32, 0x05, 0x30, 0x2e, 0x32, 0x2e, 0x30, 0x1a, 0x0e, 0x31, 0x32, 0x37, 0x2e,
-	0x30, 0x2e, 0x30, 0x2e, 0x31, 0x3a, 0x37, 0x34, 0x30, 0x30, 0x2a, 0x01, 0x01, 0x32, 0x10, 0x61,
-	0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2f, 0x6a, 0x73, 0x6f, 0x6e, 0x3a,
-	0x10, 0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2f, 0x6a, 0x73, 0x6f,
-	0x6e, 0x52, 0x3c, 0x0a, 0x03, 0x32, 0x30, 0x30, 0x12, 0x35, 0x0a, 0x1b, 0x4f, 0x4b, 0x20, 0x2d,
-	0x20, 0x41, 0x20, 0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73, 0x66, 0x75, 0x6c, 0x20, 0x72, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f,
+	0x22, 0x00, 0x12, 0x64, 0x0a, 0x12, 0x45, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x41, 0x75, 0x64, 0x69,
+	0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73, 0x12, 0x34, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74,
+	0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62,
+	0x65, 0x74, 0x61, 0x31, 0x2e, 0x45, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x41, 0x75, 0x64, 0x69, 0x74,
+	0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x14,
+	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x48, 0x74, 0x74, 0x70,
+	0x42, 0x6f, 0x64, 0x79, 0x22, 0x00, 0x30, 0x01, 0x42, 0xf5, 0x0f, 0x92, 0x41, 0x84, 0x0e, 0x12,
+	0xfe, 0x06, 0x0a, 0x1b, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x41, 0x64, 0x6d,
+	0x69, 0x6e, 0x69, 0x73, 0x74, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x41, 0x50, 0x49, 0x12,
+	0xcf, 0x05, 0x54, 0x68, 0x65, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x41,
+	0x50, 0x49, 0x73, 0x20, 0x61, 0x64, 0x68, 0x65, 0x72, 0x65, 0x20, 0x74, 0x6f, 0x20, 0x74, 0x68,
+	0x65, 0x20, 0x4f, 0x70, 0x65, 0x6e, 0x41, 0x50, 0x49, 0x20, 0x73, 0x70, 0x65, 0x63, 0x69, 0x66,
+	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20, 0x61, 0x6c, 0x73, 0x6f, 0x20, 0x6b, 0x6e,
+	0x6f, 0x77, 0x6e, 0x20, 0x61, 0x73, 0x20, 0x53, 0x77, 0x61, 0x67, 0x67, 0x65, 0x72, 0x2c, 0x20,
+	0x77, 0x68, 0x69, 0x63, 0x68, 0x20, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x73, 0x20, 0x61,
+	0x20, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64, 0x69, 0x7a, 0x65, 0x64, 0x20, 0x61, 0x70,
+	0x70, 0x72, 0x6f, 0x61, 0x63, 0x68, 0x20, 0x66, 0x6f, 0x72, 0x20, 0x64, 0x65, 0x73, 0x69, 0x67,
+	0x6e, 0x69, 0x6e, 0x67, 0x2c, 0x20, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x69, 0x6e,
+	0x67, 0x2c, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x63, 0x6f, 0x6e, 0x73, 0x75, 0x6d, 0x69, 0x6e, 0x67,
+	0x20, 0x52, 0x45, 0x53, 0x54, 0x66, 0x75, 0x6c, 0x20, 0x41, 0x50, 0x49, 0x73, 0x2e, 0x20, 0x57,
+	0x69, 0x74, 0x68, 0x20, 0x4f, 0x70, 0x65, 0x6e, 0x41, 0x50, 0x49, 0x2c, 0x20, 0x79, 0x6f, 0x75,
+	0x20, 0x67, 0x61, 0x69, 0x6e, 0x20, 0x61, 0x20, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x20, 0x75, 0x6e,
+	0x64, 0x65, 0x72, 0x73, 0x74, 0x61, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x6f, 0x66, 0x20, 0x74,
+	0x68, 0x65, 0x20, 0x41, 0x50, 0x49, 0x20, 0x65, 0x6e, 0x64, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73,
+	0x2c, 0x20, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x2f, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x20, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2c, 0x20, 0x61,
+	0x6e, 0x64, 0x20, 0x61, 0x75, 0x74, 0x68, 0x65, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x20, 0x6d, 0x65, 0x63, 0x68, 0x61, 0x6e, 0x69, 0x73, 0x6d, 0x73, 0x20, 0x73, 0x75, 0x70,
+	0x70, 0x6f, 0x72, 0x74, 0x65, 0x64, 0x20, 0x62, 0x79, 0x20, 0x74, 0x68, 0x65, 0x20, 0x46, 0x72,
+	0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x41, 0x50, 0x49, 0x73, 0x2e, 0x20, 0x42, 0x79, 0x20,
+	0x6c, 0x65, 0x76, 0x65, 0x72, 0x61, 0x67, 0x69, 0x6e, 0x67, 0x20, 0x74, 0x68, 0x65, 0x20, 0x4f,
+	0x70, 0x65, 0x6e, 0x41, 0x50, 0x49, 0x20, 0x73, 0x70, 0x65, 0x63, 0x69, 0x66, 0x69, 0x63, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20, 0x64, 0x65, 0x76, 0x65, 0x6c, 0x6f, 0x70, 0x65, 0x72, 0x73,
+	0x20, 0x63, 0x61, 0x6e, 0x20, 0x65, 0x61, 0x73, 0x69, 0x6c, 0x79, 0x20, 0x65, 0x78, 0x70, 0x6c,
+	0x6f, 0x72, 0x65, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x61, 0x63, 0x74,
+	0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x74, 0x68, 0x65, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69,
+	0x65, 0x72, 0x20, 0x41, 0x50, 0x49, 0x73, 0x20, 0x75, 0x73, 0x69, 0x6e, 0x67, 0x20, 0x61, 0x20,
+	0x76, 0x61, 0x72, 0x69, 0x65, 0x74, 0x79, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x6f, 0x6f, 0x6c, 0x73,
+	0x20, 0x61, 0x6e, 0x64, 0x20, 0x6c, 0x69, 0x62, 0x72, 0x61, 0x72, 0x69, 0x65, 0x73, 0x2e, 0x20,
+	0x54, 0x68, 0x65, 0x20, 0x4f, 0x70, 0x65, 0x6e, 0x41, 0x50, 0x49, 0x20, 0x73, 0x70, 0x65, 0x63,
+	0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65,
+	0x73, 0x20, 0x61, 0x75, 0x74, 0x6f, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x20, 0x63, 0x6f, 0x64, 0x65,
+	0x20, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20, 0x69, 0x6e, 0x74,
+	0x65, 0x72, 0x61, 0x63, 0x74, 0x69, 0x76, 0x65, 0x20, 0x41, 0x50, 0x49, 0x20, 0x64, 0x6f, 0x63,
+	0x75, 0x6d, 0x65, 0x6e, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2c, 0x20, 0x61, 0x6e, 0x64, 0x20,
+	0x73, 0x65, 0x61, 0x6d, 0x6c, 0x65, 0x73, 0x73, 0x20, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x72, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x41, 0x50, 0x49, 0x20, 0x74, 0x65,
+	0x73, 0x74, 0x69, 0x6e, 0x67, 0x20, 0x66, 0x72, 0x61, 0x6d, 0x65, 0x77, 0x6f, 0x72, 0x6b, 0x73,
+	0x2c, 0x20, 0x6d, 0x61, 0x6b, 0x69, 0x6e, 0x67, 0x20, 0x69, 0x74, 0x20, 0x65, 0x61, 0x73, 0x69,
+	0x65, 0x72, 0x20, 0x74, 0x68, 0x61, 0x6e, 0x20, 0x65, 0x76, 0x65, 0x72, 0x20, 0x74, 0x6f, 0x20,
+	0x69, 0x6e, 0x74, 0x65, 0x67, 0x72, 0x61, 0x74, 0x65, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69,
+	0x65, 0x72, 0x20, 0x69, 0x6e, 0x74, 0x6f, 0x20, 0x79, 0x6f, 0x75, 0x72, 0x20, 0x65, 0x78, 0x69,
+	0x73, 0x74, 0x69, 0x6e, 0x67, 0x20, 0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x77, 0x6f, 0x72, 0x6b, 0x66, 0x6c, 0x6f, 0x77, 0x73,
+	0x2e, 0x22, 0x40, 0x0a, 0x13, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x20, 0x46, 0x6f,
+	0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x15, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a,
+	0x2f, 0x2f, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x6f, 0x72, 0x67, 0x2f, 0x1a,
+	0x12, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x40, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e,
+	0x6f, 0x72, 0x67, 0x2a, 0x44, 0x0a, 0x0a, 0x41, 0x70, 0x61, 0x63, 0x68, 0x65, 0x20, 0x32, 0x2e,
+	0x30, 0x12, 0x36, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x67, 0x69, 0x74, 0x68, 0x75,
+	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2f, 0x66,
+	0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2f, 0x62, 0x6c, 0x6f, 0x62, 0x2f, 0x6d, 0x61, 0x69,
+	0x6e, 0x2f, 0x4c, 0x49, 0x43, 0x45, 0x4e, 0x53, 0x45, 0x32, 0x05, 0x30, 0x2e, 0x32, 0x2e, 0x30,
+	0x1a, 0x0e, 0x31, 0x32, 0x37, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x31, 0x3a, 0x37, 0x34, 0x30, 0x30,
+	0x2a, 0x01, 0x01, 0x32, 0x10, 0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x2f, 0x6a, 0x73, 0x6f, 0x6e, 0x3a, 0x10, 0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x2f, 0x6a, 0x73, 0x6f, 0x6e, 0x52, 0x3c, 0x0a, 0x03, 0x32, 0x30, 0x30, 0x12, 0x35,
+	0x0a, 0x1b, 0x4f, 0x4b, 0x20, 0x2d, 0x20, 0x41, 0x20, 0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73,
+	0x66, 0x75, 0x6c, 0x20, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x12, 0x16, 0x0a,
+	0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53,
+	0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x69, 0x0a, 0x03, 0x34, 0x30, 0x30, 0x12, 0x62, 0x0a, 0x48,
+	0x42, 0x61, 0x64, 0x20, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x20, 0x2d, 0x20, 0x54, 0x68,
+	0x65, 0x20, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x20, 0x77, 0x61, 0x73, 0x20, 0x6d, 0x61,
+	0x6c, 0x66, 0x6f, 0x72, 0x6d, 0x65, 0x64, 0x20, 0x6f, 0x72, 0x20, 0x63, 0x6f, 0x6e, 0x74, 0x61,
+	0x69, 0x6e, 0x65, 0x64, 0x20, 0x69, 0x6e, 0x76, 0x61, 0x6c, 0x69, 0x64, 0x20, 0x70, 0x61, 0x72,
+	0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73, 0x2e, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67,
+	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73,
+	0x52, 0x4a, 0x0a, 0x03, 0x34, 0x30, 0x31, 0x12, 0x43, 0x0a, 0x29, 0x55, 0x6e, 0x61, 0x75, 0x74,
+	0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65, 0x64, 0x20, 0x2d, 0x20, 0x41, 0x75, 0x74, 0x68, 0x65, 0x6e,
+	0x74, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x69, 0x73, 0x20, 0x72, 0x65, 0x71, 0x75,
+	0x69, 0x72, 0x65, 0x64, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+	0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x61, 0x0a, 0x03,
+	0x34, 0x30, 0x33, 0x12, 0x5a, 0x0a, 0x40, 0x46, 0x6f, 0x72, 0x62, 0x69, 0x64, 0x64, 0x65, 0x6e,
+	0x20, 0x2d, 0x20, 0x55, 0x73, 0x65, 0x72, 0x20, 0x64, 0x6f, 0x65, 0x73, 0x20, 0x6e, 0x6f, 0x74,
+	0x20, 0x68, 0x61, 0x76, 0x65, 0x20, 0x70, 0x65, 0x72, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e,
+	0x20, 0x74, 0x6f, 0x20, 0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x68, 0x65, 0x20, 0x72,
+	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f,
 	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52,
-	0x69, 0x0a, 0x03, 0x34, 0x30, 0x30, 0x12, 0x62, 0x0a, 0x48, 0x42, 0x61, 0x64, 0x20, 0x52, 0x65,
-	0x71, 0x75, 0x65, 0x73, 0x74, 0x20, 0x2d, 0x20, 0x54, 0x68, 0x65, 0x20, 0x72, 0x65, 0x71, 0x75,
-	0x65, 0x73, 0x74, 0x20, 0x77, 0x61, 0x73, 0x20, 0x6d, 0x61, 0x6c, 0x66, 0x6f, 0x72, 0x6d, 0x65,
-	0x64, 0x20, 0x6f, 0x72, 0x20, 0x63, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x64, 0x20, 0x69,
-	0x6e, 0x76, 0x61, 0x6c, 0x69, 0x64, 0x20, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72,
-	0x73, 0x2e, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
-	0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x4a, 0x0a, 0x03, 0x34, 0x30,
-	0x31, 0x12, 0x43, 0x0a, 0x29, 0x55, 0x6e, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72, 0x69, 0x7a, 0x65,
-	0x64, 0x20, 0x2d, 0x20, 0x41, 0x75, 0x74, 0x68, 0x65, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x74, 0x69,
-	0x6f, 0x6e, 0x20, 0x69, 0x73, 0x20, 0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x12, 0x16,
-	0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e,
-	0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x61, 0x0a, 0x03, 0x34, 0x30, 0x33, 0x12, 0x5a, 0x0a,
-	0x40, 0x46, 0x6f, 0x72, 0x62, 0x69, 0x64, 0x64, 0x65, 0x6e, 0x20, 0x2d, 0x20, 0x55, 0x73, 0x65,
-	0x72, 0x20, 0x64, 0x6f, 0x65, 0x73, 0x20, 0x6e, 0x6f, 0x74, 0x20, 0x68, 0x61, 0x76, 0x65, 0x20,
-	0x70, 0x65, 0x72, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x20, 0x74, 0x6f, 0x20, 0x61, 0x63,
-	0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x68, 0x65, 0x20, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63,
-	0x65, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72,
-	0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x51, 0x0a, 0x03, 0x34, 0x30, 0x34,
-	0x12, 0x4a, 0x0a, 0x30, 0x4e, 0x6f, 0x74, 0x20, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x20, 0x2d, 0x20,
-	0x54, 0x68, 0x65, 0x20, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x65, 0x64, 0x20, 0x72, 0x65,
-	0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x20, 0x77, 0x61, 0x73, 0x20, 0x6e, 0x6f, 0x74, 0x20, 0x66,
-	0x6f, 0x75, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
-	0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x75, 0x0a, 0x03,
-	0x35, 0x30, 0x30, 0x12, 0x6e, 0x0a, 0x54, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x20,
-	0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x2e, 0x20, 0x52, 0x65,
-	0x74, 0x75, 0x72, 0x6e, 0x65, 0x64, 0x20, 0x77, 0x68, 0x65, 0x6e, 0x20, 0x74, 0x68, 0x65, 0x72,
-	0x65, 0x73, 0x20, 0x69, 0x73, 0x20, 0x73, 0x6f, 0x6d, 0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x20,
-	0x77, 0x72, 0x6f, 0x6e, 0x67, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74,
-	0x69, 0x65, 0x72, 0x20, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x12, 0x16, 0x0a, 0x14, 0x1a,
-	0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61,
-	0x74, 0x75, 0x73, 0x5a, 0xa8, 0x01, 0x0a, 0x4e, 0x0a, 0x05, 0x42, 0x61, 0x73, 0x69, 0x63, 0x12,
-	0x45, 0x08, 0x01, 0x12, 0x37, 0x75, 0x73, 0x65, 0x20, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x20,
-	0x49, 0x44, 0x20, 0x61, 0x73, 0x20, 0x75, 0x73, 0x65, 0x72, 0x6e, 0x61, 0x6d, 0x65, 0x20, 0x61,
-	0x6e, 0x64, 0x20, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x20, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74,
-	0x20, 0x61, 0x73, 0x20, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64, 0x1a, 0x06, 0x42, 0x61,
-	0x73, 0x69, 0x63, 0x20, 0x20, 0x02, 0x0a, 0x56, 0x0a, 0x06, 0x42, 0x65, 0x61, 0x72, 0x65, 0x72,
-	0x12, 0x4c, 0x08, 0x03, 0x12, 0x3d, 0x41, 0x63, 0x63, 0x65, 0x73, 0x73, 0x20, 0x74, 0x6f, 0x6b,
-	0x65, 0x6e, 0x20, 0x6f, 0x72, 0x20, 0x4a, 0x57, 0x54, 0x20, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x2c,
-	0x20, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x65, 0x64, 0x20, 0x62, 0x79, 0x20, 0x42, 0x65, 0x61,
-	0x72, 0x65, 0x72, 0x3a, 0x20, 0x42, 0x65, 0x61, 0x72, 0x65, 0x72, 0x20, 0x3c, 0x74, 0x6f, 0x6b,
-	0x65, 0x6e, 0x3e, 0x1a, 0x07, 0x42, 0x65, 0x61, 0x72, 0x65, 0x72, 0x20, 0x20, 0x02, 0x62, 0x0b,
-	0x0a, 0x09, 0x0a, 0x05, 0x42, 0x61, 0x73, 0x69, 0x63, 0x12, 0x00, 0x62, 0x0c, 0x0a, 0x0a, 0x0a,
-	0x06, 0x42, 0x65, 0x61, 0x72, 0x65, 0x72, 0x12, 0x00, 0x6a, 0x06, 0x0a, 0x04, 0x55, 0x73, 0x65,
-	0x72, 0x6a, 0x07, 0x0a, 0x05, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x6a, 0x0e, 0x0a, 0x0c, 0x4f, 0x72,
-	0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x6a, 0x09, 0x0a, 0x07, 0x50, 0x72,
-	0x6f, 0x6a, 0x65, 0x63, 0x74, 0x6a, 0x0a, 0x0a, 0x08, 0x52, 0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f,
-	0x6e, 0x6a, 0x0a, 0x0a, 0x08, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x6a, 0x08, 0x0a,
-	0x06, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x6a, 0x06, 0x0a, 0x04, 0x52, 0x6f, 0x6c, 0x65, 0x6a,
-	0x0c, 0x0a, 0x0a, 0x50, 0x65, 0x72, 0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x0a, 0x1d, 0x63,
-	0x6f, 0x6d, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e,
-	0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x42, 0x0a, 0x41, 0x64,
-	0x6d, 0x69, 0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3a, 0x67, 0x69, 0x74, 0x68,
-	0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2f,
-	0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x76,
-	0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x3b, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x76,
-	0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xa2, 0x02, 0x03, 0x52, 0x46, 0x58, 0xaa, 0x02, 0x19, 0x52,
-	0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72,
-	0x2e, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xca, 0x02, 0x19, 0x52, 0x61, 0x79, 0x73, 0x74,
-	0x61, 0x63, 0x6b, 0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x5c, 0x56, 0x31, 0x62,
-	0x65, 0x74, 0x61, 0x31, 0xe2, 0x02, 0x25, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x5c,
-	0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x5c, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31,
-	0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x1b, 0x52,
-	0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x3a, 0x3a, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65,
-	0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x33,
+	0x51, 0x0a, 0x03, 0x34, 0x30, 0x34, 0x12, 0x4a, 0x0a, 0x30, 0x4e, 0x6f, 0x74, 0x20, 0x46, 0x6f,
+	0x75, 0x6e, 0x64, 0x20, 0x2d, 0x20, 0x54, 0x68, 0x65, 0x20, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x65, 0x64, 0x20, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x20, 0x77, 0x61, 0x73,
+	0x20, 0x6e, 0x6f, 0x74, 0x20, 0x66, 0x6f, 0x75, 0x6e, 0x64, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12,
+	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72, 0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74,
+	0x75, 0x73, 0x52, 0x75, 0x0a, 0x03, 0x35, 0x30, 0x30, 0x12, 0x6e, 0x0a, 0x54, 0x49, 0x6e, 0x74,
+	0x65, 0x72, 0x6e, 0x61, 0x6c, 0x20, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x45, 0x72, 0x72,
+	0x6f, 0x72, 0x2e, 0x20, 0x52, 0x65, 0x74, 0x75, 0x72, 0x6e, 0x65, 0x64, 0x20, 0x77, 0x68, 0x65,
+	0x6e, 0x20, 0x74, 0x68, 0x65, 0x72, 0x65, 0x73, 0x20, 0x69, 0x73, 0x20, 0x73, 0x6f, 0x6d, 0x65,
+	0x74, 0x68, 0x69, 0x6e, 0x67, 0x20, 0x77, 0x72, 0x6f, 0x6e, 0x67, 0x20, 0x77, 0x69, 0x74, 0x68,
+	0x20, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x20, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72,
+	0x2e, 0x12, 0x16, 0x0a, 0x14, 0x1a, 0x12, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x72,
+	0x70, 0x63, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x5a, 0xa8, 0x01, 0x0a, 0x4e, 0x0a, 0x05,
+	0x42, 0x61, 0x73, 0x69, 0x63, 0x12, 0x45, 0x08, 0x01, 0x12, 0x37, 0x75, 0x73, 0x65, 0x20, 0x43,
+	0x6c, 0x69, 0x65, 0x6e, 0x74, 0x20, 0x49, 0x44, 0x20, 0x61, 0x73, 0x20, 0x75, 0x73, 0x65, 0x72,
+	0x6e, 0x61, 0x6d, 0x65, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x20,
+	0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x20, 0x61, 0x73, 0x20, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f,
+	0x72, 0x64, 0x1a, 0x06, 0x42, 0x61, 0x73, 0x69, 0x63, 0x20, 0x20, 0x02, 0x0a, 0x56, 0x0a, 0x06,
+	0x42, 0x65, 0x61, 0x72, 0x65, 0x72, 0x12, 0x4c, 0x08, 0x03, 0x12, 0x3d, 0x41, 0x63, 0x63, 0x65,
+	0x73, 0x73, 0x20, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x20, 0x6f, 0x72, 0x20, 0x4a, 0x57, 0x54, 0x20,
+	0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x2c, 0x20, 0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x65, 0x64, 0x20,
+	0x62, 0x79, 0x20, 0x42, 0x65, 0x61, 0x72, 0x65, 0x72, 0x3a, 0x20, 0x42, 0x65, 0x61, 0x72, 0x65,
+	0x72, 0x20, 0x3c, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x3e, 0x1a, 0x07, 0x42, 0x65, 0x61, 0x72, 0x65,
+	0x72, 0x20, 0x20, 0x02, 0x62, 0x0b, 0x0a, 0x09, 0x0a, 0x05, 0x42, 0x61, 0x73, 0x69, 0x63, 0x12,
+	0x00, 0x62, 0x0c, 0x0a, 0x0a, 0x0a, 0x06, 0x42, 0x65, 0x61, 0x72, 0x65, 0x72, 0x12, 0x00, 0x6a,
+	0x06, 0x0a, 0x04, 0x55, 0x73, 0x65, 0x72, 0x6a, 0x07, 0x0a, 0x05, 0x47, 0x72, 0x6f, 0x75, 0x70,
+	0x6a, 0x0e, 0x0a, 0x0c, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x6a, 0x09, 0x0a, 0x07, 0x50, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x6a, 0x0a, 0x0a, 0x08, 0x52,
+	0x65, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x6a, 0x0a, 0x0a, 0x08, 0x52, 0x65, 0x73, 0x6f, 0x75,
+	0x72, 0x63, 0x65, 0x6a, 0x08, 0x0a, 0x06, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x6a, 0x06, 0x0a,
+	0x04, 0x52, 0x6f, 0x6c, 0x65, 0x6a, 0x0c, 0x0a, 0x0a, 0x50, 0x65, 0x72, 0x6d, 0x69, 0x73, 0x73,
+	0x69, 0x6f, 0x6e, 0x0a, 0x1d, 0x63, 0x6f, 0x6d, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63,
+	0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74,
+	0x61, 0x31, 0x42, 0x0a, 0x41, 0x64, 0x6d, 0x69, 0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01,
+	0x5a, 0x3a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x72, 0x61, 0x79,
+	0x73, 0x74, 0x61, 0x63, 0x6b, 0x2f, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2f, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x3b, 0x66, 0x72, 0x6f,
+	0x6e, 0x74, 0x69, 0x65, 0x72, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xa2, 0x02, 0x03, 0x52,
+	0x46, 0x58, 0xaa, 0x02, 0x19, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x46, 0x72,
+	0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xca, 0x02,
+	0x19, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69,
+	0x65, 0x72, 0x5c, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xe2, 0x02, 0x25, 0x52, 0x61, 0x79,
+	0x73, 0x74, 0x61, 0x63, 0x6b, 0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x5c, 0x56,
+	0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61,
+	0x74, 0x61, 0xea, 0x02, 0x1b, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x3a, 0x3a, 0x46,
+	0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -10186,7 +10245,7 @@ func file_raystack_frontier_v1beta1_admin_proto_rawDescGZIP() []byte {
 	return file_raystack_frontier_v1beta1_admin_proto_rawDescData
 }
 
-var file_raystack_frontier_v1beta1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 130)
+var file_raystack_frontier_v1beta1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 131)
 var file_raystack_frontier_v1beta1_admin_proto_goTypes = []interface{}{
 	(*ListAllUsersRequest)(nil),                                    // 0: raystack.frontier.v1beta1.ListAllUsersRequest
 	(*ListAllUsersResponse)(nil),                                   // 1: raystack.frontier.v1beta1.ListAllUsersResponse
@@ -10303,297 +10362,302 @@ var file_raystack_frontier_v1beta1_admin_proto_goTypes = []interface{}{
 	(*RevokeUserSessionRequest)(nil),                               // 112: raystack.frontier.v1beta1.RevokeUserSessionRequest
 	(*RevokeUserSessionResponse)(nil),                              // 113: raystack.frontier.v1beta1.RevokeUserSessionResponse
 	(*ListAuditRecordsRequest)(nil),                                // 114: raystack.frontier.v1beta1.ListAuditRecordsRequest
-	(*ListAuditRecordsResponse)(nil),                               // 115: raystack.frontier.v1beta1.ListAuditRecordsResponse
-	nil,                                                            // 116: raystack.frontier.v1beta1.WebhookRequestBody.HeadersEntry
-	(*SearchOrganizationsResponse_OrganizationResult)(nil),         // 117: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult
-	(*SearchOrganizationUsersResponse_OrganizationUser)(nil),       // 118: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.OrganizationUser
-	(*SearchOrganizationProjectsResponse_OrganizationProject)(nil), // 119: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.OrganizationProject
-	(*SearchProjectUsersResponse_ProjectUser)(nil),                 // 120: raystack.frontier.v1beta1.SearchProjectUsersResponse.ProjectUser
-	(*SearchOrganizationInvoicesResponse_OrganizationInvoice)(nil), // 121: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.OrganizationInvoice
-	(*SearchOrganizationTokensResponse_OrganizationToken)(nil),     // 122: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.OrganizationToken
-	(*SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCredential)(nil), // 123: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.OrganizationServiceUserCredential
-	(*SearchUserOrganizationsResponse_UserOrganization)(nil),                                   // 124: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.UserOrganization
-	(*SearchUserProjectsResponse_UserProject)(nil),                                             // 125: raystack.frontier.v1beta1.SearchUserProjectsResponse.UserProject
-	(*AdminCreateOrganizationRequest_OrganizationRequestBody)(nil),                             // 126: raystack.frontier.v1beta1.AdminCreateOrganizationRequest.OrganizationRequestBody
-	(*SearchInvoicesResponse_Invoice)(nil),                                                     // 127: raystack.frontier.v1beta1.SearchInvoicesResponse.Invoice
-	(*SearchOrganizationServiceUsersResponse_Project)(nil),                                     // 128: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.Project
-	(*SearchOrganizationServiceUsersResponse_OrganizationServiceUser)(nil),                     // 129: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser
-	(*User)(nil),                       // 130: raystack.frontier.v1beta1.User
-	(*ServiceUser)(nil),                // 131: raystack.frontier.v1beta1.ServiceUser
-	(*Group)(nil),                      // 132: raystack.frontier.v1beta1.Group
-	(*Organization)(nil),               // 133: raystack.frontier.v1beta1.Organization
-	(*Project)(nil),                    // 134: raystack.frontier.v1beta1.Project
-	(*Relation)(nil),                   // 135: raystack.frontier.v1beta1.Relation
-	(*Resource)(nil),                   // 136: raystack.frontier.v1beta1.Resource
-	(*RoleRequestBody)(nil),            // 137: raystack.frontier.v1beta1.RoleRequestBody
-	(*Role)(nil),                       // 138: raystack.frontier.v1beta1.Role
-	(*structpb.Struct)(nil),            // 139: google.protobuf.Struct
-	(*Permission)(nil),                 // 140: raystack.frontier.v1beta1.Permission
-	(*Preference)(nil),                 // 141: raystack.frontier.v1beta1.Preference
-	(*PreferenceRequestBody)(nil),      // 142: raystack.frontier.v1beta1.PreferenceRequestBody
-	(*CheckoutSubscriptionBody)(nil),   // 143: raystack.frontier.v1beta1.CheckoutSubscriptionBody
-	(*CheckoutProductBody)(nil),        // 144: raystack.frontier.v1beta1.CheckoutProductBody
-	(*Subscription)(nil),               // 145: raystack.frontier.v1beta1.Subscription
-	(*Product)(nil),                    // 146: raystack.frontier.v1beta1.Product
-	(*Invoice)(nil),                    // 147: raystack.frontier.v1beta1.Invoice
-	(*BillingAccount)(nil),             // 148: raystack.frontier.v1beta1.BillingAccount
-	(*Webhook)(nil),                    // 149: raystack.frontier.v1beta1.Webhook
-	(*RQLRequest)(nil),                 // 150: raystack.frontier.v1beta1.RQLRequest
-	(*OrganizationKyc)(nil),            // 151: raystack.frontier.v1beta1.OrganizationKyc
-	(*RQLQueryPaginationResponse)(nil), // 152: raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	(*RQLQueryGroupResponse)(nil),      // 153: raystack.frontier.v1beta1.RQLQueryGroupResponse
-	(*Prospect)(nil),                   // 154: raystack.frontier.v1beta1.Prospect
-	(Prospect_Status)(0),               // 155: raystack.frontier.v1beta1.Prospect.Status
-	(*Session)(nil),                    // 156: raystack.frontier.v1beta1.Session
-	(*AuditRecord)(nil),                // 157: raystack.frontier.v1beta1.AuditRecord
-	(*timestamppb.Timestamp)(nil),      // 158: google.protobuf.Timestamp
-	(*ExportOrganizationsRequest)(nil), // 159: raystack.frontier.v1beta1.ExportOrganizationsRequest
-	(*httpbody.HttpBody)(nil),          // 160: google.api.HttpBody
+	(*ExportAuditRecordsRequest)(nil),                              // 115: raystack.frontier.v1beta1.ExportAuditRecordsRequest
+	(*ListAuditRecordsResponse)(nil),                               // 116: raystack.frontier.v1beta1.ListAuditRecordsResponse
+	nil,                                                            // 117: raystack.frontier.v1beta1.WebhookRequestBody.HeadersEntry
+	(*SearchOrganizationsResponse_OrganizationResult)(nil),         // 118: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult
+	(*SearchOrganizationUsersResponse_OrganizationUser)(nil),       // 119: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.OrganizationUser
+	(*SearchOrganizationProjectsResponse_OrganizationProject)(nil), // 120: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.OrganizationProject
+	(*SearchProjectUsersResponse_ProjectUser)(nil),                 // 121: raystack.frontier.v1beta1.SearchProjectUsersResponse.ProjectUser
+	(*SearchOrganizationInvoicesResponse_OrganizationInvoice)(nil), // 122: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.OrganizationInvoice
+	(*SearchOrganizationTokensResponse_OrganizationToken)(nil),     // 123: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.OrganizationToken
+	(*SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCredential)(nil), // 124: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.OrganizationServiceUserCredential
+	(*SearchUserOrganizationsResponse_UserOrganization)(nil),                                   // 125: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.UserOrganization
+	(*SearchUserProjectsResponse_UserProject)(nil),                                             // 126: raystack.frontier.v1beta1.SearchUserProjectsResponse.UserProject
+	(*AdminCreateOrganizationRequest_OrganizationRequestBody)(nil),                             // 127: raystack.frontier.v1beta1.AdminCreateOrganizationRequest.OrganizationRequestBody
+	(*SearchInvoicesResponse_Invoice)(nil),                                                     // 128: raystack.frontier.v1beta1.SearchInvoicesResponse.Invoice
+	(*SearchOrganizationServiceUsersResponse_Project)(nil),                                     // 129: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.Project
+	(*SearchOrganizationServiceUsersResponse_OrganizationServiceUser)(nil),                     // 130: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser
+	(*User)(nil),                       // 131: raystack.frontier.v1beta1.User
+	(*ServiceUser)(nil),                // 132: raystack.frontier.v1beta1.ServiceUser
+	(*Group)(nil),                      // 133: raystack.frontier.v1beta1.Group
+	(*Organization)(nil),               // 134: raystack.frontier.v1beta1.Organization
+	(*Project)(nil),                    // 135: raystack.frontier.v1beta1.Project
+	(*Relation)(nil),                   // 136: raystack.frontier.v1beta1.Relation
+	(*Resource)(nil),                   // 137: raystack.frontier.v1beta1.Resource
+	(*RoleRequestBody)(nil),            // 138: raystack.frontier.v1beta1.RoleRequestBody
+	(*Role)(nil),                       // 139: raystack.frontier.v1beta1.Role
+	(*structpb.Struct)(nil),            // 140: google.protobuf.Struct
+	(*Permission)(nil),                 // 141: raystack.frontier.v1beta1.Permission
+	(*Preference)(nil),                 // 142: raystack.frontier.v1beta1.Preference
+	(*PreferenceRequestBody)(nil),      // 143: raystack.frontier.v1beta1.PreferenceRequestBody
+	(*CheckoutSubscriptionBody)(nil),   // 144: raystack.frontier.v1beta1.CheckoutSubscriptionBody
+	(*CheckoutProductBody)(nil),        // 145: raystack.frontier.v1beta1.CheckoutProductBody
+	(*Subscription)(nil),               // 146: raystack.frontier.v1beta1.Subscription
+	(*Product)(nil),                    // 147: raystack.frontier.v1beta1.Product
+	(*Invoice)(nil),                    // 148: raystack.frontier.v1beta1.Invoice
+	(*BillingAccount)(nil),             // 149: raystack.frontier.v1beta1.BillingAccount
+	(*Webhook)(nil),                    // 150: raystack.frontier.v1beta1.Webhook
+	(*RQLRequest)(nil),                 // 151: raystack.frontier.v1beta1.RQLRequest
+	(*OrganizationKyc)(nil),            // 152: raystack.frontier.v1beta1.OrganizationKyc
+	(*RQLQueryPaginationResponse)(nil), // 153: raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	(*RQLQueryGroupResponse)(nil),      // 154: raystack.frontier.v1beta1.RQLQueryGroupResponse
+	(*Prospect)(nil),                   // 155: raystack.frontier.v1beta1.Prospect
+	(Prospect_Status)(0),               // 156: raystack.frontier.v1beta1.Prospect.Status
+	(*Session)(nil),                    // 157: raystack.frontier.v1beta1.Session
+	(*RQLExportRequest)(nil),           // 158: raystack.frontier.v1beta1.RQLExportRequest
+	(*AuditRecord)(nil),                // 159: raystack.frontier.v1beta1.AuditRecord
+	(*timestamppb.Timestamp)(nil),      // 160: google.protobuf.Timestamp
+	(*ExportOrganizationsRequest)(nil), // 161: raystack.frontier.v1beta1.ExportOrganizationsRequest
+	(*httpbody.HttpBody)(nil),          // 162: google.api.HttpBody
 }
 var file_raystack_frontier_v1beta1_admin_proto_depIdxs = []int32{
-	130, // 0: raystack.frontier.v1beta1.ListAllUsersResponse.users:type_name -> raystack.frontier.v1beta1.User
-	131, // 1: raystack.frontier.v1beta1.ListAllServiceUsersResponse.service_users:type_name -> raystack.frontier.v1beta1.ServiceUser
-	132, // 2: raystack.frontier.v1beta1.ListGroupsResponse.groups:type_name -> raystack.frontier.v1beta1.Group
-	133, // 3: raystack.frontier.v1beta1.ListAllOrganizationsResponse.organizations:type_name -> raystack.frontier.v1beta1.Organization
-	134, // 4: raystack.frontier.v1beta1.ListProjectsResponse.projects:type_name -> raystack.frontier.v1beta1.Project
-	135, // 5: raystack.frontier.v1beta1.ListRelationsResponse.relations:type_name -> raystack.frontier.v1beta1.Relation
-	136, // 6: raystack.frontier.v1beta1.ListResourcesResponse.resources:type_name -> raystack.frontier.v1beta1.Resource
-	137, // 7: raystack.frontier.v1beta1.CreateRoleRequest.body:type_name -> raystack.frontier.v1beta1.RoleRequestBody
-	138, // 8: raystack.frontier.v1beta1.CreateRoleResponse.role:type_name -> raystack.frontier.v1beta1.Role
-	137, // 9: raystack.frontier.v1beta1.UpdateRoleRequest.body:type_name -> raystack.frontier.v1beta1.RoleRequestBody
-	138, // 10: raystack.frontier.v1beta1.UpdateRoleResponse.role:type_name -> raystack.frontier.v1beta1.Role
-	139, // 11: raystack.frontier.v1beta1.PermissionRequestBody.metadata:type_name -> google.protobuf.Struct
+	131, // 0: raystack.frontier.v1beta1.ListAllUsersResponse.users:type_name -> raystack.frontier.v1beta1.User
+	132, // 1: raystack.frontier.v1beta1.ListAllServiceUsersResponse.service_users:type_name -> raystack.frontier.v1beta1.ServiceUser
+	133, // 2: raystack.frontier.v1beta1.ListGroupsResponse.groups:type_name -> raystack.frontier.v1beta1.Group
+	134, // 3: raystack.frontier.v1beta1.ListAllOrganizationsResponse.organizations:type_name -> raystack.frontier.v1beta1.Organization
+	135, // 4: raystack.frontier.v1beta1.ListProjectsResponse.projects:type_name -> raystack.frontier.v1beta1.Project
+	136, // 5: raystack.frontier.v1beta1.ListRelationsResponse.relations:type_name -> raystack.frontier.v1beta1.Relation
+	137, // 6: raystack.frontier.v1beta1.ListResourcesResponse.resources:type_name -> raystack.frontier.v1beta1.Resource
+	138, // 7: raystack.frontier.v1beta1.CreateRoleRequest.body:type_name -> raystack.frontier.v1beta1.RoleRequestBody
+	139, // 8: raystack.frontier.v1beta1.CreateRoleResponse.role:type_name -> raystack.frontier.v1beta1.Role
+	138, // 9: raystack.frontier.v1beta1.UpdateRoleRequest.body:type_name -> raystack.frontier.v1beta1.RoleRequestBody
+	139, // 10: raystack.frontier.v1beta1.UpdateRoleResponse.role:type_name -> raystack.frontier.v1beta1.Role
+	140, // 11: raystack.frontier.v1beta1.PermissionRequestBody.metadata:type_name -> google.protobuf.Struct
 	20,  // 12: raystack.frontier.v1beta1.CreatePermissionRequest.bodies:type_name -> raystack.frontier.v1beta1.PermissionRequestBody
-	140, // 13: raystack.frontier.v1beta1.CreatePermissionResponse.permissions:type_name -> raystack.frontier.v1beta1.Permission
+	141, // 13: raystack.frontier.v1beta1.CreatePermissionResponse.permissions:type_name -> raystack.frontier.v1beta1.Permission
 	20,  // 14: raystack.frontier.v1beta1.UpdatePermissionRequest.body:type_name -> raystack.frontier.v1beta1.PermissionRequestBody
-	140, // 15: raystack.frontier.v1beta1.UpdatePermissionResponse.permission:type_name -> raystack.frontier.v1beta1.Permission
-	141, // 16: raystack.frontier.v1beta1.ListPreferencesResponse.preferences:type_name -> raystack.frontier.v1beta1.Preference
-	142, // 17: raystack.frontier.v1beta1.CreatePreferencesRequest.preferences:type_name -> raystack.frontier.v1beta1.PreferenceRequestBody
-	141, // 18: raystack.frontier.v1beta1.CreatePreferencesResponse.preference:type_name -> raystack.frontier.v1beta1.Preference
-	130, // 19: raystack.frontier.v1beta1.ListPlatformUsersResponse.users:type_name -> raystack.frontier.v1beta1.User
-	131, // 20: raystack.frontier.v1beta1.ListPlatformUsersResponse.serviceusers:type_name -> raystack.frontier.v1beta1.ServiceUser
-	143, // 21: raystack.frontier.v1beta1.DelegatedCheckoutRequest.subscription_body:type_name -> raystack.frontier.v1beta1.CheckoutSubscriptionBody
-	144, // 22: raystack.frontier.v1beta1.DelegatedCheckoutRequest.product_body:type_name -> raystack.frontier.v1beta1.CheckoutProductBody
-	145, // 23: raystack.frontier.v1beta1.DelegatedCheckoutResponse.subscription:type_name -> raystack.frontier.v1beta1.Subscription
-	146, // 24: raystack.frontier.v1beta1.DelegatedCheckoutResponse.product:type_name -> raystack.frontier.v1beta1.Product
-	147, // 25: raystack.frontier.v1beta1.ListAllInvoicesResponse.invoices:type_name -> raystack.frontier.v1beta1.Invoice
-	148, // 26: raystack.frontier.v1beta1.ListAllBillingAccountsResponse.billing_accounts:type_name -> raystack.frontier.v1beta1.BillingAccount
-	116, // 27: raystack.frontier.v1beta1.WebhookRequestBody.headers:type_name -> raystack.frontier.v1beta1.WebhookRequestBody.HeadersEntry
-	139, // 28: raystack.frontier.v1beta1.WebhookRequestBody.metadata:type_name -> google.protobuf.Struct
+	141, // 15: raystack.frontier.v1beta1.UpdatePermissionResponse.permission:type_name -> raystack.frontier.v1beta1.Permission
+	142, // 16: raystack.frontier.v1beta1.ListPreferencesResponse.preferences:type_name -> raystack.frontier.v1beta1.Preference
+	143, // 17: raystack.frontier.v1beta1.CreatePreferencesRequest.preferences:type_name -> raystack.frontier.v1beta1.PreferenceRequestBody
+	142, // 18: raystack.frontier.v1beta1.CreatePreferencesResponse.preference:type_name -> raystack.frontier.v1beta1.Preference
+	131, // 19: raystack.frontier.v1beta1.ListPlatformUsersResponse.users:type_name -> raystack.frontier.v1beta1.User
+	132, // 20: raystack.frontier.v1beta1.ListPlatformUsersResponse.serviceusers:type_name -> raystack.frontier.v1beta1.ServiceUser
+	144, // 21: raystack.frontier.v1beta1.DelegatedCheckoutRequest.subscription_body:type_name -> raystack.frontier.v1beta1.CheckoutSubscriptionBody
+	145, // 22: raystack.frontier.v1beta1.DelegatedCheckoutRequest.product_body:type_name -> raystack.frontier.v1beta1.CheckoutProductBody
+	146, // 23: raystack.frontier.v1beta1.DelegatedCheckoutResponse.subscription:type_name -> raystack.frontier.v1beta1.Subscription
+	147, // 24: raystack.frontier.v1beta1.DelegatedCheckoutResponse.product:type_name -> raystack.frontier.v1beta1.Product
+	148, // 25: raystack.frontier.v1beta1.ListAllInvoicesResponse.invoices:type_name -> raystack.frontier.v1beta1.Invoice
+	149, // 26: raystack.frontier.v1beta1.ListAllBillingAccountsResponse.billing_accounts:type_name -> raystack.frontier.v1beta1.BillingAccount
+	117, // 27: raystack.frontier.v1beta1.WebhookRequestBody.headers:type_name -> raystack.frontier.v1beta1.WebhookRequestBody.HeadersEntry
+	140, // 28: raystack.frontier.v1beta1.WebhookRequestBody.metadata:type_name -> google.protobuf.Struct
 	49,  // 29: raystack.frontier.v1beta1.CreateWebhookRequest.body:type_name -> raystack.frontier.v1beta1.WebhookRequestBody
-	149, // 30: raystack.frontier.v1beta1.CreateWebhookResponse.webhook:type_name -> raystack.frontier.v1beta1.Webhook
+	150, // 30: raystack.frontier.v1beta1.CreateWebhookResponse.webhook:type_name -> raystack.frontier.v1beta1.Webhook
 	49,  // 31: raystack.frontier.v1beta1.UpdateWebhookRequest.body:type_name -> raystack.frontier.v1beta1.WebhookRequestBody
-	149, // 32: raystack.frontier.v1beta1.UpdateWebhookResponse.webhook:type_name -> raystack.frontier.v1beta1.Webhook
-	149, // 33: raystack.frontier.v1beta1.ListWebhooksResponse.webhooks:type_name -> raystack.frontier.v1beta1.Webhook
-	150, // 34: raystack.frontier.v1beta1.SearchOrganizationsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	151, // 35: raystack.frontier.v1beta1.SetOrganizationKycResponse.organization_kyc:type_name -> raystack.frontier.v1beta1.OrganizationKyc
-	151, // 36: raystack.frontier.v1beta1.ListOrganizationsKycResponse.organizations_kyc:type_name -> raystack.frontier.v1beta1.OrganizationKyc
-	117, // 37: raystack.frontier.v1beta1.SearchOrganizationsResponse.organizations:type_name -> raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult
-	152, // 38: raystack.frontier.v1beta1.SearchOrganizationsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 39: raystack.frontier.v1beta1.SearchOrganizationsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 40: raystack.frontier.v1beta1.ListProspectsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	154, // 41: raystack.frontier.v1beta1.ListProspectsResponse.prospects:type_name -> raystack.frontier.v1beta1.Prospect
-	152, // 42: raystack.frontier.v1beta1.ListProspectsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 43: raystack.frontier.v1beta1.ListProspectsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	154, // 44: raystack.frontier.v1beta1.GetProspectResponse.prospect:type_name -> raystack.frontier.v1beta1.Prospect
-	155, // 45: raystack.frontier.v1beta1.UpdateProspectRequest.status:type_name -> raystack.frontier.v1beta1.Prospect.Status
-	139, // 46: raystack.frontier.v1beta1.UpdateProspectRequest.metadata:type_name -> google.protobuf.Struct
-	154, // 47: raystack.frontier.v1beta1.UpdateProspectResponse.prospect:type_name -> raystack.frontier.v1beta1.Prospect
-	155, // 48: raystack.frontier.v1beta1.CreateProspectRequest.status:type_name -> raystack.frontier.v1beta1.Prospect.Status
-	139, // 49: raystack.frontier.v1beta1.CreateProspectRequest.metadata:type_name -> google.protobuf.Struct
-	154, // 50: raystack.frontier.v1beta1.CreateProspectResponse.prospect:type_name -> raystack.frontier.v1beta1.Prospect
-	150, // 51: raystack.frontier.v1beta1.SearchOrganizationUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	118, // 52: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.org_users:type_name -> raystack.frontier.v1beta1.SearchOrganizationUsersResponse.OrganizationUser
-	152, // 53: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 54: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 55: raystack.frontier.v1beta1.SearchOrganizationProjectsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	119, // 56: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.org_projects:type_name -> raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.OrganizationProject
-	152, // 57: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 58: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 59: raystack.frontier.v1beta1.SearchProjectUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	120, // 60: raystack.frontier.v1beta1.SearchProjectUsersResponse.project_users:type_name -> raystack.frontier.v1beta1.SearchProjectUsersResponse.ProjectUser
-	152, // 61: raystack.frontier.v1beta1.SearchProjectUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 62: raystack.frontier.v1beta1.SearchProjectUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 63: raystack.frontier.v1beta1.SearchOrganizationInvoicesRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	121, // 64: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.organization_invoices:type_name -> raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.OrganizationInvoice
-	152, // 65: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 66: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 67: raystack.frontier.v1beta1.SearchOrganizationTokensRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	122, // 68: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.organization_tokens:type_name -> raystack.frontier.v1beta1.SearchOrganizationTokensResponse.OrganizationToken
-	152, // 69: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 70: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 71: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	123, // 72: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.organization_serviceuser_credentials:type_name -> raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.OrganizationServiceUserCredential
-	152, // 73: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 74: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 75: raystack.frontier.v1beta1.SearchUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	130, // 76: raystack.frontier.v1beta1.SearchUsersResponse.users:type_name -> raystack.frontier.v1beta1.User
-	152, // 77: raystack.frontier.v1beta1.SearchUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 78: raystack.frontier.v1beta1.SearchUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 79: raystack.frontier.v1beta1.SearchUserOrganizationsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	124, // 80: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.user_organizations:type_name -> raystack.frontier.v1beta1.SearchUserOrganizationsResponse.UserOrganization
-	152, // 81: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 82: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 83: raystack.frontier.v1beta1.SearchUserProjectsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	125, // 84: raystack.frontier.v1beta1.SearchUserProjectsResponse.user_projects:type_name -> raystack.frontier.v1beta1.SearchUserProjectsResponse.UserProject
-	152, // 85: raystack.frontier.v1beta1.SearchUserProjectsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 86: raystack.frontier.v1beta1.SearchUserProjectsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	126, // 87: raystack.frontier.v1beta1.AdminCreateOrganizationRequest.body:type_name -> raystack.frontier.v1beta1.AdminCreateOrganizationRequest.OrganizationRequestBody
-	133, // 88: raystack.frontier.v1beta1.AdminCreateOrganizationResponse.organization:type_name -> raystack.frontier.v1beta1.Organization
-	150, // 89: raystack.frontier.v1beta1.SearchInvoicesRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	127, // 90: raystack.frontier.v1beta1.SearchInvoicesResponse.invoices:type_name -> raystack.frontier.v1beta1.SearchInvoicesResponse.Invoice
-	152, // 91: raystack.frontier.v1beta1.SearchInvoicesResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 92: raystack.frontier.v1beta1.SearchInvoicesResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	150, // 93: raystack.frontier.v1beta1.SearchOrganizationServiceUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	129, // 94: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.organization_service_users:type_name -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser
-	152, // 95: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 96: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	130, // 97: raystack.frontier.v1beta1.GetCurrentAdminUserResponse.user:type_name -> raystack.frontier.v1beta1.User
-	131, // 98: raystack.frontier.v1beta1.GetCurrentAdminUserResponse.service_user:type_name -> raystack.frontier.v1beta1.ServiceUser
-	156, // 99: raystack.frontier.v1beta1.ListUserSessionsResponse.sessions:type_name -> raystack.frontier.v1beta1.Session
-	150, // 100: raystack.frontier.v1beta1.ListAuditRecordsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
-	157, // 101: raystack.frontier.v1beta1.ListAuditRecordsResponse.audit_records:type_name -> raystack.frontier.v1beta1.AuditRecord
-	152, // 102: raystack.frontier.v1beta1.ListAuditRecordsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	153, // 103: raystack.frontier.v1beta1.ListAuditRecordsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
-	158, // 104: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult.created_at:type_name -> google.protobuf.Timestamp
-	158, // 105: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult.updated_at:type_name -> google.protobuf.Timestamp
-	158, // 106: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult.subscription_cycle_end_at:type_name -> google.protobuf.Timestamp
-	158, // 107: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.OrganizationUser.org_joined_at:type_name -> google.protobuf.Timestamp
-	158, // 108: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.OrganizationProject.created_at:type_name -> google.protobuf.Timestamp
-	158, // 109: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.OrganizationInvoice.created_at:type_name -> google.protobuf.Timestamp
-	158, // 110: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.OrganizationToken.created_at:type_name -> google.protobuf.Timestamp
-	158, // 111: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.OrganizationServiceUserCredential.created_at:type_name -> google.protobuf.Timestamp
-	158, // 112: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.UserOrganization.org_joined_on:type_name -> google.protobuf.Timestamp
-	158, // 113: raystack.frontier.v1beta1.SearchUserProjectsResponse.UserProject.project_created_on:type_name -> google.protobuf.Timestamp
-	139, // 114: raystack.frontier.v1beta1.AdminCreateOrganizationRequest.OrganizationRequestBody.metadata:type_name -> google.protobuf.Struct
-	158, // 115: raystack.frontier.v1beta1.SearchInvoicesResponse.Invoice.created_at:type_name -> google.protobuf.Timestamp
-	128, // 116: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser.projects:type_name -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.Project
-	158, // 117: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser.created_at:type_name -> google.protobuf.Timestamp
-	0,   // 118: raystack.frontier.v1beta1.AdminService.ListAllUsers:input_type -> raystack.frontier.v1beta1.ListAllUsersRequest
-	2,   // 119: raystack.frontier.v1beta1.AdminService.ListAllServiceUsers:input_type -> raystack.frontier.v1beta1.ListAllServiceUsersRequest
-	4,   // 120: raystack.frontier.v1beta1.AdminService.ListGroups:input_type -> raystack.frontier.v1beta1.ListGroupsRequest
-	6,   // 121: raystack.frontier.v1beta1.AdminService.ListAllOrganizations:input_type -> raystack.frontier.v1beta1.ListAllOrganizationsRequest
-	102, // 122: raystack.frontier.v1beta1.AdminService.AdminCreateOrganization:input_type -> raystack.frontier.v1beta1.AdminCreateOrganizationRequest
-	65,  // 123: raystack.frontier.v1beta1.AdminService.SearchOrganizations:input_type -> raystack.frontier.v1beta1.SearchOrganizationsRequest
-	80,  // 124: raystack.frontier.v1beta1.AdminService.SearchOrganizationUsers:input_type -> raystack.frontier.v1beta1.SearchOrganizationUsersRequest
-	86,  // 125: raystack.frontier.v1beta1.AdminService.SearchProjectUsers:input_type -> raystack.frontier.v1beta1.SearchProjectUsersRequest
-	83,  // 126: raystack.frontier.v1beta1.AdminService.SearchOrganizationProjects:input_type -> raystack.frontier.v1beta1.SearchOrganizationProjectsRequest
-	88,  // 127: raystack.frontier.v1beta1.AdminService.SearchOrganizationInvoices:input_type -> raystack.frontier.v1beta1.SearchOrganizationInvoicesRequest
-	90,  // 128: raystack.frontier.v1beta1.AdminService.SearchOrganizationTokens:input_type -> raystack.frontier.v1beta1.SearchOrganizationTokensRequest
-	93,  // 129: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUserCredentials:input_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsRequest
-	106, // 130: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUsers:input_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersRequest
-	159, // 131: raystack.frontier.v1beta1.AdminService.ExportOrganizations:input_type -> raystack.frontier.v1beta1.ExportOrganizationsRequest
-	82,  // 132: raystack.frontier.v1beta1.AdminService.ExportOrganizationUsers:input_type -> raystack.frontier.v1beta1.ExportOrganizationUsersRequest
-	85,  // 133: raystack.frontier.v1beta1.AdminService.ExportOrganizationProjects:input_type -> raystack.frontier.v1beta1.ExportOrganizationProjectsRequest
-	92,  // 134: raystack.frontier.v1beta1.AdminService.ExportOrganizationTokens:input_type -> raystack.frontier.v1beta1.ExportOrganizationTokensRequest
-	97,  // 135: raystack.frontier.v1beta1.AdminService.ExportUsers:input_type -> raystack.frontier.v1beta1.ExportUsersRequest
-	95,  // 136: raystack.frontier.v1beta1.AdminService.SearchUsers:input_type -> raystack.frontier.v1beta1.SearchUsersRequest
-	98,  // 137: raystack.frontier.v1beta1.AdminService.SearchUserOrganizations:input_type -> raystack.frontier.v1beta1.SearchUserOrganizationsRequest
-	100, // 138: raystack.frontier.v1beta1.AdminService.SearchUserProjects:input_type -> raystack.frontier.v1beta1.SearchUserProjectsRequest
-	64,  // 139: raystack.frontier.v1beta1.AdminService.SetOrganizationKyc:input_type -> raystack.frontier.v1beta1.SetOrganizationKycRequest
-	67,  // 140: raystack.frontier.v1beta1.AdminService.ListOrganizationsKyc:input_type -> raystack.frontier.v1beta1.ListOrganizationsKycRequest
-	8,   // 141: raystack.frontier.v1beta1.AdminService.ListProjects:input_type -> raystack.frontier.v1beta1.ListProjectsRequest
-	10,  // 142: raystack.frontier.v1beta1.AdminService.ListRelations:input_type -> raystack.frontier.v1beta1.ListRelationsRequest
-	12,  // 143: raystack.frontier.v1beta1.AdminService.ListResources:input_type -> raystack.frontier.v1beta1.ListResourcesRequest
-	14,  // 144: raystack.frontier.v1beta1.AdminService.CreateRole:input_type -> raystack.frontier.v1beta1.CreateRoleRequest
-	16,  // 145: raystack.frontier.v1beta1.AdminService.UpdateRole:input_type -> raystack.frontier.v1beta1.UpdateRoleRequest
-	18,  // 146: raystack.frontier.v1beta1.AdminService.DeleteRole:input_type -> raystack.frontier.v1beta1.DeleteRoleRequest
-	21,  // 147: raystack.frontier.v1beta1.AdminService.CreatePermission:input_type -> raystack.frontier.v1beta1.CreatePermissionRequest
-	23,  // 148: raystack.frontier.v1beta1.AdminService.UpdatePermission:input_type -> raystack.frontier.v1beta1.UpdatePermissionRequest
-	25,  // 149: raystack.frontier.v1beta1.AdminService.DeletePermission:input_type -> raystack.frontier.v1beta1.DeletePermissionRequest
-	27,  // 150: raystack.frontier.v1beta1.AdminService.ListPreferences:input_type -> raystack.frontier.v1beta1.ListPreferencesRequest
-	29,  // 151: raystack.frontier.v1beta1.AdminService.CreatePreferences:input_type -> raystack.frontier.v1beta1.CreatePreferencesRequest
-	31,  // 152: raystack.frontier.v1beta1.AdminService.CheckFederatedResourcePermission:input_type -> raystack.frontier.v1beta1.CheckFederatedResourcePermissionRequest
-	33,  // 153: raystack.frontier.v1beta1.AdminService.AddPlatformUser:input_type -> raystack.frontier.v1beta1.AddPlatformUserRequest
-	35,  // 154: raystack.frontier.v1beta1.AdminService.ListPlatformUsers:input_type -> raystack.frontier.v1beta1.ListPlatformUsersRequest
-	37,  // 155: raystack.frontier.v1beta1.AdminService.RemovePlatformUser:input_type -> raystack.frontier.v1beta1.RemovePlatformUserRequest
-	39,  // 156: raystack.frontier.v1beta1.AdminService.DelegatedCheckout:input_type -> raystack.frontier.v1beta1.DelegatedCheckoutRequest
-	41,  // 157: raystack.frontier.v1beta1.AdminService.ListAllInvoices:input_type -> raystack.frontier.v1beta1.ListAllInvoicesRequest
-	43,  // 158: raystack.frontier.v1beta1.AdminService.GenerateInvoices:input_type -> raystack.frontier.v1beta1.GenerateInvoicesRequest
-	45,  // 159: raystack.frontier.v1beta1.AdminService.ListAllBillingAccounts:input_type -> raystack.frontier.v1beta1.ListAllBillingAccountsRequest
-	47,  // 160: raystack.frontier.v1beta1.AdminService.RevertBillingUsage:input_type -> raystack.frontier.v1beta1.RevertBillingUsageRequest
-	50,  // 161: raystack.frontier.v1beta1.AdminService.CreateWebhook:input_type -> raystack.frontier.v1beta1.CreateWebhookRequest
-	52,  // 162: raystack.frontier.v1beta1.AdminService.UpdateWebhook:input_type -> raystack.frontier.v1beta1.UpdateWebhookRequest
-	54,  // 163: raystack.frontier.v1beta1.AdminService.DeleteWebhook:input_type -> raystack.frontier.v1beta1.DeleteWebhookRequest
-	56,  // 164: raystack.frontier.v1beta1.AdminService.ListWebhooks:input_type -> raystack.frontier.v1beta1.ListWebhooksRequest
-	58,  // 165: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountLimits:input_type -> raystack.frontier.v1beta1.UpdateBillingAccountLimitsRequest
-	60,  // 166: raystack.frontier.v1beta1.AdminService.GetBillingAccountDetails:input_type -> raystack.frontier.v1beta1.GetBillingAccountDetailsRequest
-	62,  // 167: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountDetails:input_type -> raystack.frontier.v1beta1.UpdateBillingAccountDetailsRequest
-	78,  // 168: raystack.frontier.v1beta1.AdminService.CreateProspect:input_type -> raystack.frontier.v1beta1.CreateProspectRequest
-	70,  // 169: raystack.frontier.v1beta1.AdminService.ListProspects:input_type -> raystack.frontier.v1beta1.ListProspectsRequest
-	72,  // 170: raystack.frontier.v1beta1.AdminService.GetProspect:input_type -> raystack.frontier.v1beta1.GetProspectRequest
-	74,  // 171: raystack.frontier.v1beta1.AdminService.UpdateProspect:input_type -> raystack.frontier.v1beta1.UpdateProspectRequest
-	76,  // 172: raystack.frontier.v1beta1.AdminService.DeleteProspect:input_type -> raystack.frontier.v1beta1.DeleteProspectRequest
-	104, // 173: raystack.frontier.v1beta1.AdminService.SearchInvoices:input_type -> raystack.frontier.v1beta1.SearchInvoicesRequest
-	108, // 174: raystack.frontier.v1beta1.AdminService.GetCurrentAdminUser:input_type -> raystack.frontier.v1beta1.GetCurrentAdminUserRequest
-	110, // 175: raystack.frontier.v1beta1.AdminService.ListUserSessions:input_type -> raystack.frontier.v1beta1.ListUserSessionsRequest
-	112, // 176: raystack.frontier.v1beta1.AdminService.RevokeUserSession:input_type -> raystack.frontier.v1beta1.RevokeUserSessionRequest
-	114, // 177: raystack.frontier.v1beta1.AdminService.ListAuditRecords:input_type -> raystack.frontier.v1beta1.ListAuditRecordsRequest
-	1,   // 178: raystack.frontier.v1beta1.AdminService.ListAllUsers:output_type -> raystack.frontier.v1beta1.ListAllUsersResponse
-	3,   // 179: raystack.frontier.v1beta1.AdminService.ListAllServiceUsers:output_type -> raystack.frontier.v1beta1.ListAllServiceUsersResponse
-	5,   // 180: raystack.frontier.v1beta1.AdminService.ListGroups:output_type -> raystack.frontier.v1beta1.ListGroupsResponse
-	7,   // 181: raystack.frontier.v1beta1.AdminService.ListAllOrganizations:output_type -> raystack.frontier.v1beta1.ListAllOrganizationsResponse
-	103, // 182: raystack.frontier.v1beta1.AdminService.AdminCreateOrganization:output_type -> raystack.frontier.v1beta1.AdminCreateOrganizationResponse
-	69,  // 183: raystack.frontier.v1beta1.AdminService.SearchOrganizations:output_type -> raystack.frontier.v1beta1.SearchOrganizationsResponse
-	81,  // 184: raystack.frontier.v1beta1.AdminService.SearchOrganizationUsers:output_type -> raystack.frontier.v1beta1.SearchOrganizationUsersResponse
-	87,  // 185: raystack.frontier.v1beta1.AdminService.SearchProjectUsers:output_type -> raystack.frontier.v1beta1.SearchProjectUsersResponse
-	84,  // 186: raystack.frontier.v1beta1.AdminService.SearchOrganizationProjects:output_type -> raystack.frontier.v1beta1.SearchOrganizationProjectsResponse
-	89,  // 187: raystack.frontier.v1beta1.AdminService.SearchOrganizationInvoices:output_type -> raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse
-	91,  // 188: raystack.frontier.v1beta1.AdminService.SearchOrganizationTokens:output_type -> raystack.frontier.v1beta1.SearchOrganizationTokensResponse
-	94,  // 189: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUserCredentials:output_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse
-	107, // 190: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUsers:output_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse
-	160, // 191: raystack.frontier.v1beta1.AdminService.ExportOrganizations:output_type -> google.api.HttpBody
-	160, // 192: raystack.frontier.v1beta1.AdminService.ExportOrganizationUsers:output_type -> google.api.HttpBody
-	160, // 193: raystack.frontier.v1beta1.AdminService.ExportOrganizationProjects:output_type -> google.api.HttpBody
-	160, // 194: raystack.frontier.v1beta1.AdminService.ExportOrganizationTokens:output_type -> google.api.HttpBody
-	160, // 195: raystack.frontier.v1beta1.AdminService.ExportUsers:output_type -> google.api.HttpBody
-	96,  // 196: raystack.frontier.v1beta1.AdminService.SearchUsers:output_type -> raystack.frontier.v1beta1.SearchUsersResponse
-	99,  // 197: raystack.frontier.v1beta1.AdminService.SearchUserOrganizations:output_type -> raystack.frontier.v1beta1.SearchUserOrganizationsResponse
-	101, // 198: raystack.frontier.v1beta1.AdminService.SearchUserProjects:output_type -> raystack.frontier.v1beta1.SearchUserProjectsResponse
-	66,  // 199: raystack.frontier.v1beta1.AdminService.SetOrganizationKyc:output_type -> raystack.frontier.v1beta1.SetOrganizationKycResponse
-	68,  // 200: raystack.frontier.v1beta1.AdminService.ListOrganizationsKyc:output_type -> raystack.frontier.v1beta1.ListOrganizationsKycResponse
-	9,   // 201: raystack.frontier.v1beta1.AdminService.ListProjects:output_type -> raystack.frontier.v1beta1.ListProjectsResponse
-	11,  // 202: raystack.frontier.v1beta1.AdminService.ListRelations:output_type -> raystack.frontier.v1beta1.ListRelationsResponse
-	13,  // 203: raystack.frontier.v1beta1.AdminService.ListResources:output_type -> raystack.frontier.v1beta1.ListResourcesResponse
-	15,  // 204: raystack.frontier.v1beta1.AdminService.CreateRole:output_type -> raystack.frontier.v1beta1.CreateRoleResponse
-	17,  // 205: raystack.frontier.v1beta1.AdminService.UpdateRole:output_type -> raystack.frontier.v1beta1.UpdateRoleResponse
-	19,  // 206: raystack.frontier.v1beta1.AdminService.DeleteRole:output_type -> raystack.frontier.v1beta1.DeleteRoleResponse
-	22,  // 207: raystack.frontier.v1beta1.AdminService.CreatePermission:output_type -> raystack.frontier.v1beta1.CreatePermissionResponse
-	24,  // 208: raystack.frontier.v1beta1.AdminService.UpdatePermission:output_type -> raystack.frontier.v1beta1.UpdatePermissionResponse
-	26,  // 209: raystack.frontier.v1beta1.AdminService.DeletePermission:output_type -> raystack.frontier.v1beta1.DeletePermissionResponse
-	28,  // 210: raystack.frontier.v1beta1.AdminService.ListPreferences:output_type -> raystack.frontier.v1beta1.ListPreferencesResponse
-	30,  // 211: raystack.frontier.v1beta1.AdminService.CreatePreferences:output_type -> raystack.frontier.v1beta1.CreatePreferencesResponse
-	32,  // 212: raystack.frontier.v1beta1.AdminService.CheckFederatedResourcePermission:output_type -> raystack.frontier.v1beta1.CheckFederatedResourcePermissionResponse
-	34,  // 213: raystack.frontier.v1beta1.AdminService.AddPlatformUser:output_type -> raystack.frontier.v1beta1.AddPlatformUserResponse
-	36,  // 214: raystack.frontier.v1beta1.AdminService.ListPlatformUsers:output_type -> raystack.frontier.v1beta1.ListPlatformUsersResponse
-	38,  // 215: raystack.frontier.v1beta1.AdminService.RemovePlatformUser:output_type -> raystack.frontier.v1beta1.RemovePlatformUserResponse
-	40,  // 216: raystack.frontier.v1beta1.AdminService.DelegatedCheckout:output_type -> raystack.frontier.v1beta1.DelegatedCheckoutResponse
-	42,  // 217: raystack.frontier.v1beta1.AdminService.ListAllInvoices:output_type -> raystack.frontier.v1beta1.ListAllInvoicesResponse
-	44,  // 218: raystack.frontier.v1beta1.AdminService.GenerateInvoices:output_type -> raystack.frontier.v1beta1.GenerateInvoicesResponse
-	46,  // 219: raystack.frontier.v1beta1.AdminService.ListAllBillingAccounts:output_type -> raystack.frontier.v1beta1.ListAllBillingAccountsResponse
-	48,  // 220: raystack.frontier.v1beta1.AdminService.RevertBillingUsage:output_type -> raystack.frontier.v1beta1.RevertBillingUsageResponse
-	51,  // 221: raystack.frontier.v1beta1.AdminService.CreateWebhook:output_type -> raystack.frontier.v1beta1.CreateWebhookResponse
-	53,  // 222: raystack.frontier.v1beta1.AdminService.UpdateWebhook:output_type -> raystack.frontier.v1beta1.UpdateWebhookResponse
-	55,  // 223: raystack.frontier.v1beta1.AdminService.DeleteWebhook:output_type -> raystack.frontier.v1beta1.DeleteWebhookResponse
-	57,  // 224: raystack.frontier.v1beta1.AdminService.ListWebhooks:output_type -> raystack.frontier.v1beta1.ListWebhooksResponse
-	59,  // 225: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountLimits:output_type -> raystack.frontier.v1beta1.UpdateBillingAccountLimitsResponse
-	61,  // 226: raystack.frontier.v1beta1.AdminService.GetBillingAccountDetails:output_type -> raystack.frontier.v1beta1.GetBillingAccountDetailsResponse
-	63,  // 227: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountDetails:output_type -> raystack.frontier.v1beta1.UpdateBillingAccountDetailsResponse
-	79,  // 228: raystack.frontier.v1beta1.AdminService.CreateProspect:output_type -> raystack.frontier.v1beta1.CreateProspectResponse
-	71,  // 229: raystack.frontier.v1beta1.AdminService.ListProspects:output_type -> raystack.frontier.v1beta1.ListProspectsResponse
-	73,  // 230: raystack.frontier.v1beta1.AdminService.GetProspect:output_type -> raystack.frontier.v1beta1.GetProspectResponse
-	75,  // 231: raystack.frontier.v1beta1.AdminService.UpdateProspect:output_type -> raystack.frontier.v1beta1.UpdateProspectResponse
-	77,  // 232: raystack.frontier.v1beta1.AdminService.DeleteProspect:output_type -> raystack.frontier.v1beta1.DeleteProspectResponse
-	105, // 233: raystack.frontier.v1beta1.AdminService.SearchInvoices:output_type -> raystack.frontier.v1beta1.SearchInvoicesResponse
-	109, // 234: raystack.frontier.v1beta1.AdminService.GetCurrentAdminUser:output_type -> raystack.frontier.v1beta1.GetCurrentAdminUserResponse
-	111, // 235: raystack.frontier.v1beta1.AdminService.ListUserSessions:output_type -> raystack.frontier.v1beta1.ListUserSessionsResponse
-	113, // 236: raystack.frontier.v1beta1.AdminService.RevokeUserSession:output_type -> raystack.frontier.v1beta1.RevokeUserSessionResponse
-	115, // 237: raystack.frontier.v1beta1.AdminService.ListAuditRecords:output_type -> raystack.frontier.v1beta1.ListAuditRecordsResponse
-	178, // [178:238] is the sub-list for method output_type
-	118, // [118:178] is the sub-list for method input_type
-	118, // [118:118] is the sub-list for extension type_name
-	118, // [118:118] is the sub-list for extension extendee
-	0,   // [0:118] is the sub-list for field type_name
+	150, // 32: raystack.frontier.v1beta1.UpdateWebhookResponse.webhook:type_name -> raystack.frontier.v1beta1.Webhook
+	150, // 33: raystack.frontier.v1beta1.ListWebhooksResponse.webhooks:type_name -> raystack.frontier.v1beta1.Webhook
+	151, // 34: raystack.frontier.v1beta1.SearchOrganizationsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	152, // 35: raystack.frontier.v1beta1.SetOrganizationKycResponse.organization_kyc:type_name -> raystack.frontier.v1beta1.OrganizationKyc
+	152, // 36: raystack.frontier.v1beta1.ListOrganizationsKycResponse.organizations_kyc:type_name -> raystack.frontier.v1beta1.OrganizationKyc
+	118, // 37: raystack.frontier.v1beta1.SearchOrganizationsResponse.organizations:type_name -> raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult
+	153, // 38: raystack.frontier.v1beta1.SearchOrganizationsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 39: raystack.frontier.v1beta1.SearchOrganizationsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 40: raystack.frontier.v1beta1.ListProspectsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	155, // 41: raystack.frontier.v1beta1.ListProspectsResponse.prospects:type_name -> raystack.frontier.v1beta1.Prospect
+	153, // 42: raystack.frontier.v1beta1.ListProspectsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 43: raystack.frontier.v1beta1.ListProspectsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	155, // 44: raystack.frontier.v1beta1.GetProspectResponse.prospect:type_name -> raystack.frontier.v1beta1.Prospect
+	156, // 45: raystack.frontier.v1beta1.UpdateProspectRequest.status:type_name -> raystack.frontier.v1beta1.Prospect.Status
+	140, // 46: raystack.frontier.v1beta1.UpdateProspectRequest.metadata:type_name -> google.protobuf.Struct
+	155, // 47: raystack.frontier.v1beta1.UpdateProspectResponse.prospect:type_name -> raystack.frontier.v1beta1.Prospect
+	156, // 48: raystack.frontier.v1beta1.CreateProspectRequest.status:type_name -> raystack.frontier.v1beta1.Prospect.Status
+	140, // 49: raystack.frontier.v1beta1.CreateProspectRequest.metadata:type_name -> google.protobuf.Struct
+	155, // 50: raystack.frontier.v1beta1.CreateProspectResponse.prospect:type_name -> raystack.frontier.v1beta1.Prospect
+	151, // 51: raystack.frontier.v1beta1.SearchOrganizationUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	119, // 52: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.org_users:type_name -> raystack.frontier.v1beta1.SearchOrganizationUsersResponse.OrganizationUser
+	153, // 53: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 54: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 55: raystack.frontier.v1beta1.SearchOrganizationProjectsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	120, // 56: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.org_projects:type_name -> raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.OrganizationProject
+	153, // 57: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 58: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 59: raystack.frontier.v1beta1.SearchProjectUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	121, // 60: raystack.frontier.v1beta1.SearchProjectUsersResponse.project_users:type_name -> raystack.frontier.v1beta1.SearchProjectUsersResponse.ProjectUser
+	153, // 61: raystack.frontier.v1beta1.SearchProjectUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 62: raystack.frontier.v1beta1.SearchProjectUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 63: raystack.frontier.v1beta1.SearchOrganizationInvoicesRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	122, // 64: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.organization_invoices:type_name -> raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.OrganizationInvoice
+	153, // 65: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 66: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 67: raystack.frontier.v1beta1.SearchOrganizationTokensRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	123, // 68: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.organization_tokens:type_name -> raystack.frontier.v1beta1.SearchOrganizationTokensResponse.OrganizationToken
+	153, // 69: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 70: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 71: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	124, // 72: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.organization_serviceuser_credentials:type_name -> raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.OrganizationServiceUserCredential
+	153, // 73: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 74: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 75: raystack.frontier.v1beta1.SearchUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	131, // 76: raystack.frontier.v1beta1.SearchUsersResponse.users:type_name -> raystack.frontier.v1beta1.User
+	153, // 77: raystack.frontier.v1beta1.SearchUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 78: raystack.frontier.v1beta1.SearchUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 79: raystack.frontier.v1beta1.SearchUserOrganizationsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	125, // 80: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.user_organizations:type_name -> raystack.frontier.v1beta1.SearchUserOrganizationsResponse.UserOrganization
+	153, // 81: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 82: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 83: raystack.frontier.v1beta1.SearchUserProjectsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	126, // 84: raystack.frontier.v1beta1.SearchUserProjectsResponse.user_projects:type_name -> raystack.frontier.v1beta1.SearchUserProjectsResponse.UserProject
+	153, // 85: raystack.frontier.v1beta1.SearchUserProjectsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 86: raystack.frontier.v1beta1.SearchUserProjectsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	127, // 87: raystack.frontier.v1beta1.AdminCreateOrganizationRequest.body:type_name -> raystack.frontier.v1beta1.AdminCreateOrganizationRequest.OrganizationRequestBody
+	134, // 88: raystack.frontier.v1beta1.AdminCreateOrganizationResponse.organization:type_name -> raystack.frontier.v1beta1.Organization
+	151, // 89: raystack.frontier.v1beta1.SearchInvoicesRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	128, // 90: raystack.frontier.v1beta1.SearchInvoicesResponse.invoices:type_name -> raystack.frontier.v1beta1.SearchInvoicesResponse.Invoice
+	153, // 91: raystack.frontier.v1beta1.SearchInvoicesResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 92: raystack.frontier.v1beta1.SearchInvoicesResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	151, // 93: raystack.frontier.v1beta1.SearchOrganizationServiceUsersRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	130, // 94: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.organization_service_users:type_name -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser
+	153, // 95: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 96: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	131, // 97: raystack.frontier.v1beta1.GetCurrentAdminUserResponse.user:type_name -> raystack.frontier.v1beta1.User
+	132, // 98: raystack.frontier.v1beta1.GetCurrentAdminUserResponse.service_user:type_name -> raystack.frontier.v1beta1.ServiceUser
+	157, // 99: raystack.frontier.v1beta1.ListUserSessionsResponse.sessions:type_name -> raystack.frontier.v1beta1.Session
+	151, // 100: raystack.frontier.v1beta1.ListAuditRecordsRequest.query:type_name -> raystack.frontier.v1beta1.RQLRequest
+	158, // 101: raystack.frontier.v1beta1.ExportAuditRecordsRequest.query:type_name -> raystack.frontier.v1beta1.RQLExportRequest
+	159, // 102: raystack.frontier.v1beta1.ListAuditRecordsResponse.audit_records:type_name -> raystack.frontier.v1beta1.AuditRecord
+	153, // 103: raystack.frontier.v1beta1.ListAuditRecordsResponse.pagination:type_name -> raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	154, // 104: raystack.frontier.v1beta1.ListAuditRecordsResponse.group:type_name -> raystack.frontier.v1beta1.RQLQueryGroupResponse
+	160, // 105: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult.created_at:type_name -> google.protobuf.Timestamp
+	160, // 106: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult.updated_at:type_name -> google.protobuf.Timestamp
+	160, // 107: raystack.frontier.v1beta1.SearchOrganizationsResponse.OrganizationResult.subscription_cycle_end_at:type_name -> google.protobuf.Timestamp
+	160, // 108: raystack.frontier.v1beta1.SearchOrganizationUsersResponse.OrganizationUser.org_joined_at:type_name -> google.protobuf.Timestamp
+	160, // 109: raystack.frontier.v1beta1.SearchOrganizationProjectsResponse.OrganizationProject.created_at:type_name -> google.protobuf.Timestamp
+	160, // 110: raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse.OrganizationInvoice.created_at:type_name -> google.protobuf.Timestamp
+	160, // 111: raystack.frontier.v1beta1.SearchOrganizationTokensResponse.OrganizationToken.created_at:type_name -> google.protobuf.Timestamp
+	160, // 112: raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse.OrganizationServiceUserCredential.created_at:type_name -> google.protobuf.Timestamp
+	160, // 113: raystack.frontier.v1beta1.SearchUserOrganizationsResponse.UserOrganization.org_joined_on:type_name -> google.protobuf.Timestamp
+	160, // 114: raystack.frontier.v1beta1.SearchUserProjectsResponse.UserProject.project_created_on:type_name -> google.protobuf.Timestamp
+	140, // 115: raystack.frontier.v1beta1.AdminCreateOrganizationRequest.OrganizationRequestBody.metadata:type_name -> google.protobuf.Struct
+	160, // 116: raystack.frontier.v1beta1.SearchInvoicesResponse.Invoice.created_at:type_name -> google.protobuf.Timestamp
+	129, // 117: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser.projects:type_name -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.Project
+	160, // 118: raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse.OrganizationServiceUser.created_at:type_name -> google.protobuf.Timestamp
+	0,   // 119: raystack.frontier.v1beta1.AdminService.ListAllUsers:input_type -> raystack.frontier.v1beta1.ListAllUsersRequest
+	2,   // 120: raystack.frontier.v1beta1.AdminService.ListAllServiceUsers:input_type -> raystack.frontier.v1beta1.ListAllServiceUsersRequest
+	4,   // 121: raystack.frontier.v1beta1.AdminService.ListGroups:input_type -> raystack.frontier.v1beta1.ListGroupsRequest
+	6,   // 122: raystack.frontier.v1beta1.AdminService.ListAllOrganizations:input_type -> raystack.frontier.v1beta1.ListAllOrganizationsRequest
+	102, // 123: raystack.frontier.v1beta1.AdminService.AdminCreateOrganization:input_type -> raystack.frontier.v1beta1.AdminCreateOrganizationRequest
+	65,  // 124: raystack.frontier.v1beta1.AdminService.SearchOrganizations:input_type -> raystack.frontier.v1beta1.SearchOrganizationsRequest
+	80,  // 125: raystack.frontier.v1beta1.AdminService.SearchOrganizationUsers:input_type -> raystack.frontier.v1beta1.SearchOrganizationUsersRequest
+	86,  // 126: raystack.frontier.v1beta1.AdminService.SearchProjectUsers:input_type -> raystack.frontier.v1beta1.SearchProjectUsersRequest
+	83,  // 127: raystack.frontier.v1beta1.AdminService.SearchOrganizationProjects:input_type -> raystack.frontier.v1beta1.SearchOrganizationProjectsRequest
+	88,  // 128: raystack.frontier.v1beta1.AdminService.SearchOrganizationInvoices:input_type -> raystack.frontier.v1beta1.SearchOrganizationInvoicesRequest
+	90,  // 129: raystack.frontier.v1beta1.AdminService.SearchOrganizationTokens:input_type -> raystack.frontier.v1beta1.SearchOrganizationTokensRequest
+	93,  // 130: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUserCredentials:input_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsRequest
+	106, // 131: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUsers:input_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersRequest
+	161, // 132: raystack.frontier.v1beta1.AdminService.ExportOrganizations:input_type -> raystack.frontier.v1beta1.ExportOrganizationsRequest
+	82,  // 133: raystack.frontier.v1beta1.AdminService.ExportOrganizationUsers:input_type -> raystack.frontier.v1beta1.ExportOrganizationUsersRequest
+	85,  // 134: raystack.frontier.v1beta1.AdminService.ExportOrganizationProjects:input_type -> raystack.frontier.v1beta1.ExportOrganizationProjectsRequest
+	92,  // 135: raystack.frontier.v1beta1.AdminService.ExportOrganizationTokens:input_type -> raystack.frontier.v1beta1.ExportOrganizationTokensRequest
+	97,  // 136: raystack.frontier.v1beta1.AdminService.ExportUsers:input_type -> raystack.frontier.v1beta1.ExportUsersRequest
+	95,  // 137: raystack.frontier.v1beta1.AdminService.SearchUsers:input_type -> raystack.frontier.v1beta1.SearchUsersRequest
+	98,  // 138: raystack.frontier.v1beta1.AdminService.SearchUserOrganizations:input_type -> raystack.frontier.v1beta1.SearchUserOrganizationsRequest
+	100, // 139: raystack.frontier.v1beta1.AdminService.SearchUserProjects:input_type -> raystack.frontier.v1beta1.SearchUserProjectsRequest
+	64,  // 140: raystack.frontier.v1beta1.AdminService.SetOrganizationKyc:input_type -> raystack.frontier.v1beta1.SetOrganizationKycRequest
+	67,  // 141: raystack.frontier.v1beta1.AdminService.ListOrganizationsKyc:input_type -> raystack.frontier.v1beta1.ListOrganizationsKycRequest
+	8,   // 142: raystack.frontier.v1beta1.AdminService.ListProjects:input_type -> raystack.frontier.v1beta1.ListProjectsRequest
+	10,  // 143: raystack.frontier.v1beta1.AdminService.ListRelations:input_type -> raystack.frontier.v1beta1.ListRelationsRequest
+	12,  // 144: raystack.frontier.v1beta1.AdminService.ListResources:input_type -> raystack.frontier.v1beta1.ListResourcesRequest
+	14,  // 145: raystack.frontier.v1beta1.AdminService.CreateRole:input_type -> raystack.frontier.v1beta1.CreateRoleRequest
+	16,  // 146: raystack.frontier.v1beta1.AdminService.UpdateRole:input_type -> raystack.frontier.v1beta1.UpdateRoleRequest
+	18,  // 147: raystack.frontier.v1beta1.AdminService.DeleteRole:input_type -> raystack.frontier.v1beta1.DeleteRoleRequest
+	21,  // 148: raystack.frontier.v1beta1.AdminService.CreatePermission:input_type -> raystack.frontier.v1beta1.CreatePermissionRequest
+	23,  // 149: raystack.frontier.v1beta1.AdminService.UpdatePermission:input_type -> raystack.frontier.v1beta1.UpdatePermissionRequest
+	25,  // 150: raystack.frontier.v1beta1.AdminService.DeletePermission:input_type -> raystack.frontier.v1beta1.DeletePermissionRequest
+	27,  // 151: raystack.frontier.v1beta1.AdminService.ListPreferences:input_type -> raystack.frontier.v1beta1.ListPreferencesRequest
+	29,  // 152: raystack.frontier.v1beta1.AdminService.CreatePreferences:input_type -> raystack.frontier.v1beta1.CreatePreferencesRequest
+	31,  // 153: raystack.frontier.v1beta1.AdminService.CheckFederatedResourcePermission:input_type -> raystack.frontier.v1beta1.CheckFederatedResourcePermissionRequest
+	33,  // 154: raystack.frontier.v1beta1.AdminService.AddPlatformUser:input_type -> raystack.frontier.v1beta1.AddPlatformUserRequest
+	35,  // 155: raystack.frontier.v1beta1.AdminService.ListPlatformUsers:input_type -> raystack.frontier.v1beta1.ListPlatformUsersRequest
+	37,  // 156: raystack.frontier.v1beta1.AdminService.RemovePlatformUser:input_type -> raystack.frontier.v1beta1.RemovePlatformUserRequest
+	39,  // 157: raystack.frontier.v1beta1.AdminService.DelegatedCheckout:input_type -> raystack.frontier.v1beta1.DelegatedCheckoutRequest
+	41,  // 158: raystack.frontier.v1beta1.AdminService.ListAllInvoices:input_type -> raystack.frontier.v1beta1.ListAllInvoicesRequest
+	43,  // 159: raystack.frontier.v1beta1.AdminService.GenerateInvoices:input_type -> raystack.frontier.v1beta1.GenerateInvoicesRequest
+	45,  // 160: raystack.frontier.v1beta1.AdminService.ListAllBillingAccounts:input_type -> raystack.frontier.v1beta1.ListAllBillingAccountsRequest
+	47,  // 161: raystack.frontier.v1beta1.AdminService.RevertBillingUsage:input_type -> raystack.frontier.v1beta1.RevertBillingUsageRequest
+	50,  // 162: raystack.frontier.v1beta1.AdminService.CreateWebhook:input_type -> raystack.frontier.v1beta1.CreateWebhookRequest
+	52,  // 163: raystack.frontier.v1beta1.AdminService.UpdateWebhook:input_type -> raystack.frontier.v1beta1.UpdateWebhookRequest
+	54,  // 164: raystack.frontier.v1beta1.AdminService.DeleteWebhook:input_type -> raystack.frontier.v1beta1.DeleteWebhookRequest
+	56,  // 165: raystack.frontier.v1beta1.AdminService.ListWebhooks:input_type -> raystack.frontier.v1beta1.ListWebhooksRequest
+	58,  // 166: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountLimits:input_type -> raystack.frontier.v1beta1.UpdateBillingAccountLimitsRequest
+	60,  // 167: raystack.frontier.v1beta1.AdminService.GetBillingAccountDetails:input_type -> raystack.frontier.v1beta1.GetBillingAccountDetailsRequest
+	62,  // 168: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountDetails:input_type -> raystack.frontier.v1beta1.UpdateBillingAccountDetailsRequest
+	78,  // 169: raystack.frontier.v1beta1.AdminService.CreateProspect:input_type -> raystack.frontier.v1beta1.CreateProspectRequest
+	70,  // 170: raystack.frontier.v1beta1.AdminService.ListProspects:input_type -> raystack.frontier.v1beta1.ListProspectsRequest
+	72,  // 171: raystack.frontier.v1beta1.AdminService.GetProspect:input_type -> raystack.frontier.v1beta1.GetProspectRequest
+	74,  // 172: raystack.frontier.v1beta1.AdminService.UpdateProspect:input_type -> raystack.frontier.v1beta1.UpdateProspectRequest
+	76,  // 173: raystack.frontier.v1beta1.AdminService.DeleteProspect:input_type -> raystack.frontier.v1beta1.DeleteProspectRequest
+	104, // 174: raystack.frontier.v1beta1.AdminService.SearchInvoices:input_type -> raystack.frontier.v1beta1.SearchInvoicesRequest
+	108, // 175: raystack.frontier.v1beta1.AdminService.GetCurrentAdminUser:input_type -> raystack.frontier.v1beta1.GetCurrentAdminUserRequest
+	110, // 176: raystack.frontier.v1beta1.AdminService.ListUserSessions:input_type -> raystack.frontier.v1beta1.ListUserSessionsRequest
+	112, // 177: raystack.frontier.v1beta1.AdminService.RevokeUserSession:input_type -> raystack.frontier.v1beta1.RevokeUserSessionRequest
+	114, // 178: raystack.frontier.v1beta1.AdminService.ListAuditRecords:input_type -> raystack.frontier.v1beta1.ListAuditRecordsRequest
+	115, // 179: raystack.frontier.v1beta1.AdminService.ExportAuditRecords:input_type -> raystack.frontier.v1beta1.ExportAuditRecordsRequest
+	1,   // 180: raystack.frontier.v1beta1.AdminService.ListAllUsers:output_type -> raystack.frontier.v1beta1.ListAllUsersResponse
+	3,   // 181: raystack.frontier.v1beta1.AdminService.ListAllServiceUsers:output_type -> raystack.frontier.v1beta1.ListAllServiceUsersResponse
+	5,   // 182: raystack.frontier.v1beta1.AdminService.ListGroups:output_type -> raystack.frontier.v1beta1.ListGroupsResponse
+	7,   // 183: raystack.frontier.v1beta1.AdminService.ListAllOrganizations:output_type -> raystack.frontier.v1beta1.ListAllOrganizationsResponse
+	103, // 184: raystack.frontier.v1beta1.AdminService.AdminCreateOrganization:output_type -> raystack.frontier.v1beta1.AdminCreateOrganizationResponse
+	69,  // 185: raystack.frontier.v1beta1.AdminService.SearchOrganizations:output_type -> raystack.frontier.v1beta1.SearchOrganizationsResponse
+	81,  // 186: raystack.frontier.v1beta1.AdminService.SearchOrganizationUsers:output_type -> raystack.frontier.v1beta1.SearchOrganizationUsersResponse
+	87,  // 187: raystack.frontier.v1beta1.AdminService.SearchProjectUsers:output_type -> raystack.frontier.v1beta1.SearchProjectUsersResponse
+	84,  // 188: raystack.frontier.v1beta1.AdminService.SearchOrganizationProjects:output_type -> raystack.frontier.v1beta1.SearchOrganizationProjectsResponse
+	89,  // 189: raystack.frontier.v1beta1.AdminService.SearchOrganizationInvoices:output_type -> raystack.frontier.v1beta1.SearchOrganizationInvoicesResponse
+	91,  // 190: raystack.frontier.v1beta1.AdminService.SearchOrganizationTokens:output_type -> raystack.frontier.v1beta1.SearchOrganizationTokensResponse
+	94,  // 191: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUserCredentials:output_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUserCredentialsResponse
+	107, // 192: raystack.frontier.v1beta1.AdminService.SearchOrganizationServiceUsers:output_type -> raystack.frontier.v1beta1.SearchOrganizationServiceUsersResponse
+	162, // 193: raystack.frontier.v1beta1.AdminService.ExportOrganizations:output_type -> google.api.HttpBody
+	162, // 194: raystack.frontier.v1beta1.AdminService.ExportOrganizationUsers:output_type -> google.api.HttpBody
+	162, // 195: raystack.frontier.v1beta1.AdminService.ExportOrganizationProjects:output_type -> google.api.HttpBody
+	162, // 196: raystack.frontier.v1beta1.AdminService.ExportOrganizationTokens:output_type -> google.api.HttpBody
+	162, // 197: raystack.frontier.v1beta1.AdminService.ExportUsers:output_type -> google.api.HttpBody
+	96,  // 198: raystack.frontier.v1beta1.AdminService.SearchUsers:output_type -> raystack.frontier.v1beta1.SearchUsersResponse
+	99,  // 199: raystack.frontier.v1beta1.AdminService.SearchUserOrganizations:output_type -> raystack.frontier.v1beta1.SearchUserOrganizationsResponse
+	101, // 200: raystack.frontier.v1beta1.AdminService.SearchUserProjects:output_type -> raystack.frontier.v1beta1.SearchUserProjectsResponse
+	66,  // 201: raystack.frontier.v1beta1.AdminService.SetOrganizationKyc:output_type -> raystack.frontier.v1beta1.SetOrganizationKycResponse
+	68,  // 202: raystack.frontier.v1beta1.AdminService.ListOrganizationsKyc:output_type -> raystack.frontier.v1beta1.ListOrganizationsKycResponse
+	9,   // 203: raystack.frontier.v1beta1.AdminService.ListProjects:output_type -> raystack.frontier.v1beta1.ListProjectsResponse
+	11,  // 204: raystack.frontier.v1beta1.AdminService.ListRelations:output_type -> raystack.frontier.v1beta1.ListRelationsResponse
+	13,  // 205: raystack.frontier.v1beta1.AdminService.ListResources:output_type -> raystack.frontier.v1beta1.ListResourcesResponse
+	15,  // 206: raystack.frontier.v1beta1.AdminService.CreateRole:output_type -> raystack.frontier.v1beta1.CreateRoleResponse
+	17,  // 207: raystack.frontier.v1beta1.AdminService.UpdateRole:output_type -> raystack.frontier.v1beta1.UpdateRoleResponse
+	19,  // 208: raystack.frontier.v1beta1.AdminService.DeleteRole:output_type -> raystack.frontier.v1beta1.DeleteRoleResponse
+	22,  // 209: raystack.frontier.v1beta1.AdminService.CreatePermission:output_type -> raystack.frontier.v1beta1.CreatePermissionResponse
+	24,  // 210: raystack.frontier.v1beta1.AdminService.UpdatePermission:output_type -> raystack.frontier.v1beta1.UpdatePermissionResponse
+	26,  // 211: raystack.frontier.v1beta1.AdminService.DeletePermission:output_type -> raystack.frontier.v1beta1.DeletePermissionResponse
+	28,  // 212: raystack.frontier.v1beta1.AdminService.ListPreferences:output_type -> raystack.frontier.v1beta1.ListPreferencesResponse
+	30,  // 213: raystack.frontier.v1beta1.AdminService.CreatePreferences:output_type -> raystack.frontier.v1beta1.CreatePreferencesResponse
+	32,  // 214: raystack.frontier.v1beta1.AdminService.CheckFederatedResourcePermission:output_type -> raystack.frontier.v1beta1.CheckFederatedResourcePermissionResponse
+	34,  // 215: raystack.frontier.v1beta1.AdminService.AddPlatformUser:output_type -> raystack.frontier.v1beta1.AddPlatformUserResponse
+	36,  // 216: raystack.frontier.v1beta1.AdminService.ListPlatformUsers:output_type -> raystack.frontier.v1beta1.ListPlatformUsersResponse
+	38,  // 217: raystack.frontier.v1beta1.AdminService.RemovePlatformUser:output_type -> raystack.frontier.v1beta1.RemovePlatformUserResponse
+	40,  // 218: raystack.frontier.v1beta1.AdminService.DelegatedCheckout:output_type -> raystack.frontier.v1beta1.DelegatedCheckoutResponse
+	42,  // 219: raystack.frontier.v1beta1.AdminService.ListAllInvoices:output_type -> raystack.frontier.v1beta1.ListAllInvoicesResponse
+	44,  // 220: raystack.frontier.v1beta1.AdminService.GenerateInvoices:output_type -> raystack.frontier.v1beta1.GenerateInvoicesResponse
+	46,  // 221: raystack.frontier.v1beta1.AdminService.ListAllBillingAccounts:output_type -> raystack.frontier.v1beta1.ListAllBillingAccountsResponse
+	48,  // 222: raystack.frontier.v1beta1.AdminService.RevertBillingUsage:output_type -> raystack.frontier.v1beta1.RevertBillingUsageResponse
+	51,  // 223: raystack.frontier.v1beta1.AdminService.CreateWebhook:output_type -> raystack.frontier.v1beta1.CreateWebhookResponse
+	53,  // 224: raystack.frontier.v1beta1.AdminService.UpdateWebhook:output_type -> raystack.frontier.v1beta1.UpdateWebhookResponse
+	55,  // 225: raystack.frontier.v1beta1.AdminService.DeleteWebhook:output_type -> raystack.frontier.v1beta1.DeleteWebhookResponse
+	57,  // 226: raystack.frontier.v1beta1.AdminService.ListWebhooks:output_type -> raystack.frontier.v1beta1.ListWebhooksResponse
+	59,  // 227: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountLimits:output_type -> raystack.frontier.v1beta1.UpdateBillingAccountLimitsResponse
+	61,  // 228: raystack.frontier.v1beta1.AdminService.GetBillingAccountDetails:output_type -> raystack.frontier.v1beta1.GetBillingAccountDetailsResponse
+	63,  // 229: raystack.frontier.v1beta1.AdminService.UpdateBillingAccountDetails:output_type -> raystack.frontier.v1beta1.UpdateBillingAccountDetailsResponse
+	79,  // 230: raystack.frontier.v1beta1.AdminService.CreateProspect:output_type -> raystack.frontier.v1beta1.CreateProspectResponse
+	71,  // 231: raystack.frontier.v1beta1.AdminService.ListProspects:output_type -> raystack.frontier.v1beta1.ListProspectsResponse
+	73,  // 232: raystack.frontier.v1beta1.AdminService.GetProspect:output_type -> raystack.frontier.v1beta1.GetProspectResponse
+	75,  // 233: raystack.frontier.v1beta1.AdminService.UpdateProspect:output_type -> raystack.frontier.v1beta1.UpdateProspectResponse
+	77,  // 234: raystack.frontier.v1beta1.AdminService.DeleteProspect:output_type -> raystack.frontier.v1beta1.DeleteProspectResponse
+	105, // 235: raystack.frontier.v1beta1.AdminService.SearchInvoices:output_type -> raystack.frontier.v1beta1.SearchInvoicesResponse
+	109, // 236: raystack.frontier.v1beta1.AdminService.GetCurrentAdminUser:output_type -> raystack.frontier.v1beta1.GetCurrentAdminUserResponse
+	111, // 237: raystack.frontier.v1beta1.AdminService.ListUserSessions:output_type -> raystack.frontier.v1beta1.ListUserSessionsResponse
+	113, // 238: raystack.frontier.v1beta1.AdminService.RevokeUserSession:output_type -> raystack.frontier.v1beta1.RevokeUserSessionResponse
+	116, // 239: raystack.frontier.v1beta1.AdminService.ListAuditRecords:output_type -> raystack.frontier.v1beta1.ListAuditRecordsResponse
+	162, // 240: raystack.frontier.v1beta1.AdminService.ExportAuditRecords:output_type -> google.api.HttpBody
+	180, // [180:241] is the sub-list for method output_type
+	119, // [119:180] is the sub-list for method input_type
+	119, // [119:119] is the sub-list for extension type_name
+	119, // [119:119] is the sub-list for extension extendee
+	0,   // [0:119] is the sub-list for field type_name
 }
 
 func init() { file_raystack_frontier_v1beta1_admin_proto_init() }
@@ -11984,6 +12048,18 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_admin_proto_msgTypes[115].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ExportAuditRecordsRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[116].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ListAuditRecordsResponse); i {
 			case 0:
 				return &v.state
@@ -11995,7 +12071,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[117].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[118].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationsResponse_OrganizationResult); i {
 			case 0:
 				return &v.state
@@ -12007,7 +12083,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[118].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[119].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationUsersResponse_OrganizationUser); i {
 			case 0:
 				return &v.state
@@ -12019,7 +12095,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[119].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[120].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationProjectsResponse_OrganizationProject); i {
 			case 0:
 				return &v.state
@@ -12031,7 +12107,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[120].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[121].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchProjectUsersResponse_ProjectUser); i {
 			case 0:
 				return &v.state
@@ -12043,7 +12119,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[121].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[122].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationInvoicesResponse_OrganizationInvoice); i {
 			case 0:
 				return &v.state
@@ -12055,7 +12131,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[122].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[123].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationTokensResponse_OrganizationToken); i {
 			case 0:
 				return &v.state
@@ -12067,7 +12143,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[123].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[124].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationServiceUserCredentialsResponse_OrganizationServiceUserCredential); i {
 			case 0:
 				return &v.state
@@ -12079,7 +12155,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[124].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[125].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchUserOrganizationsResponse_UserOrganization); i {
 			case 0:
 				return &v.state
@@ -12091,7 +12167,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[125].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[126].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchUserProjectsResponse_UserProject); i {
 			case 0:
 				return &v.state
@@ -12103,7 +12179,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[126].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[127].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AdminCreateOrganizationRequest_OrganizationRequestBody); i {
 			case 0:
 				return &v.state
@@ -12115,7 +12191,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[127].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[128].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchInvoicesResponse_Invoice); i {
 			case 0:
 				return &v.state
@@ -12127,7 +12203,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[128].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[129].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationServiceUsersResponse_Project); i {
 			case 0:
 				return &v.state
@@ -12139,7 +12215,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_admin_proto_msgTypes[129].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_admin_proto_msgTypes[130].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SearchOrganizationServiceUsersResponse_OrganizationServiceUser); i {
 			case 0:
 				return &v.state
@@ -12158,7 +12234,7 @@ func file_raystack_frontier_v1beta1_admin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_raystack_frontier_v1beta1_admin_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   130,
+			NumMessages:   131,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/v1beta1/admin.pb.validate.go
+++ b/proto/v1beta1/admin.pb.validate.go
@@ -15920,6 +15920,137 @@ var _ interface {
 	ErrorName() string
 } = ListAuditRecordsRequestValidationError{}
 
+// Validate checks the field values on ExportAuditRecordsRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ExportAuditRecordsRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ExportAuditRecordsRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ExportAuditRecordsRequestMultiError, or nil if none found.
+func (m *ExportAuditRecordsRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ExportAuditRecordsRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetQuery()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, ExportAuditRecordsRequestValidationError{
+					field:  "Query",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, ExportAuditRecordsRequestValidationError{
+					field:  "Query",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetQuery()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return ExportAuditRecordsRequestValidationError{
+				field:  "Query",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return ExportAuditRecordsRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ExportAuditRecordsRequestMultiError is an error wrapping multiple validation
+// errors returned by ExportAuditRecordsRequest.ValidateAll() if the
+// designated constraints aren't met.
+type ExportAuditRecordsRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ExportAuditRecordsRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ExportAuditRecordsRequestMultiError) AllErrors() []error { return m }
+
+// ExportAuditRecordsRequestValidationError is the validation error returned by
+// ExportAuditRecordsRequest.Validate if the designated constraints aren't met.
+type ExportAuditRecordsRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ExportAuditRecordsRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ExportAuditRecordsRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ExportAuditRecordsRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ExportAuditRecordsRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ExportAuditRecordsRequestValidationError) ErrorName() string {
+	return "ExportAuditRecordsRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ExportAuditRecordsRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sExportAuditRecordsRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ExportAuditRecordsRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ExportAuditRecordsRequestValidationError{}
+
 // Validate checks the field values on ListAuditRecordsResponse with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.

--- a/proto/v1beta1/admin_grpc.pb.go
+++ b/proto/v1beta1/admin_grpc.pb.go
@@ -80,6 +80,7 @@ const (
 	AdminService_ListUserSessions_FullMethodName                         = "/raystack.frontier.v1beta1.AdminService/ListUserSessions"
 	AdminService_RevokeUserSession_FullMethodName                        = "/raystack.frontier.v1beta1.AdminService/RevokeUserSession"
 	AdminService_ListAuditRecords_FullMethodName                         = "/raystack.frontier.v1beta1.AdminService/ListAuditRecords"
+	AdminService_ExportAuditRecords_FullMethodName                       = "/raystack.frontier.v1beta1.AdminService/ExportAuditRecords"
 )
 
 // AdminServiceClient is the client API for AdminService service.
@@ -178,6 +179,9 @@ type AdminServiceClient interface {
 	RevokeUserSession(ctx context.Context, in *RevokeUserSessionRequest, opts ...grpc.CallOption) (*RevokeUserSessionResponse, error)
 	// Audit Records (Admin Only)
 	ListAuditRecords(ctx context.Context, in *ListAuditRecordsRequest, opts ...grpc.CallOption) (*ListAuditRecordsResponse, error)
+	// buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+	// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+	ExportAuditRecords(ctx context.Context, in *ExportAuditRecordsRequest, opts ...grpc.CallOption) (AdminService_ExportAuditRecordsClient, error)
 }
 
 type adminServiceClient struct {
@@ -844,6 +848,38 @@ func (c *adminServiceClient) ListAuditRecords(ctx context.Context, in *ListAudit
 	return out, nil
 }
 
+func (c *adminServiceClient) ExportAuditRecords(ctx context.Context, in *ExportAuditRecordsRequest, opts ...grpc.CallOption) (AdminService_ExportAuditRecordsClient, error) {
+	stream, err := c.cc.NewStream(ctx, &AdminService_ServiceDesc.Streams[5], AdminService_ExportAuditRecords_FullMethodName, opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &adminServiceExportAuditRecordsClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type AdminService_ExportAuditRecordsClient interface {
+	Recv() (*httpbody.HttpBody, error)
+	grpc.ClientStream
+}
+
+type adminServiceExportAuditRecordsClient struct {
+	grpc.ClientStream
+}
+
+func (x *adminServiceExportAuditRecordsClient) Recv() (*httpbody.HttpBody, error) {
+	m := new(httpbody.HttpBody)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // AdminServiceServer is the server API for AdminService service.
 // All implementations must embed UnimplementedAdminServiceServer
 // for forward compatibility
@@ -940,6 +976,9 @@ type AdminServiceServer interface {
 	RevokeUserSession(context.Context, *RevokeUserSessionRequest) (*RevokeUserSessionResponse, error)
 	// Audit Records (Admin Only)
 	ListAuditRecords(context.Context, *ListAuditRecordsRequest) (*ListAuditRecordsResponse, error)
+	// buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+	// buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+	ExportAuditRecords(*ExportAuditRecordsRequest, AdminService_ExportAuditRecordsServer) error
 	mustEmbedUnimplementedAdminServiceServer()
 }
 
@@ -1126,6 +1165,9 @@ func (UnimplementedAdminServiceServer) RevokeUserSession(context.Context, *Revok
 }
 func (UnimplementedAdminServiceServer) ListAuditRecords(context.Context, *ListAuditRecordsRequest) (*ListAuditRecordsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListAuditRecords not implemented")
+}
+func (UnimplementedAdminServiceServer) ExportAuditRecords(*ExportAuditRecordsRequest, AdminService_ExportAuditRecordsServer) error {
+	return status.Errorf(codes.Unimplemented, "method ExportAuditRecords not implemented")
 }
 func (UnimplementedAdminServiceServer) mustEmbedUnimplementedAdminServiceServer() {}
 
@@ -2235,6 +2277,27 @@ func _AdminService_ListAuditRecords_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AdminService_ExportAuditRecords_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ExportAuditRecordsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(AdminServiceServer).ExportAuditRecords(m, &adminServiceExportAuditRecordsServer{stream})
+}
+
+type AdminService_ExportAuditRecordsServer interface {
+	Send(*httpbody.HttpBody) error
+	grpc.ServerStream
+}
+
+type adminServiceExportAuditRecordsServer struct {
+	grpc.ServerStream
+}
+
+func (x *adminServiceExportAuditRecordsServer) Send(m *httpbody.HttpBody) error {
+	return x.ServerStream.SendMsg(m)
+}
+
 // AdminService_ServiceDesc is the grpc.ServiceDesc for AdminService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2487,6 +2550,11 @@ var AdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "ExportUsers",
 			Handler:       _AdminService_ExportUsers_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "ExportAuditRecords",
+			Handler:       _AdminService_ExportAuditRecords_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/proto/v1beta1/models.pb.go
+++ b/proto/v1beta1/models.pb.go
@@ -4885,6 +4885,69 @@ func (x *RQLRequest) GetSort() []*RQLSort {
 	return nil
 }
 
+type RQLExportRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Filters []*RQLFilter `protobuf:"bytes,1,rep,name=filters,proto3" json:"filters,omitempty"`
+	Search  string       `protobuf:"bytes,2,opt,name=search,proto3" json:"search,omitempty"`
+	Sort    []*RQLSort   `protobuf:"bytes,3,rep,name=sort,proto3" json:"sort,omitempty"`
+}
+
+func (x *RQLExportRequest) Reset() {
+	*x = RQLExportRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[46]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *RQLExportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RQLExportRequest) ProtoMessage() {}
+
+func (x *RQLExportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[46]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RQLExportRequest.ProtoReflect.Descriptor instead.
+func (*RQLExportRequest) Descriptor() ([]byte, []int) {
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *RQLExportRequest) GetFilters() []*RQLFilter {
+	if x != nil {
+		return x.Filters
+	}
+	return nil
+}
+
+func (x *RQLExportRequest) GetSearch() string {
+	if x != nil {
+		return x.Search
+	}
+	return ""
+}
+
+func (x *RQLExportRequest) GetSort() []*RQLSort {
+	if x != nil {
+		return x.Sort
+	}
+	return nil
+}
+
 type RQLFilter struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4903,7 +4966,7 @@ type RQLFilter struct {
 func (x *RQLFilter) Reset() {
 	*x = RQLFilter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[46]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[47]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4916,7 +4979,7 @@ func (x *RQLFilter) String() string {
 func (*RQLFilter) ProtoMessage() {}
 
 func (x *RQLFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[46]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[47]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4929,7 +4992,7 @@ func (x *RQLFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RQLFilter.ProtoReflect.Descriptor instead.
 func (*RQLFilter) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{46}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *RQLFilter) GetName() string {
@@ -5008,7 +5071,7 @@ type RQLSort struct {
 func (x *RQLSort) Reset() {
 	*x = RQLSort{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[47]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[48]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5021,7 +5084,7 @@ func (x *RQLSort) String() string {
 func (*RQLSort) ProtoMessage() {}
 
 func (x *RQLSort) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[47]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[48]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5034,7 +5097,7 @@ func (x *RQLSort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RQLSort.ProtoReflect.Descriptor instead.
 func (*RQLSort) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{47}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *RQLSort) GetName() string {
@@ -5064,7 +5127,7 @@ type RQLQueryPaginationResponse struct {
 func (x *RQLQueryPaginationResponse) Reset() {
 	*x = RQLQueryPaginationResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[48]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[49]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5077,7 +5140,7 @@ func (x *RQLQueryPaginationResponse) String() string {
 func (*RQLQueryPaginationResponse) ProtoMessage() {}
 
 func (x *RQLQueryPaginationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[48]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[49]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5090,7 +5153,7 @@ func (x *RQLQueryPaginationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RQLQueryPaginationResponse.ProtoReflect.Descriptor instead.
 func (*RQLQueryPaginationResponse) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{48}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *RQLQueryPaginationResponse) GetOffset() uint32 {
@@ -5126,7 +5189,7 @@ type RQLQueryGroupResponse struct {
 func (x *RQLQueryGroupResponse) Reset() {
 	*x = RQLQueryGroupResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[49]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[50]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5139,7 +5202,7 @@ func (x *RQLQueryGroupResponse) String() string {
 func (*RQLQueryGroupResponse) ProtoMessage() {}
 
 func (x *RQLQueryGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[49]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[50]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5152,7 +5215,7 @@ func (x *RQLQueryGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RQLQueryGroupResponse.ProtoReflect.Descriptor instead.
 func (*RQLQueryGroupResponse) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{49}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *RQLQueryGroupResponse) GetName() string {
@@ -5181,7 +5244,7 @@ type RQLQueryGroupData struct {
 func (x *RQLQueryGroupData) Reset() {
 	*x = RQLQueryGroupData{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[50]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[51]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5194,7 +5257,7 @@ func (x *RQLQueryGroupData) String() string {
 func (*RQLQueryGroupData) ProtoMessage() {}
 
 func (x *RQLQueryGroupData) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[50]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[51]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5207,7 +5270,7 @@ func (x *RQLQueryGroupData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RQLQueryGroupData.ProtoReflect.Descriptor instead.
 func (*RQLQueryGroupData) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{50}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *RQLQueryGroupData) GetName() string {
@@ -5233,7 +5296,7 @@ type ExportOrganizationsRequest struct {
 func (x *ExportOrganizationsRequest) Reset() {
 	*x = ExportOrganizationsRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[51]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[52]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5246,7 +5309,7 @@ func (x *ExportOrganizationsRequest) String() string {
 func (*ExportOrganizationsRequest) ProtoMessage() {}
 
 func (x *ExportOrganizationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[51]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[52]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5259,7 +5322,7 @@ func (x *ExportOrganizationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportOrganizationsRequest.ProtoReflect.Descriptor instead.
 func (*ExportOrganizationsRequest) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{51}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{52}
 }
 
 type Session struct {
@@ -5277,7 +5340,7 @@ type Session struct {
 func (x *Session) Reset() {
 	*x = Session{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[52]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[53]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5290,7 +5353,7 @@ func (x *Session) String() string {
 func (*Session) ProtoMessage() {}
 
 func (x *Session) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[52]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[53]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5303,7 +5366,7 @@ func (x *Session) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session.ProtoReflect.Descriptor instead.
 func (*Session) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{52}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *Session) GetId() string {
@@ -5355,7 +5418,7 @@ type AuditRecordActor struct {
 func (x *AuditRecordActor) Reset() {
 	*x = AuditRecordActor{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[53]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[54]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5368,7 +5431,7 @@ func (x *AuditRecordActor) String() string {
 func (*AuditRecordActor) ProtoMessage() {}
 
 func (x *AuditRecordActor) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[53]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[54]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5381,7 +5444,7 @@ func (x *AuditRecordActor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditRecordActor.ProtoReflect.Descriptor instead.
 func (*AuditRecordActor) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{53}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *AuditRecordActor) GetId() string {
@@ -5426,7 +5489,7 @@ type AuditRecordResource struct {
 func (x *AuditRecordResource) Reset() {
 	*x = AuditRecordResource{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[54]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[55]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5439,7 +5502,7 @@ func (x *AuditRecordResource) String() string {
 func (*AuditRecordResource) ProtoMessage() {}
 
 func (x *AuditRecordResource) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[54]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[55]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5452,7 +5515,7 @@ func (x *AuditRecordResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditRecordResource.ProtoReflect.Descriptor instead.
 func (*AuditRecordResource) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{54}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *AuditRecordResource) GetId() string {
@@ -5497,7 +5560,7 @@ type AuditRecordTarget struct {
 func (x *AuditRecordTarget) Reset() {
 	*x = AuditRecordTarget{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[55]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[56]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5510,7 +5573,7 @@ func (x *AuditRecordTarget) String() string {
 func (*AuditRecordTarget) ProtoMessage() {}
 
 func (x *AuditRecordTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[55]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[56]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5523,7 +5586,7 @@ func (x *AuditRecordTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditRecordTarget.ProtoReflect.Descriptor instead.
 func (*AuditRecordTarget) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{55}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *AuditRecordTarget) GetId() string {
@@ -5574,7 +5637,7 @@ type AuditRecord struct {
 func (x *AuditRecord) Reset() {
 	*x = AuditRecord{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[56]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[57]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5587,7 +5650,7 @@ func (x *AuditRecord) String() string {
 func (*AuditRecord) ProtoMessage() {}
 
 func (x *AuditRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[56]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[57]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5600,7 +5663,7 @@ func (x *AuditRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditRecord.ProtoReflect.Descriptor instead.
 func (*AuditRecord) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{56}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *AuditRecord) GetId() string {
@@ -5689,7 +5752,7 @@ type BillingAccount_Address struct {
 func (x *BillingAccount_Address) Reset() {
 	*x = BillingAccount_Address{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[58]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[59]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5702,7 +5765,7 @@ func (x *BillingAccount_Address) String() string {
 func (*BillingAccount_Address) ProtoMessage() {}
 
 func (x *BillingAccount_Address) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[58]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[59]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5775,7 +5838,7 @@ type BillingAccount_Tax struct {
 func (x *BillingAccount_Tax) Reset() {
 	*x = BillingAccount_Tax{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[59]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[60]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5788,7 +5851,7 @@ func (x *BillingAccount_Tax) String() string {
 func (*BillingAccount_Tax) ProtoMessage() {}
 
 func (x *BillingAccount_Tax) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[59]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[60]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5831,7 +5894,7 @@ type BillingAccount_Balance struct {
 func (x *BillingAccount_Balance) Reset() {
 	*x = BillingAccount_Balance{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[60]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[61]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5844,7 +5907,7 @@ func (x *BillingAccount_Balance) String() string {
 func (*BillingAccount_Balance) ProtoMessage() {}
 
 func (x *BillingAccount_Balance) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[60]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[61]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5894,7 +5957,7 @@ type Subscription_Phase struct {
 func (x *Subscription_Phase) Reset() {
 	*x = Subscription_Phase{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[61]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[62]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5907,7 +5970,7 @@ func (x *Subscription_Phase) String() string {
 func (*Subscription_Phase) ProtoMessage() {}
 
 func (x *Subscription_Phase) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[61]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[62]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5958,7 +6021,7 @@ type Product_BehaviorConfig struct {
 func (x *Product_BehaviorConfig) Reset() {
 	*x = Product_BehaviorConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[62]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[63]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5971,7 +6034,7 @@ func (x *Product_BehaviorConfig) String() string {
 func (*Product_BehaviorConfig) ProtoMessage() {}
 
 func (x *Product_BehaviorConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[62]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[63]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6027,7 +6090,7 @@ type Webhook_Secret struct {
 func (x *Webhook_Secret) Reset() {
 	*x = Webhook_Secret{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[63]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[64]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6040,7 +6103,7 @@ func (x *Webhook_Secret) String() string {
 func (*Webhook_Secret) ProtoMessage() {}
 
 func (x *Webhook_Secret) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[63]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[64]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6084,7 +6147,7 @@ type Session_Meta struct {
 func (x *Session_Meta) Reset() {
 	*x = Session_Meta{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[65]
+		mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[66]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6097,7 +6160,7 @@ func (x *Session_Meta) String() string {
 func (*Session_Meta) ProtoMessage() {}
 
 func (x *Session_Meta) ProtoReflect() protoreflect.Message {
-	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[65]
+	mi := &file_raystack_frontier_v1beta1_models_proto_msgTypes[66]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6110,7 +6173,7 @@ func (x *Session_Meta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Session_Meta.ProtoReflect.Descriptor instead.
 func (*Session_Meta) Descriptor() ([]byte, []int) {
-	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{52, 0}
+	return file_raystack_frontier_v1beta1_models_proto_rawDescGZIP(), []int{53, 0}
 }
 
 func (x *Session_Meta) GetOperatingSystem() string {
@@ -7435,140 +7498,150 @@ var file_raystack_frontier_v1beta1_models_proto_rawDesc = []byte{
 	0x72, 0x63, 0x68, 0x12, 0x36, 0x0a, 0x04, 0x73, 0x6f, 0x72, 0x74, 0x18, 0x06, 0x20, 0x03, 0x28,
 	0x0b, 0x32, 0x22, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f,
 	0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x52, 0x51,
-	0x4c, 0x53, 0x6f, 0x72, 0x74, 0x52, 0x04, 0x73, 0x6f, 0x72, 0x74, 0x22, 0xaf, 0x01, 0x0a, 0x09,
-	0x52, 0x51, 0x4c, 0x46, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d,
-	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1a, 0x0a,
-	0x08, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
-	0x08, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x12, 0x1f, 0x0a, 0x0a, 0x62, 0x6f, 0x6f,
-	0x6c, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x48, 0x00, 0x52,
-	0x09, 0x62, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x23, 0x0a, 0x0c, 0x73, 0x74,
-	0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
-	0x48, 0x00, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
-	0x23, 0x0a, 0x0c, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18,
-	0x05, 0x20, 0x01, 0x28, 0x02, 0x48, 0x00, 0x52, 0x0b, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x56,
-	0x61, 0x6c, 0x75, 0x65, 0x42, 0x07, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22, 0x45, 0x0a,
-	0x07, 0x52, 0x51, 0x4c, 0x53, 0x6f, 0x72, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x26, 0x0a, 0x05,
-	0x6f, 0x72, 0x64, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x10, 0xfa, 0x42, 0x0d,
-	0x72, 0x0b, 0x52, 0x03, 0x61, 0x73, 0x63, 0x52, 0x04, 0x64, 0x65, 0x73, 0x63, 0x52, 0x05, 0x6f,
-	0x72, 0x64, 0x65, 0x72, 0x22, 0x6b, 0x0a, 0x1a, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65, 0x72, 0x79,
-	0x50, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
-	0x73, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6f, 0x66, 0x66, 0x73, 0x65, 0x74, 0x18, 0x01, 0x20, 0x01,
-	0x28, 0x0d, 0x52, 0x06, 0x6f, 0x66, 0x66, 0x73, 0x65, 0x74, 0x12, 0x14, 0x0a, 0x05, 0x6c, 0x69,
-	0x6d, 0x69, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05, 0x6c, 0x69, 0x6d, 0x69, 0x74,
-	0x12, 0x1f, 0x0a, 0x0b, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18,
-	0x03, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x0a, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x43, 0x6f, 0x75, 0x6e,
-	0x74, 0x22, 0x6d, 0x0a, 0x15, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65, 0x72, 0x79, 0x47, 0x72, 0x6f,
-	0x75, 0x70, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
-	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x40,
-	0x0a, 0x04, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2c, 0x2e, 0x72,
-	0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72,
-	0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65, 0x72,
-	0x79, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x44, 0x61, 0x74, 0x61, 0x52, 0x04, 0x64, 0x61, 0x74, 0x61,
-	0x22, 0x3d, 0x0a, 0x11, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65, 0x72, 0x79, 0x47, 0x72, 0x6f, 0x75,
-	0x70, 0x44, 0x61, 0x74, 0x61, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20,
-	0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x63, 0x6f, 0x75,
-	0x6e, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x22,
-	0x1c, 0x0a, 0x1a, 0x45, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x22, 0x8b, 0x03,
-	0x0a, 0x07, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18,
-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x43, 0x0a, 0x08, 0x6d, 0x65, 0x74,
-	0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x27, 0x2e, 0x72, 0x61,
-	0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e,
-	0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x2e,
-	0x4d, 0x65, 0x74, 0x61, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x2c,
-	0x0a, 0x12, 0x69, 0x73, 0x5f, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x5f, 0x73, 0x65, 0x73,
-	0x73, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x52, 0x10, 0x69, 0x73, 0x43, 0x75,
-	0x72, 0x72, 0x65, 0x6e, 0x74, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x39, 0x0a, 0x0a,
-	0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b,
-	0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
-	0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x09, 0x63, 0x72,
-	0x65, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x12, 0x39, 0x0a, 0x0a, 0x75, 0x70, 0x64, 0x61, 0x74,
-	0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f,
-	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69,
-	0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x09, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64,
-	0x41, 0x74, 0x1a, 0x86, 0x01, 0x0a, 0x04, 0x4d, 0x65, 0x74, 0x61, 0x12, 0x29, 0x0a, 0x10, 0x6f,
-	0x70, 0x65, 0x72, 0x61, 0x74, 0x69, 0x6e, 0x67, 0x5f, 0x73, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x18,
-	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x69, 0x6e, 0x67,
-	0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x12, 0x18, 0x0a, 0x07, 0x62, 0x72, 0x6f, 0x77, 0x73, 0x65,
-	0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x62, 0x72, 0x6f, 0x77, 0x73, 0x65, 0x72,
-	0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x70, 0x5f, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x18, 0x03,
-	0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x70, 0x41, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x12,
-	0x1a, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28,
-	0x09, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0x8c, 0x01, 0x0a, 0x10,
-	0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72,
-	0x12, 0x1b, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x0b, 0xe0, 0x41,
-	0x02, 0xfa, 0x42, 0x05, 0x72, 0x03, 0xb0, 0x01, 0x01, 0x52, 0x02, 0x69, 0x64, 0x12, 0x12, 0x0a,
-	0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70,
-	0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52,
-	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x33, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74,
-	0x61, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
-	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
-	0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x8c, 0x01, 0x0a, 0x13, 0x41,
-	0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72,
-	0x63, 0x65, 0x12, 0x13, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x03,
-	0xe0, 0x41, 0x02, 0x52, 0x02, 0x69, 0x64, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18,
-	0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x03, 0xe0, 0x41, 0x02, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
-	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
-	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x33, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61,
-	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52,
-	0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x80, 0x01, 0x0a, 0x11, 0x41, 0x75,
-	0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x12,
-	0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12,
-	0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74,
-	0x79, 0x70, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28,
-	0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x33, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64,
-	0x61, 0x74, 0x61, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75,
-	0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0xeb, 0x03, 0x0a,
-	0x0b, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x12, 0x0e, 0x0a, 0x02,
-	0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x41, 0x0a, 0x05,
-	0x61, 0x63, 0x74, 0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2b, 0x2e, 0x72, 0x61,
-	0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e,
-	0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63,
-	0x6f, 0x72, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x52, 0x05, 0x61, 0x63, 0x74, 0x6f, 0x72, 0x12,
-	0x14, 0x0a, 0x05, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05,
-	0x65, 0x76, 0x65, 0x6e, 0x74, 0x12, 0x4a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63,
-	0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61,
-	0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65,
-	0x74, 0x61, 0x31, 0x2e, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x52,
-	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x52, 0x08, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63,
-	0x65, 0x12, 0x44, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18, 0x05, 0x20, 0x01, 0x28,
+	0x4c, 0x53, 0x6f, 0x72, 0x74, 0x52, 0x04, 0x73, 0x6f, 0x72, 0x74, 0x22, 0xa2, 0x01, 0x0a, 0x10,
+	0x52, 0x51, 0x4c, 0x45, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x12, 0x3e, 0x0a, 0x07, 0x66, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28,
+	0x0b, 0x32, 0x24, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f,
+	0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x52, 0x51,
+	0x4c, 0x46, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x52, 0x07, 0x66, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x73,
+	0x12, 0x16, 0x0a, 0x06, 0x73, 0x65, 0x61, 0x72, 0x63, 0x68, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x06, 0x73, 0x65, 0x61, 0x72, 0x63, 0x68, 0x12, 0x36, 0x0a, 0x04, 0x73, 0x6f, 0x72, 0x74,
+	0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63,
+	0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74,
+	0x61, 0x31, 0x2e, 0x52, 0x51, 0x4c, 0x53, 0x6f, 0x72, 0x74, 0x52, 0x04, 0x73, 0x6f, 0x72, 0x74,
+	0x22, 0xaf, 0x01, 0x0a, 0x09, 0x52, 0x51, 0x4c, 0x46, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x12, 0x12,
+	0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61,
+	0x6d, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x12, 0x1f,
+	0x0a, 0x0a, 0x62, 0x6f, 0x6f, 0x6c, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20, 0x01,
+	0x28, 0x08, 0x48, 0x00, 0x52, 0x09, 0x62, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x12,
+	0x23, 0x0a, 0x0c, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18,
+	0x04, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x0b, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56,
+	0x61, 0x6c, 0x75, 0x65, 0x12, 0x23, 0x0a, 0x0c, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x5f, 0x76,
+	0x61, 0x6c, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x02, 0x48, 0x00, 0x52, 0x0b, 0x6e, 0x75,
+	0x6d, 0x62, 0x65, 0x72, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x07, 0x0a, 0x05, 0x76, 0x61, 0x6c,
+	0x75, 0x65, 0x22, 0x45, 0x0a, 0x07, 0x52, 0x51, 0x4c, 0x53, 0x6f, 0x72, 0x74, 0x12, 0x12, 0x0a,
+	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d,
+	0x65, 0x12, 0x26, 0x0a, 0x05, 0x6f, 0x72, 0x64, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x42, 0x10, 0xfa, 0x42, 0x0d, 0x72, 0x0b, 0x52, 0x03, 0x61, 0x73, 0x63, 0x52, 0x04, 0x64, 0x65,
+	0x73, 0x63, 0x52, 0x05, 0x6f, 0x72, 0x64, 0x65, 0x72, 0x22, 0x6b, 0x0a, 0x1a, 0x52, 0x51, 0x4c,
+	0x51, 0x75, 0x65, 0x72, 0x79, 0x50, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6f, 0x66, 0x66, 0x73, 0x65,
+	0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x06, 0x6f, 0x66, 0x66, 0x73, 0x65, 0x74, 0x12,
+	0x14, 0x0a, 0x05, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05,
+	0x6c, 0x69, 0x6d, 0x69, 0x74, 0x12, 0x1f, 0x0a, 0x0b, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x63,
+	0x6f, 0x75, 0x6e, 0x74, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x0a, 0x74, 0x6f, 0x74, 0x61,
+	0x6c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x22, 0x6d, 0x0a, 0x15, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65,
+	0x72, 0x79, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12,
+	0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
+	0x61, 0x6d, 0x65, 0x12, 0x40, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x03, 0x28,
 	0x0b, 0x32, 0x2c, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f,
-	0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x41, 0x75,
-	0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x52,
-	0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x12, 0x3b, 0x0a, 0x0b, 0x6f, 0x63, 0x63, 0x75, 0x72,
-	0x72, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67,
-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54,
-	0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x0a, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x72,
-	0x65, 0x64, 0x41, 0x74, 0x12, 0x15, 0x0a, 0x06, 0x6f, 0x72, 0x67, 0x5f, 0x69, 0x64, 0x18, 0x07,
-	0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x6f, 0x72, 0x67, 0x49, 0x64, 0x12, 0x1d, 0x0a, 0x0a, 0x72,
-	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x5f, 0x69, 0x64, 0x18, 0x08, 0x20, 0x01, 0x28, 0x09, 0x52,
-	0x09, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x49, 0x64, 0x12, 0x33, 0x0a, 0x08, 0x6d, 0x65,
-	0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67,
+	0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x52, 0x51,
+	0x4c, 0x51, 0x75, 0x65, 0x72, 0x79, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x44, 0x61, 0x74, 0x61, 0x52,
+	0x04, 0x64, 0x61, 0x74, 0x61, 0x22, 0x3d, 0x0a, 0x11, 0x52, 0x51, 0x4c, 0x51, 0x75, 0x65, 0x72,
+	0x79, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x44, 0x61, 0x74, 0x61, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+	0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x14,
+	0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05, 0x63,
+	0x6f, 0x75, 0x6e, 0x74, 0x22, 0x1c, 0x0a, 0x1a, 0x45, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x4f, 0x72,
+	0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x22, 0x8b, 0x03, 0x0a, 0x07, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x0e,
+	0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x43,
+	0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x27, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e,
+	0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x53, 0x65, 0x73,
+	0x73, 0x69, 0x6f, 0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64,
+	0x61, 0x74, 0x61, 0x12, 0x2c, 0x0a, 0x12, 0x69, 0x73, 0x5f, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e,
+	0x74, 0x5f, 0x73, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08, 0x52,
+	0x10, 0x69, 0x73, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f,
+	0x6e, 0x12, 0x39, 0x0a, 0x0a, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18,
+	0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d,
+	0x70, 0x52, 0x09, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x12, 0x39, 0x0a, 0x0a,
+	0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+	0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x09, 0x75, 0x70,
+	0x64, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x1a, 0x86, 0x01, 0x0a, 0x04, 0x4d, 0x65, 0x74, 0x61,
+	0x12, 0x29, 0x0a, 0x10, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x69, 0x6e, 0x67, 0x5f, 0x73, 0x79,
+	0x73, 0x74, 0x65, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x6f, 0x70, 0x65, 0x72,
+	0x61, 0x74, 0x69, 0x6e, 0x67, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x12, 0x18, 0x0a, 0x07, 0x62,
+	0x72, 0x6f, 0x77, 0x73, 0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x62, 0x72,
+	0x6f, 0x77, 0x73, 0x65, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x70, 0x5f, 0x61, 0x64, 0x64, 0x72,
+	0x65, 0x73, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x70, 0x41, 0x64, 0x64,
+	0x72, 0x65, 0x73, 0x73, 0x12, 0x1a, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x22, 0x8c, 0x01, 0x0a, 0x10, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64,
+	0x41, 0x63, 0x74, 0x6f, 0x72, 0x12, 0x1b, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x09, 0x42, 0x0b, 0xe0, 0x41, 0x02, 0xfa, 0x42, 0x05, 0x72, 0x03, 0xb0, 0x01, 0x01, 0x52, 0x02,
+	0x69, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x33, 0x0a, 0x08, 0x6d, 0x65,
+	0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67,
 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53,
-	0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12,
-	0x39, 0x0a, 0x0a, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x0a, 0x20,
-	0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
-	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52,
-	0x09, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x42, 0xee, 0x01, 0x0a, 0x1d, 0x63,
-	0x6f, 0x6d, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e,
-	0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x42, 0x0b, 0x4d, 0x6f,
-	0x64, 0x65, 0x6c, 0x73, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3a, 0x67, 0x69, 0x74,
-	0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b,
-	0x2f, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
-	0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x3b, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72,
-	0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xa2, 0x02, 0x03, 0x52, 0x46, 0x58, 0xaa, 0x02, 0x19,
-	0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65,
-	0x72, 0x2e, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xca, 0x02, 0x19, 0x52, 0x61, 0x79, 0x73,
-	0x74, 0x61, 0x63, 0x6b, 0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x5c, 0x56, 0x31,
-	0x62, 0x65, 0x74, 0x61, 0x31, 0xe2, 0x02, 0x25, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b,
-	0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x5c, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61,
-	0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x1b,
-	0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x3a, 0x3a, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69,
-	0x65, 0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f,
-	0x74, 0x6f, 0x33,
+	0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22,
+	0x8c, 0x01, 0x0a, 0x13, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x52,
+	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x12, 0x13, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x09, 0x42, 0x03, 0xe0, 0x41, 0x02, 0x52, 0x02, 0x69, 0x64, 0x12, 0x17, 0x0a, 0x04,
+	0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x42, 0x03, 0xe0, 0x41, 0x02, 0x52,
+	0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x33, 0x0a, 0x08, 0x6d, 0x65, 0x74,
+	0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f,
+	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74,
+	0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x80,
+	0x01, 0x0a, 0x11, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x54, 0x61,
+	0x72, 0x67, 0x65, 0x74, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x02, 0x69, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x33, 0x0a, 0x08,
+	0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17,
+	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+	0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74,
+	0x61, 0x22, 0xeb, 0x03, 0x0a, 0x0b, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72,
+	0x64, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69,
+	0x64, 0x12, 0x41, 0x0a, 0x05, 0x61, 0x63, 0x74, 0x6f, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x2b, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e,
+	0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x41, 0x75, 0x64,
+	0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x41, 0x63, 0x74, 0x6f, 0x72, 0x52, 0x05, 0x61,
+	0x63, 0x74, 0x6f, 0x72, 0x12, 0x14, 0x0a, 0x05, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x18, 0x03, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x05, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x12, 0x4a, 0x0a, 0x08, 0x72, 0x65,
+	0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2e, 0x2e, 0x72,
+	0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72,
+	0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65,
+	0x63, 0x6f, 0x72, 0x64, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x52, 0x08, 0x72, 0x65,
+	0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x12, 0x44, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74,
+	0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2c, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63,
+	0x6b, 0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74,
+	0x61, 0x31, 0x2e, 0x41, 0x75, 0x64, 0x69, 0x74, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x54, 0x61,
+	0x72, 0x67, 0x65, 0x74, 0x52, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x12, 0x3b, 0x0a, 0x0b,
+	0x6f, 0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x0a, 0x6f,
+	0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x64, 0x41, 0x74, 0x12, 0x15, 0x0a, 0x06, 0x6f, 0x72, 0x67,
+	0x5f, 0x69, 0x64, 0x18, 0x07, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x6f, 0x72, 0x67, 0x49, 0x64,
+	0x12, 0x1d, 0x0a, 0x0a, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x5f, 0x69, 0x64, 0x18, 0x08,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x49, 0x64, 0x12,
+	0x33, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x09, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61,
+	0x64, 0x61, 0x74, 0x61, 0x12, 0x39, 0x0a, 0x0a, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x5f,
+	0x61, 0x74, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73,
+	0x74, 0x61, 0x6d, 0x70, 0x52, 0x09, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x41, 0x74, 0x42,
+	0xee, 0x01, 0x0a, 0x1d, 0x63, 0x6f, 0x6d, 0x2e, 0x72, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b,
+	0x2e, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61,
+	0x31, 0x42, 0x0b, 0x4d, 0x6f, 0x64, 0x65, 0x6c, 0x73, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01,
+	0x5a, 0x3a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x72, 0x61, 0x79,
+	0x73, 0x74, 0x61, 0x63, 0x6b, 0x2f, 0x66, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2f, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x3b, 0x66, 0x72, 0x6f,
+	0x6e, 0x74, 0x69, 0x65, 0x72, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xa2, 0x02, 0x03, 0x52,
+	0x46, 0x58, 0xaa, 0x02, 0x19, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x2e, 0x46, 0x72,
+	0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x2e, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xca, 0x02,
+	0x19, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69,
+	0x65, 0x72, 0x5c, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0xe2, 0x02, 0x25, 0x52, 0x61, 0x79,
+	0x73, 0x74, 0x61, 0x63, 0x6b, 0x5c, 0x46, 0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x5c, 0x56,
+	0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61,
+	0x74, 0x61, 0xea, 0x02, 0x1b, 0x52, 0x61, 0x79, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x3a, 0x3a, 0x46,
+	0x72, 0x6f, 0x6e, 0x74, 0x69, 0x65, 0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -7584,7 +7657,7 @@ func file_raystack_frontier_v1beta1_models_proto_rawDescGZIP() []byte {
 }
 
 var file_raystack_frontier_v1beta1_models_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_raystack_frontier_v1beta1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
+var file_raystack_frontier_v1beta1_models_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_raystack_frontier_v1beta1_models_proto_goTypes = []interface{}{
 	(Prospect_Status)(0),               // 0: raystack.frontier.v1beta1.Prospect.Status
 	(*User)(nil),                       // 1: raystack.frontier.v1beta1.User
@@ -7633,172 +7706,175 @@ var file_raystack_frontier_v1beta1_models_proto_goTypes = []interface{}{
 	(*CheckoutSetupBody)(nil),          // 44: raystack.frontier.v1beta1.CheckoutSetupBody
 	(*Prospect)(nil),                   // 45: raystack.frontier.v1beta1.Prospect
 	(*RQLRequest)(nil),                 // 46: raystack.frontier.v1beta1.RQLRequest
-	(*RQLFilter)(nil),                  // 47: raystack.frontier.v1beta1.RQLFilter
-	(*RQLSort)(nil),                    // 48: raystack.frontier.v1beta1.RQLSort
-	(*RQLQueryPaginationResponse)(nil), // 49: raystack.frontier.v1beta1.RQLQueryPaginationResponse
-	(*RQLQueryGroupResponse)(nil),      // 50: raystack.frontier.v1beta1.RQLQueryGroupResponse
-	(*RQLQueryGroupData)(nil),          // 51: raystack.frontier.v1beta1.RQLQueryGroupData
-	(*ExportOrganizationsRequest)(nil), // 52: raystack.frontier.v1beta1.ExportOrganizationsRequest
-	(*Session)(nil),                    // 53: raystack.frontier.v1beta1.Session
-	(*AuditRecordActor)(nil),           // 54: raystack.frontier.v1beta1.AuditRecordActor
-	(*AuditRecordResource)(nil),        // 55: raystack.frontier.v1beta1.AuditRecordResource
-	(*AuditRecordTarget)(nil),          // 56: raystack.frontier.v1beta1.AuditRecordTarget
-	(*AuditRecord)(nil),                // 57: raystack.frontier.v1beta1.AuditRecord
-	nil,                                // 58: raystack.frontier.v1beta1.AuditLog.ContextEntry
-	(*BillingAccount_Address)(nil),     // 59: raystack.frontier.v1beta1.BillingAccount.Address
-	(*BillingAccount_Tax)(nil),         // 60: raystack.frontier.v1beta1.BillingAccount.Tax
-	(*BillingAccount_Balance)(nil),     // 61: raystack.frontier.v1beta1.BillingAccount.Balance
-	(*Subscription_Phase)(nil),         // 62: raystack.frontier.v1beta1.Subscription.Phase
-	(*Product_BehaviorConfig)(nil),     // 63: raystack.frontier.v1beta1.Product.BehaviorConfig
-	(*Webhook_Secret)(nil),             // 64: raystack.frontier.v1beta1.Webhook.Secret
-	nil,                                // 65: raystack.frontier.v1beta1.Webhook.HeadersEntry
-	(*Session_Meta)(nil),               // 66: raystack.frontier.v1beta1.Session.Meta
-	(*structpb.Struct)(nil),            // 67: google.protobuf.Struct
-	(*timestamppb.Timestamp)(nil),      // 68: google.protobuf.Timestamp
+	(*RQLExportRequest)(nil),           // 47: raystack.frontier.v1beta1.RQLExportRequest
+	(*RQLFilter)(nil),                  // 48: raystack.frontier.v1beta1.RQLFilter
+	(*RQLSort)(nil),                    // 49: raystack.frontier.v1beta1.RQLSort
+	(*RQLQueryPaginationResponse)(nil), // 50: raystack.frontier.v1beta1.RQLQueryPaginationResponse
+	(*RQLQueryGroupResponse)(nil),      // 51: raystack.frontier.v1beta1.RQLQueryGroupResponse
+	(*RQLQueryGroupData)(nil),          // 52: raystack.frontier.v1beta1.RQLQueryGroupData
+	(*ExportOrganizationsRequest)(nil), // 53: raystack.frontier.v1beta1.ExportOrganizationsRequest
+	(*Session)(nil),                    // 54: raystack.frontier.v1beta1.Session
+	(*AuditRecordActor)(nil),           // 55: raystack.frontier.v1beta1.AuditRecordActor
+	(*AuditRecordResource)(nil),        // 56: raystack.frontier.v1beta1.AuditRecordResource
+	(*AuditRecordTarget)(nil),          // 57: raystack.frontier.v1beta1.AuditRecordTarget
+	(*AuditRecord)(nil),                // 58: raystack.frontier.v1beta1.AuditRecord
+	nil,                                // 59: raystack.frontier.v1beta1.AuditLog.ContextEntry
+	(*BillingAccount_Address)(nil),     // 60: raystack.frontier.v1beta1.BillingAccount.Address
+	(*BillingAccount_Tax)(nil),         // 61: raystack.frontier.v1beta1.BillingAccount.Tax
+	(*BillingAccount_Balance)(nil),     // 62: raystack.frontier.v1beta1.BillingAccount.Balance
+	(*Subscription_Phase)(nil),         // 63: raystack.frontier.v1beta1.Subscription.Phase
+	(*Product_BehaviorConfig)(nil),     // 64: raystack.frontier.v1beta1.Product.BehaviorConfig
+	(*Webhook_Secret)(nil),             // 65: raystack.frontier.v1beta1.Webhook.Secret
+	nil,                                // 66: raystack.frontier.v1beta1.Webhook.HeadersEntry
+	(*Session_Meta)(nil),               // 67: raystack.frontier.v1beta1.Session.Meta
+	(*structpb.Struct)(nil),            // 68: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil),      // 69: google.protobuf.Timestamp
 }
 var file_raystack_frontier_v1beta1_models_proto_depIdxs = []int32{
-	67,  // 0: raystack.frontier.v1beta1.User.metadata:type_name -> google.protobuf.Struct
-	68,  // 1: raystack.frontier.v1beta1.User.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 2: raystack.frontier.v1beta1.User.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 3: raystack.frontier.v1beta1.ServiceUser.metadata:type_name -> google.protobuf.Struct
-	68,  // 4: raystack.frontier.v1beta1.ServiceUser.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 5: raystack.frontier.v1beta1.ServiceUser.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 6: raystack.frontier.v1beta1.Group.metadata:type_name -> google.protobuf.Struct
-	68,  // 7: raystack.frontier.v1beta1.Group.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 8: raystack.frontier.v1beta1.Group.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 0: raystack.frontier.v1beta1.User.metadata:type_name -> google.protobuf.Struct
+	69,  // 1: raystack.frontier.v1beta1.User.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 2: raystack.frontier.v1beta1.User.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 3: raystack.frontier.v1beta1.ServiceUser.metadata:type_name -> google.protobuf.Struct
+	69,  // 4: raystack.frontier.v1beta1.ServiceUser.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 5: raystack.frontier.v1beta1.ServiceUser.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 6: raystack.frontier.v1beta1.Group.metadata:type_name -> google.protobuf.Struct
+	69,  // 7: raystack.frontier.v1beta1.Group.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 8: raystack.frontier.v1beta1.Group.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 9: raystack.frontier.v1beta1.Group.users:type_name -> raystack.frontier.v1beta1.User
-	67,  // 10: raystack.frontier.v1beta1.Role.metadata:type_name -> google.protobuf.Struct
-	68,  // 11: raystack.frontier.v1beta1.Role.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 12: raystack.frontier.v1beta1.Role.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 13: raystack.frontier.v1beta1.Organization.metadata:type_name -> google.protobuf.Struct
-	68,  // 14: raystack.frontier.v1beta1.Organization.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 15: raystack.frontier.v1beta1.Organization.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 16: raystack.frontier.v1beta1.OrganizationKyc.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 17: raystack.frontier.v1beta1.OrganizationKyc.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 18: raystack.frontier.v1beta1.Project.metadata:type_name -> google.protobuf.Struct
-	68,  // 19: raystack.frontier.v1beta1.Project.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 20: raystack.frontier.v1beta1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 21: raystack.frontier.v1beta1.Domain.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 22: raystack.frontier.v1beta1.Domain.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 23: raystack.frontier.v1beta1.Policy.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 24: raystack.frontier.v1beta1.Policy.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 25: raystack.frontier.v1beta1.Policy.metadata:type_name -> google.protobuf.Struct
-	68,  // 26: raystack.frontier.v1beta1.Relation.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 27: raystack.frontier.v1beta1.Relation.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 28: raystack.frontier.v1beta1.Permission.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 29: raystack.frontier.v1beta1.Permission.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 30: raystack.frontier.v1beta1.Permission.metadata:type_name -> google.protobuf.Struct
-	67,  // 31: raystack.frontier.v1beta1.Namespace.metadata:type_name -> google.protobuf.Struct
-	68,  // 32: raystack.frontier.v1beta1.Namespace.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 33: raystack.frontier.v1beta1.Namespace.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 34: raystack.frontier.v1beta1.Resource.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 35: raystack.frontier.v1beta1.Resource.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 36: raystack.frontier.v1beta1.Resource.metadata:type_name -> google.protobuf.Struct
-	68,  // 37: raystack.frontier.v1beta1.MetaSchema.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 38: raystack.frontier.v1beta1.MetaSchema.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 39: raystack.frontier.v1beta1.Invitation.metadata:type_name -> google.protobuf.Struct
-	68,  // 40: raystack.frontier.v1beta1.Invitation.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 41: raystack.frontier.v1beta1.Invitation.expires_at:type_name -> google.protobuf.Timestamp
-	68,  // 42: raystack.frontier.v1beta1.ServiceUserJWK.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 43: raystack.frontier.v1beta1.SecretCredential.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 44: raystack.frontier.v1beta1.ServiceUserToken.created_at:type_name -> google.protobuf.Timestamp
+	68,  // 10: raystack.frontier.v1beta1.Role.metadata:type_name -> google.protobuf.Struct
+	69,  // 11: raystack.frontier.v1beta1.Role.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 12: raystack.frontier.v1beta1.Role.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 13: raystack.frontier.v1beta1.Organization.metadata:type_name -> google.protobuf.Struct
+	69,  // 14: raystack.frontier.v1beta1.Organization.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 15: raystack.frontier.v1beta1.Organization.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 16: raystack.frontier.v1beta1.OrganizationKyc.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 17: raystack.frontier.v1beta1.OrganizationKyc.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 18: raystack.frontier.v1beta1.Project.metadata:type_name -> google.protobuf.Struct
+	69,  // 19: raystack.frontier.v1beta1.Project.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 20: raystack.frontier.v1beta1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 21: raystack.frontier.v1beta1.Domain.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 22: raystack.frontier.v1beta1.Domain.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 23: raystack.frontier.v1beta1.Policy.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 24: raystack.frontier.v1beta1.Policy.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 25: raystack.frontier.v1beta1.Policy.metadata:type_name -> google.protobuf.Struct
+	69,  // 26: raystack.frontier.v1beta1.Relation.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 27: raystack.frontier.v1beta1.Relation.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 28: raystack.frontier.v1beta1.Permission.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 29: raystack.frontier.v1beta1.Permission.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 30: raystack.frontier.v1beta1.Permission.metadata:type_name -> google.protobuf.Struct
+	68,  // 31: raystack.frontier.v1beta1.Namespace.metadata:type_name -> google.protobuf.Struct
+	69,  // 32: raystack.frontier.v1beta1.Namespace.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 33: raystack.frontier.v1beta1.Namespace.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 34: raystack.frontier.v1beta1.Resource.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 35: raystack.frontier.v1beta1.Resource.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 36: raystack.frontier.v1beta1.Resource.metadata:type_name -> google.protobuf.Struct
+	69,  // 37: raystack.frontier.v1beta1.MetaSchema.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 38: raystack.frontier.v1beta1.MetaSchema.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 39: raystack.frontier.v1beta1.Invitation.metadata:type_name -> google.protobuf.Struct
+	69,  // 40: raystack.frontier.v1beta1.Invitation.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 41: raystack.frontier.v1beta1.Invitation.expires_at:type_name -> google.protobuf.Timestamp
+	69,  // 42: raystack.frontier.v1beta1.ServiceUserJWK.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 43: raystack.frontier.v1beta1.SecretCredential.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 44: raystack.frontier.v1beta1.ServiceUserToken.created_at:type_name -> google.protobuf.Timestamp
 	21,  // 45: raystack.frontier.v1beta1.AuditLog.actor:type_name -> raystack.frontier.v1beta1.AuditLogActor
 	22,  // 46: raystack.frontier.v1beta1.AuditLog.target:type_name -> raystack.frontier.v1beta1.AuditLogTarget
-	58,  // 47: raystack.frontier.v1beta1.AuditLog.context:type_name -> raystack.frontier.v1beta1.AuditLog.ContextEntry
-	68,  // 48: raystack.frontier.v1beta1.AuditLog.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 49: raystack.frontier.v1beta1.Preference.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 50: raystack.frontier.v1beta1.Preference.updated_at:type_name -> google.protobuf.Timestamp
-	59,  // 51: raystack.frontier.v1beta1.BillingAccount.address:type_name -> raystack.frontier.v1beta1.BillingAccount.Address
-	60,  // 52: raystack.frontier.v1beta1.BillingAccount.tax_data:type_name -> raystack.frontier.v1beta1.BillingAccount.Tax
-	67,  // 53: raystack.frontier.v1beta1.BillingAccount.metadata:type_name -> google.protobuf.Struct
-	68,  // 54: raystack.frontier.v1beta1.BillingAccount.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 55: raystack.frontier.v1beta1.BillingAccount.updated_at:type_name -> google.protobuf.Timestamp
+	59,  // 47: raystack.frontier.v1beta1.AuditLog.context:type_name -> raystack.frontier.v1beta1.AuditLog.ContextEntry
+	69,  // 48: raystack.frontier.v1beta1.AuditLog.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 49: raystack.frontier.v1beta1.Preference.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 50: raystack.frontier.v1beta1.Preference.updated_at:type_name -> google.protobuf.Timestamp
+	60,  // 51: raystack.frontier.v1beta1.BillingAccount.address:type_name -> raystack.frontier.v1beta1.BillingAccount.Address
+	61,  // 52: raystack.frontier.v1beta1.BillingAccount.tax_data:type_name -> raystack.frontier.v1beta1.BillingAccount.Tax
+	68,  // 53: raystack.frontier.v1beta1.BillingAccount.metadata:type_name -> google.protobuf.Struct
+	69,  // 54: raystack.frontier.v1beta1.BillingAccount.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 55: raystack.frontier.v1beta1.BillingAccount.updated_at:type_name -> google.protobuf.Timestamp
 	5,   // 56: raystack.frontier.v1beta1.BillingAccount.organization:type_name -> raystack.frontier.v1beta1.Organization
-	67,  // 57: raystack.frontier.v1beta1.Subscription.metadata:type_name -> google.protobuf.Struct
-	68,  // 58: raystack.frontier.v1beta1.Subscription.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 59: raystack.frontier.v1beta1.Subscription.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 60: raystack.frontier.v1beta1.Subscription.canceled_at:type_name -> google.protobuf.Timestamp
-	68,  // 61: raystack.frontier.v1beta1.Subscription.ended_at:type_name -> google.protobuf.Timestamp
-	68,  // 62: raystack.frontier.v1beta1.Subscription.trial_ends_at:type_name -> google.protobuf.Timestamp
-	68,  // 63: raystack.frontier.v1beta1.Subscription.current_period_start_at:type_name -> google.protobuf.Timestamp
-	68,  // 64: raystack.frontier.v1beta1.Subscription.current_period_end_at:type_name -> google.protobuf.Timestamp
-	68,  // 65: raystack.frontier.v1beta1.Subscription.billing_cycle_anchor_at:type_name -> google.protobuf.Timestamp
-	62,  // 66: raystack.frontier.v1beta1.Subscription.phases:type_name -> raystack.frontier.v1beta1.Subscription.Phase
+	68,  // 57: raystack.frontier.v1beta1.Subscription.metadata:type_name -> google.protobuf.Struct
+	69,  // 58: raystack.frontier.v1beta1.Subscription.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 59: raystack.frontier.v1beta1.Subscription.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 60: raystack.frontier.v1beta1.Subscription.canceled_at:type_name -> google.protobuf.Timestamp
+	69,  // 61: raystack.frontier.v1beta1.Subscription.ended_at:type_name -> google.protobuf.Timestamp
+	69,  // 62: raystack.frontier.v1beta1.Subscription.trial_ends_at:type_name -> google.protobuf.Timestamp
+	69,  // 63: raystack.frontier.v1beta1.Subscription.current_period_start_at:type_name -> google.protobuf.Timestamp
+	69,  // 64: raystack.frontier.v1beta1.Subscription.current_period_end_at:type_name -> google.protobuf.Timestamp
+	69,  // 65: raystack.frontier.v1beta1.Subscription.billing_cycle_anchor_at:type_name -> google.protobuf.Timestamp
+	63,  // 66: raystack.frontier.v1beta1.Subscription.phases:type_name -> raystack.frontier.v1beta1.Subscription.Phase
 	26,  // 67: raystack.frontier.v1beta1.Subscription.customer:type_name -> raystack.frontier.v1beta1.BillingAccount
 	30,  // 68: raystack.frontier.v1beta1.Subscription.plan:type_name -> raystack.frontier.v1beta1.Plan
-	67,  // 69: raystack.frontier.v1beta1.CheckoutSession.metadata:type_name -> google.protobuf.Struct
-	68,  // 70: raystack.frontier.v1beta1.CheckoutSession.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 71: raystack.frontier.v1beta1.CheckoutSession.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 72: raystack.frontier.v1beta1.CheckoutSession.expire_at:type_name -> google.protobuf.Timestamp
+	68,  // 69: raystack.frontier.v1beta1.CheckoutSession.metadata:type_name -> google.protobuf.Struct
+	69,  // 70: raystack.frontier.v1beta1.CheckoutSession.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 71: raystack.frontier.v1beta1.CheckoutSession.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 72: raystack.frontier.v1beta1.CheckoutSession.expire_at:type_name -> google.protobuf.Timestamp
 	31,  // 73: raystack.frontier.v1beta1.Plan.products:type_name -> raystack.frontier.v1beta1.Product
-	67,  // 74: raystack.frontier.v1beta1.Plan.metadata:type_name -> google.protobuf.Struct
-	68,  // 75: raystack.frontier.v1beta1.Plan.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 76: raystack.frontier.v1beta1.Plan.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 74: raystack.frontier.v1beta1.Plan.metadata:type_name -> google.protobuf.Struct
+	69,  // 75: raystack.frontier.v1beta1.Plan.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 76: raystack.frontier.v1beta1.Plan.updated_at:type_name -> google.protobuf.Timestamp
 	33,  // 77: raystack.frontier.v1beta1.Product.prices:type_name -> raystack.frontier.v1beta1.Price
 	32,  // 78: raystack.frontier.v1beta1.Product.features:type_name -> raystack.frontier.v1beta1.Feature
-	63,  // 79: raystack.frontier.v1beta1.Product.behavior_config:type_name -> raystack.frontier.v1beta1.Product.BehaviorConfig
-	67,  // 80: raystack.frontier.v1beta1.Product.metadata:type_name -> google.protobuf.Struct
-	68,  // 81: raystack.frontier.v1beta1.Product.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 82: raystack.frontier.v1beta1.Product.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 83: raystack.frontier.v1beta1.Feature.metadata:type_name -> google.protobuf.Struct
-	68,  // 84: raystack.frontier.v1beta1.Feature.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 85: raystack.frontier.v1beta1.Feature.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 86: raystack.frontier.v1beta1.Price.metadata:type_name -> google.protobuf.Struct
-	68,  // 87: raystack.frontier.v1beta1.Price.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 88: raystack.frontier.v1beta1.Price.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 89: raystack.frontier.v1beta1.BillingTransaction.metadata:type_name -> google.protobuf.Struct
-	68,  // 90: raystack.frontier.v1beta1.BillingTransaction.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 91: raystack.frontier.v1beta1.BillingTransaction.updated_at:type_name -> google.protobuf.Timestamp
+	64,  // 79: raystack.frontier.v1beta1.Product.behavior_config:type_name -> raystack.frontier.v1beta1.Product.BehaviorConfig
+	68,  // 80: raystack.frontier.v1beta1.Product.metadata:type_name -> google.protobuf.Struct
+	69,  // 81: raystack.frontier.v1beta1.Product.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 82: raystack.frontier.v1beta1.Product.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 83: raystack.frontier.v1beta1.Feature.metadata:type_name -> google.protobuf.Struct
+	69,  // 84: raystack.frontier.v1beta1.Feature.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 85: raystack.frontier.v1beta1.Feature.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 86: raystack.frontier.v1beta1.Price.metadata:type_name -> google.protobuf.Struct
+	69,  // 87: raystack.frontier.v1beta1.Price.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 88: raystack.frontier.v1beta1.Price.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 89: raystack.frontier.v1beta1.BillingTransaction.metadata:type_name -> google.protobuf.Struct
+	69,  // 90: raystack.frontier.v1beta1.BillingTransaction.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 91: raystack.frontier.v1beta1.BillingTransaction.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 92: raystack.frontier.v1beta1.BillingTransaction.user:type_name -> raystack.frontier.v1beta1.User
 	26,  // 93: raystack.frontier.v1beta1.BillingTransaction.customer:type_name -> raystack.frontier.v1beta1.BillingAccount
-	67,  // 94: raystack.frontier.v1beta1.Usage.metadata:type_name -> google.protobuf.Struct
-	68,  // 95: raystack.frontier.v1beta1.Usage.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 96: raystack.frontier.v1beta1.Usage.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 97: raystack.frontier.v1beta1.Invoice.due_date:type_name -> google.protobuf.Timestamp
-	68,  // 98: raystack.frontier.v1beta1.Invoice.effective_at:type_name -> google.protobuf.Timestamp
-	68,  // 99: raystack.frontier.v1beta1.Invoice.period_start_at:type_name -> google.protobuf.Timestamp
-	68,  // 100: raystack.frontier.v1beta1.Invoice.period_end_at:type_name -> google.protobuf.Timestamp
-	67,  // 101: raystack.frontier.v1beta1.Invoice.metadata:type_name -> google.protobuf.Struct
-	68,  // 102: raystack.frontier.v1beta1.Invoice.created_at:type_name -> google.protobuf.Timestamp
+	68,  // 94: raystack.frontier.v1beta1.Usage.metadata:type_name -> google.protobuf.Struct
+	69,  // 95: raystack.frontier.v1beta1.Usage.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 96: raystack.frontier.v1beta1.Usage.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 97: raystack.frontier.v1beta1.Invoice.due_date:type_name -> google.protobuf.Timestamp
+	69,  // 98: raystack.frontier.v1beta1.Invoice.effective_at:type_name -> google.protobuf.Timestamp
+	69,  // 99: raystack.frontier.v1beta1.Invoice.period_start_at:type_name -> google.protobuf.Timestamp
+	69,  // 100: raystack.frontier.v1beta1.Invoice.period_end_at:type_name -> google.protobuf.Timestamp
+	68,  // 101: raystack.frontier.v1beta1.Invoice.metadata:type_name -> google.protobuf.Struct
+	69,  // 102: raystack.frontier.v1beta1.Invoice.created_at:type_name -> google.protobuf.Timestamp
 	26,  // 103: raystack.frontier.v1beta1.Invoice.customer:type_name -> raystack.frontier.v1beta1.BillingAccount
-	67,  // 104: raystack.frontier.v1beta1.PaymentMethod.metadata:type_name -> google.protobuf.Struct
-	68,  // 105: raystack.frontier.v1beta1.PaymentMethod.created_at:type_name -> google.protobuf.Timestamp
-	65,  // 106: raystack.frontier.v1beta1.Webhook.headers:type_name -> raystack.frontier.v1beta1.Webhook.HeadersEntry
-	64,  // 107: raystack.frontier.v1beta1.Webhook.secrets:type_name -> raystack.frontier.v1beta1.Webhook.Secret
-	67,  // 108: raystack.frontier.v1beta1.Webhook.metadata:type_name -> google.protobuf.Struct
-	68,  // 109: raystack.frontier.v1beta1.Webhook.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 110: raystack.frontier.v1beta1.Webhook.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 111: raystack.frontier.v1beta1.WebhookEvent.data:type_name -> google.protobuf.Struct
-	67,  // 112: raystack.frontier.v1beta1.WebhookEvent.metadata:type_name -> google.protobuf.Struct
-	68,  // 113: raystack.frontier.v1beta1.WebhookEvent.created_at:type_name -> google.protobuf.Timestamp
-	67,  // 114: raystack.frontier.v1beta1.RoleRequestBody.metadata:type_name -> google.protobuf.Struct
+	68,  // 104: raystack.frontier.v1beta1.PaymentMethod.metadata:type_name -> google.protobuf.Struct
+	69,  // 105: raystack.frontier.v1beta1.PaymentMethod.created_at:type_name -> google.protobuf.Timestamp
+	66,  // 106: raystack.frontier.v1beta1.Webhook.headers:type_name -> raystack.frontier.v1beta1.Webhook.HeadersEntry
+	65,  // 107: raystack.frontier.v1beta1.Webhook.secrets:type_name -> raystack.frontier.v1beta1.Webhook.Secret
+	68,  // 108: raystack.frontier.v1beta1.Webhook.metadata:type_name -> google.protobuf.Struct
+	69,  // 109: raystack.frontier.v1beta1.Webhook.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 110: raystack.frontier.v1beta1.Webhook.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 111: raystack.frontier.v1beta1.WebhookEvent.data:type_name -> google.protobuf.Struct
+	68,  // 112: raystack.frontier.v1beta1.WebhookEvent.metadata:type_name -> google.protobuf.Struct
+	69,  // 113: raystack.frontier.v1beta1.WebhookEvent.created_at:type_name -> google.protobuf.Timestamp
+	68,  // 114: raystack.frontier.v1beta1.RoleRequestBody.metadata:type_name -> google.protobuf.Struct
 	0,   // 115: raystack.frontier.v1beta1.Prospect.status:type_name -> raystack.frontier.v1beta1.Prospect.Status
-	68,  // 116: raystack.frontier.v1beta1.Prospect.changed_at:type_name -> google.protobuf.Timestamp
-	68,  // 117: raystack.frontier.v1beta1.Prospect.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 118: raystack.frontier.v1beta1.Prospect.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 119: raystack.frontier.v1beta1.Prospect.metadata:type_name -> google.protobuf.Struct
-	47,  // 120: raystack.frontier.v1beta1.RQLRequest.filters:type_name -> raystack.frontier.v1beta1.RQLFilter
-	48,  // 121: raystack.frontier.v1beta1.RQLRequest.sort:type_name -> raystack.frontier.v1beta1.RQLSort
-	51,  // 122: raystack.frontier.v1beta1.RQLQueryGroupResponse.data:type_name -> raystack.frontier.v1beta1.RQLQueryGroupData
-	66,  // 123: raystack.frontier.v1beta1.Session.metadata:type_name -> raystack.frontier.v1beta1.Session.Meta
-	68,  // 124: raystack.frontier.v1beta1.Session.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 125: raystack.frontier.v1beta1.Session.updated_at:type_name -> google.protobuf.Timestamp
-	67,  // 126: raystack.frontier.v1beta1.AuditRecordActor.metadata:type_name -> google.protobuf.Struct
-	67,  // 127: raystack.frontier.v1beta1.AuditRecordResource.metadata:type_name -> google.protobuf.Struct
-	67,  // 128: raystack.frontier.v1beta1.AuditRecordTarget.metadata:type_name -> google.protobuf.Struct
-	54,  // 129: raystack.frontier.v1beta1.AuditRecord.actor:type_name -> raystack.frontier.v1beta1.AuditRecordActor
-	55,  // 130: raystack.frontier.v1beta1.AuditRecord.resource:type_name -> raystack.frontier.v1beta1.AuditRecordResource
-	56,  // 131: raystack.frontier.v1beta1.AuditRecord.target:type_name -> raystack.frontier.v1beta1.AuditRecordTarget
-	68,  // 132: raystack.frontier.v1beta1.AuditRecord.occurred_at:type_name -> google.protobuf.Timestamp
-	67,  // 133: raystack.frontier.v1beta1.AuditRecord.metadata:type_name -> google.protobuf.Struct
-	68,  // 134: raystack.frontier.v1beta1.AuditRecord.created_at:type_name -> google.protobuf.Timestamp
-	68,  // 135: raystack.frontier.v1beta1.BillingAccount.Balance.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 136: raystack.frontier.v1beta1.Subscription.Phase.effective_at:type_name -> google.protobuf.Timestamp
-	137, // [137:137] is the sub-list for method output_type
-	137, // [137:137] is the sub-list for method input_type
-	137, // [137:137] is the sub-list for extension type_name
-	137, // [137:137] is the sub-list for extension extendee
-	0,   // [0:137] is the sub-list for field type_name
+	69,  // 116: raystack.frontier.v1beta1.Prospect.changed_at:type_name -> google.protobuf.Timestamp
+	69,  // 117: raystack.frontier.v1beta1.Prospect.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 118: raystack.frontier.v1beta1.Prospect.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 119: raystack.frontier.v1beta1.Prospect.metadata:type_name -> google.protobuf.Struct
+	48,  // 120: raystack.frontier.v1beta1.RQLRequest.filters:type_name -> raystack.frontier.v1beta1.RQLFilter
+	49,  // 121: raystack.frontier.v1beta1.RQLRequest.sort:type_name -> raystack.frontier.v1beta1.RQLSort
+	48,  // 122: raystack.frontier.v1beta1.RQLExportRequest.filters:type_name -> raystack.frontier.v1beta1.RQLFilter
+	49,  // 123: raystack.frontier.v1beta1.RQLExportRequest.sort:type_name -> raystack.frontier.v1beta1.RQLSort
+	52,  // 124: raystack.frontier.v1beta1.RQLQueryGroupResponse.data:type_name -> raystack.frontier.v1beta1.RQLQueryGroupData
+	67,  // 125: raystack.frontier.v1beta1.Session.metadata:type_name -> raystack.frontier.v1beta1.Session.Meta
+	69,  // 126: raystack.frontier.v1beta1.Session.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 127: raystack.frontier.v1beta1.Session.updated_at:type_name -> google.protobuf.Timestamp
+	68,  // 128: raystack.frontier.v1beta1.AuditRecordActor.metadata:type_name -> google.protobuf.Struct
+	68,  // 129: raystack.frontier.v1beta1.AuditRecordResource.metadata:type_name -> google.protobuf.Struct
+	68,  // 130: raystack.frontier.v1beta1.AuditRecordTarget.metadata:type_name -> google.protobuf.Struct
+	55,  // 131: raystack.frontier.v1beta1.AuditRecord.actor:type_name -> raystack.frontier.v1beta1.AuditRecordActor
+	56,  // 132: raystack.frontier.v1beta1.AuditRecord.resource:type_name -> raystack.frontier.v1beta1.AuditRecordResource
+	57,  // 133: raystack.frontier.v1beta1.AuditRecord.target:type_name -> raystack.frontier.v1beta1.AuditRecordTarget
+	69,  // 134: raystack.frontier.v1beta1.AuditRecord.occurred_at:type_name -> google.protobuf.Timestamp
+	68,  // 135: raystack.frontier.v1beta1.AuditRecord.metadata:type_name -> google.protobuf.Struct
+	69,  // 136: raystack.frontier.v1beta1.AuditRecord.created_at:type_name -> google.protobuf.Timestamp
+	69,  // 137: raystack.frontier.v1beta1.BillingAccount.Balance.updated_at:type_name -> google.protobuf.Timestamp
+	69,  // 138: raystack.frontier.v1beta1.Subscription.Phase.effective_at:type_name -> google.protobuf.Timestamp
+	139, // [139:139] is the sub-list for method output_type
+	139, // [139:139] is the sub-list for method input_type
+	139, // [139:139] is the sub-list for extension type_name
+	139, // [139:139] is the sub-list for extension extendee
+	0,   // [0:139] is the sub-list for field type_name
 }
 
 func init() { file_raystack_frontier_v1beta1_models_proto_init() }
@@ -8360,7 +8436,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[46].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RQLFilter); i {
+			switch v := v.(*RQLExportRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8372,7 +8448,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RQLSort); i {
+			switch v := v.(*RQLFilter); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8384,7 +8460,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[48].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RQLQueryPaginationResponse); i {
+			switch v := v.(*RQLSort); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8396,7 +8472,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[49].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RQLQueryGroupResponse); i {
+			switch v := v.(*RQLQueryPaginationResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8408,7 +8484,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[50].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RQLQueryGroupData); i {
+			switch v := v.(*RQLQueryGroupResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8420,7 +8496,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[51].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ExportOrganizationsRequest); i {
+			switch v := v.(*RQLQueryGroupData); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8432,7 +8508,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[52].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Session); i {
+			switch v := v.(*ExportOrganizationsRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8444,7 +8520,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[53].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AuditRecordActor); i {
+			switch v := v.(*Session); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8456,7 +8532,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[54].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AuditRecordResource); i {
+			switch v := v.(*AuditRecordActor); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8468,7 +8544,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[55].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AuditRecordTarget); i {
+			switch v := v.(*AuditRecordResource); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8480,6 +8556,18 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			}
 		}
 		file_raystack_frontier_v1beta1_models_proto_msgTypes[56].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*AuditRecordTarget); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[57].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AuditRecord); i {
 			case 0:
 				return &v.state
@@ -8491,7 +8579,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[58].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[59].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*BillingAccount_Address); i {
 			case 0:
 				return &v.state
@@ -8503,7 +8591,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[59].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[60].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*BillingAccount_Tax); i {
 			case 0:
 				return &v.state
@@ -8515,7 +8603,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[60].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[61].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*BillingAccount_Balance); i {
 			case 0:
 				return &v.state
@@ -8527,7 +8615,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[61].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[62].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Subscription_Phase); i {
 			case 0:
 				return &v.state
@@ -8539,7 +8627,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[62].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[63].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Product_BehaviorConfig); i {
 			case 0:
 				return &v.state
@@ -8551,7 +8639,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[63].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[64].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Webhook_Secret); i {
 			case 0:
 				return &v.state
@@ -8563,7 +8651,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 				return nil
 			}
 		}
-		file_raystack_frontier_v1beta1_models_proto_msgTypes[65].Exporter = func(v interface{}, i int) interface{} {
+		file_raystack_frontier_v1beta1_models_proto_msgTypes[66].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Session_Meta); i {
 			case 0:
 				return &v.state
@@ -8585,7 +8673,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 		(*PreferenceTrait_Multiselect)(nil),
 		(*PreferenceTrait_Number)(nil),
 	}
-	file_raystack_frontier_v1beta1_models_proto_msgTypes[46].OneofWrappers = []interface{}{
+	file_raystack_frontier_v1beta1_models_proto_msgTypes[47].OneofWrappers = []interface{}{
 		(*RQLFilter_BoolValue)(nil),
 		(*RQLFilter_StringValue)(nil),
 		(*RQLFilter_NumberValue)(nil),
@@ -8596,7 +8684,7 @@ func file_raystack_frontier_v1beta1_models_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_raystack_frontier_v1beta1_models_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   66,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/v1beta1/models.pb.validate.go
+++ b/proto/v1beta1/models.pb.validate.go
@@ -9236,6 +9236,176 @@ var _ interface {
 	ErrorName() string
 } = RQLRequestValidationError{}
 
+// Validate checks the field values on RQLExportRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *RQLExportRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on RQLExportRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// RQLExportRequestMultiError, or nil if none found.
+func (m *RQLExportRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *RQLExportRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	for idx, item := range m.GetFilters() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, RQLExportRequestValidationError{
+						field:  fmt.Sprintf("Filters[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, RQLExportRequestValidationError{
+						field:  fmt.Sprintf("Filters[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return RQLExportRequestValidationError{
+					field:  fmt.Sprintf("Filters[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	// no validation rules for Search
+
+	for idx, item := range m.GetSort() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, RQLExportRequestValidationError{
+						field:  fmt.Sprintf("Sort[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, RQLExportRequestValidationError{
+						field:  fmt.Sprintf("Sort[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return RQLExportRequestValidationError{
+					field:  fmt.Sprintf("Sort[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return RQLExportRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// RQLExportRequestMultiError is an error wrapping multiple validation errors
+// returned by RQLExportRequest.ValidateAll() if the designated constraints
+// aren't met.
+type RQLExportRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m RQLExportRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m RQLExportRequestMultiError) AllErrors() []error { return m }
+
+// RQLExportRequestValidationError is the validation error returned by
+// RQLExportRequest.Validate if the designated constraints aren't met.
+type RQLExportRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e RQLExportRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e RQLExportRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e RQLExportRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e RQLExportRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e RQLExportRequestValidationError) ErrorName() string { return "RQLExportRequestValidationError" }
+
+// Error satisfies the builtin error interface
+func (e RQLExportRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sRQLExportRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = RQLExportRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = RQLExportRequestValidationError{}
+
 // Validate checks the field values on RQLFilter with the rules defined in the
 // proto definition for this message. If any rules are violated, the first
 // error encountered is returned, or nil if there are no violations.


### PR DESCRIPTION
 This PR implements the ExportAuditRecords RPC for streaming audit record data as CSV files.

  Implementation Details

  - Repository Layer: Uses PostgreSQL server-side cursors to handle large datasets without loading all records into memory. Fetches data in configurable batches (1000 records) and streams via io.Pipe to the handler.
  - Handler Layer: Receives the data stream from repository and forwards it to the client using Connect's server-side streaming with chunked HTTP responses (200KB chunks).
  - RQL Support: Supports filtering, searching, and sorting through RQL query parameters, consistent with the existing ListAuditRecords endpoint.
  - Memory Efficiency: The cursor-based approach ensures constant memory usage regardless of result set size, making it suitable for exporting large number of records
