### PR TITLE
feat: migrate Project APIs to connectRPC server

### DIFF
--- a/internal/api/v1beta1connect/project.go
+++ b/internal/api/v1beta1connect/project.go
@@ -4,8 +4,18 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/audit"
+	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/core/project"
+	"github.com/raystack/frontier/core/role"
+	"github.com/raystack/frontier/core/user"
+	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/pkg/errors"
+	"github.com/raystack/frontier/pkg/metadata"
+	"github.com/raystack/frontier/pkg/utils"
+	"go.uber.org/zap"
 
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -32,6 +42,263 @@ func (h *ConnectHandler) ListProjects(ctx context.Context, request *connect.Requ
 	return connect.NewResponse(&frontierv1beta1.ListProjectsResponse{Projects: projects}), nil
 }
 
+func (h *ConnectHandler) CreateProject(ctx context.Context, request *connect.Request[frontierv1beta1.CreateProjectRequest]) (*connect.Response[frontierv1beta1.CreateProjectResponse], error) {
+	auditor := audit.GetAuditor(ctx, request.Msg.GetBody().GetOrgId())
+
+	metaDataMap := map[string]any{}
+	var err error
+	if request.Msg.GetBody().GetMetadata() != nil {
+		metaDataMap = metadata.Build(request.Msg.GetBody().GetMetadata().AsMap())
+	}
+
+	prj := project.Project{
+		Name:         request.Msg.GetBody().GetName(),
+		Title:        request.Msg.GetBody().GetTitle(),
+		Metadata:     metaDataMap,
+		Organization: organization.Organization{ID: request.Msg.GetBody().GetOrgId()},
+	}
+	newProject, err := h.projectService.Create(ctx, prj)
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	projectPB, err := transformProjectToPB(newProject)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+	auditor.Log(audit.ProjectCreatedEvent, audit.ProjectTarget(newProject.ID))
+	return connect.NewResponse(&frontierv1beta1.CreateProjectResponse{Project: projectPB}), nil
+}
+
+func (h *ConnectHandler) GetProject(ctx context.Context, request *connect.Request[frontierv1beta1.GetProjectRequest]) (*connect.Response[frontierv1beta1.GetProjectResponse], error) {
+	fetchedProject, err := h.projectService.Get(ctx, request.Msg.GetId())
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	projectPB, err := transformProjectToPB(fetchedProject)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+
+	return connect.NewResponse(&frontierv1beta1.GetProjectResponse{Project: projectPB}), nil
+}
+
+func (h *ConnectHandler) UpdateProject(ctx context.Context, request *connect.Request[frontierv1beta1.UpdateProjectRequest]) (*connect.Response[frontierv1beta1.UpdateProjectResponse], error) {
+	auditor := audit.GetAuditor(ctx, request.Msg.GetBody().GetOrgId())
+	if request.Msg.GetBody() == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
+	}
+
+	metaDataMap := metadata.Build(request.Msg.GetBody().GetMetadata().AsMap())
+
+	updatedProject, err := h.projectService.Update(ctx, project.Project{
+		ID:           request.Msg.GetId(),
+		Name:         request.Msg.GetBody().GetName(),
+		Title:        request.Msg.GetBody().GetTitle(),
+		Organization: organization.Organization{ID: request.Msg.GetBody().GetOrgId()},
+		Metadata:     metaDataMap,
+	})
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	projectPB, err := transformProjectToPB(updatedProject)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+
+	auditor.Log(audit.ProjectUpdatedEvent, audit.ProjectTarget(updatedProject.ID))
+	return connect.NewResponse(&frontierv1beta1.UpdateProjectResponse{Project: projectPB}), nil
+}
+
+func (h *ConnectHandler) ListProjectAdmins(ctx context.Context, request *connect.Request[frontierv1beta1.ListProjectAdminsRequest]) (*connect.Response[frontierv1beta1.ListProjectAdminsResponse], error) {
+	users, err := h.projectService.ListUsers(ctx, request.Msg.GetId(), project.AdminPermission)
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	var transformedAdmins []*frontierv1beta1.User
+	for _, a := range users {
+		u, err := transformUserToPB(a)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+
+		transformedAdmins = append(transformedAdmins, u)
+	}
+
+	return connect.NewResponse(&frontierv1beta1.ListProjectAdminsResponse{Users: transformedAdmins}), nil
+}
+
+func (h *ConnectHandler) ListProjectUsers(ctx context.Context, request *connect.Request[frontierv1beta1.ListProjectUsersRequest]) (*connect.Response[frontierv1beta1.ListProjectUsersResponse], error) {
+	logger := grpczap.Extract(ctx)
+
+	permissionFilter := project.MemberPermission
+	if len(request.Msg.GetPermissionFilter()) > 0 {
+		permissionFilter = request.Msg.GetPermissionFilter()
+	}
+
+	users, err := h.projectService.ListUsers(ctx, request.Msg.GetId(), permissionFilter)
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	var transformedUsers []*frontierv1beta1.User
+	var rolePairPBs []*frontierv1beta1.ListProjectUsersResponse_RolePair
+	for _, a := range users {
+		u, err := transformUserToPB(a)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+
+		transformedUsers = append(transformedUsers, u)
+	}
+
+	if request.Msg.GetWithRoles() {
+		for _, user := range users {
+			roles, err := h.policyService.ListRoles(ctx, schema.UserPrincipal, user.ID, schema.ProjectNamespace, request.Msg.GetId())
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+			}
+
+			rolesPb := utils.Filter(utils.Map(roles, func(role role.Role) *frontierv1beta1.Role {
+				pb, err := transformRoleToPB(role)
+				if err != nil {
+					logger.Error("failed to transform role for group", zap.Error(err))
+					return nil
+				}
+				return &pb
+			}), func(role *frontierv1beta1.Role) bool {
+				return role != nil
+			})
+			rolePairPBs = append(rolePairPBs, &frontierv1beta1.ListProjectUsersResponse_RolePair{
+				UserId: user.ID,
+				Roles:  rolesPb,
+			})
+		}
+	}
+
+	return connect.NewResponse(&frontierv1beta1.ListProjectUsersResponse{
+		Users:     transformedUsers,
+		RolePairs: rolePairPBs,
+	}), nil
+}
+
+func (h *ConnectHandler) ListProjectServiceUsers(ctx context.Context, request *connect.Request[frontierv1beta1.ListProjectServiceUsersRequest]) (*connect.Response[frontierv1beta1.ListProjectServiceUsersResponse], error) {
+	logger := grpczap.Extract(ctx)
+
+	users, err := h.projectService.ListServiceUsers(ctx, request.Msg.GetId(), project.MemberPermission)
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	var transformedUsers []*frontierv1beta1.ServiceUser
+	var rolePairPBs []*frontierv1beta1.ListProjectServiceUsersResponse_RolePair
+	for _, a := range users {
+		u, err := transformServiceUserToPB(a)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+
+		transformedUsers = append(transformedUsers, u)
+	}
+
+	if request.Msg.GetWithRoles() {
+		for _, user := range users {
+			roles, err := h.policyService.ListRoles(ctx, schema.ServiceUserPrincipal, user.ID, schema.ProjectNamespace, request.Msg.GetId())
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+			}
+
+			rolesPb := utils.Filter(utils.Map(roles, func(role role.Role) *frontierv1beta1.Role {
+				pb, err := transformRoleToPB(role)
+				if err != nil {
+					logger.Error("failed to transform role for group", zap.Error(err))
+					return nil
+				}
+				return &pb
+			}), func(role *frontierv1beta1.Role) bool {
+				return role != nil
+			})
+			rolePairPBs = append(rolePairPBs, &frontierv1beta1.ListProjectServiceUsersResponse_RolePair{
+				ServiceuserId: user.ID,
+				Roles:         rolesPb,
+			})
+		}
+	}
+
+	return connect.NewResponse(&frontierv1beta1.ListProjectServiceUsersResponse{
+		Serviceusers: transformedUsers,
+		RolePairs:    rolePairPBs,
+	}), nil
+}
+
+func (h *ConnectHandler) ListProjectGroups(ctx context.Context, request *connect.Request[frontierv1beta1.ListProjectGroupsRequest]) (*connect.Response[frontierv1beta1.ListProjectGroupsResponse], error) {
+	logger := grpczap.Extract(ctx)
+
+	groups, err := h.projectService.ListGroups(ctx, request.Msg.GetId())
+	if err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+
+	var groupsPB []*frontierv1beta1.Group
+	var rolePairPBs []*frontierv1beta1.ListProjectGroupsResponse_RolePair
+	for _, g := range groups {
+		u, err := transformGroupToPB(g)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+
+		groupsPB = append(groupsPB, &u)
+	}
+
+	if request.Msg.GetWithRoles() {
+		for _, group := range groups {
+			roles, err := h.policyService.ListRoles(ctx, schema.GroupPrincipal, group.ID,
+				schema.ProjectNamespace, request.Msg.GetId())
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+			}
+
+			rolesPb := utils.Filter(utils.Map(roles, func(role role.Role) *frontierv1beta1.Role {
+				pb, err := transformRoleToPB(role)
+				if err != nil {
+					logger.Error("failed to transform role for group", zap.Error(err))
+					return nil
+				}
+				return &pb
+			}), func(role *frontierv1beta1.Role) bool {
+				return role != nil
+			})
+
+			rolePairPBs = append(rolePairPBs, &frontierv1beta1.ListProjectGroupsResponse_RolePair{
+				GroupId: group.ID,
+				Roles:   rolesPb,
+			})
+		}
+	}
+
+	return connect.NewResponse(&frontierv1beta1.ListProjectGroupsResponse{
+		Groups:    groupsPB,
+		RolePairs: rolePairPBs,
+	}), nil
+}
+
+func (h *ConnectHandler) EnableProject(ctx context.Context, request *connect.Request[frontierv1beta1.EnableProjectRequest]) (*connect.Response[frontierv1beta1.EnableProjectResponse], error) {
+	if err := h.projectService.Enable(ctx, request.Msg.GetId()); err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+	return connect.NewResponse(&frontierv1beta1.EnableProjectResponse{}), nil
+}
+
+func (h *ConnectHandler) DisableProject(ctx context.Context, request *connect.Request[frontierv1beta1.DisableProjectRequest]) (*connect.Response[frontierv1beta1.DisableProjectResponse], error) {
+	if err := h.projectService.Disable(ctx, request.Msg.GetId()); err != nil {
+		return nil, translateProjectServiceError(err)
+	}
+	return connect.NewResponse(&frontierv1beta1.DisableProjectResponse{}), nil
+}
+
 func transformProjectToPB(prj project.Project) (*frontierv1beta1.Project, error) {
 	metaData, err := prj.Metadata.ToStructPB()
 	if err != nil {
@@ -48,4 +315,19 @@ func transformProjectToPB(prj project.Project) (*frontierv1beta1.Project, error)
 		UpdatedAt:    timestamppb.New(prj.UpdatedAt),
 		MembersCount: int32(prj.MemberCount),
 	}, nil
+}
+
+func translateProjectServiceError(err error) error {
+	switch {
+	case errors.Is(err, user.ErrInvalidEmail):
+		return connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
+	case errors.Is(err, organization.ErrInvalidUUID), errors.Is(err, project.ErrInvalidDetail):
+		return connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
+	case errors.Is(err, project.ErrConflict):
+		return connect.NewError(connect.CodeAlreadyExists, ErrConflictRequest)
+	case errors.Is(err, project.ErrNotExist), errors.Is(err, project.ErrInvalidUUID), errors.Is(err, project.ErrInvalidID):
+		return connect.NewError(connect.CodeNotFound, ErrNotFound)
+	default:
+		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
 }

--- a/internal/api/v1beta1connect/project.go
+++ b/internal/api/v1beta1connect/project.go
@@ -145,7 +145,7 @@ func (h *ConnectHandler) ListProjectUsers(ctx context.Context, request *connect.
 	}
 
 	var transformedUsers []*frontierv1beta1.User
-	var rolePairPBs []*frontierv1beta1.ListProjectUsersResponse_RolePair
+	rolePairPBs := []*frontierv1beta1.ListProjectUsersResponse_RolePair{}
 	for _, a := range users {
 		u, err := transformUserToPB(a)
 		if err != nil {
@@ -194,7 +194,7 @@ func (h *ConnectHandler) ListProjectServiceUsers(ctx context.Context, request *c
 	}
 
 	var transformedUsers []*frontierv1beta1.ServiceUser
-	var rolePairPBs []*frontierv1beta1.ListProjectServiceUsersResponse_RolePair
+	rolePairPBs := []*frontierv1beta1.ListProjectServiceUsersResponse_RolePair{}
 	for _, a := range users {
 		u, err := transformServiceUserToPB(a)
 		if err != nil {
@@ -243,7 +243,7 @@ func (h *ConnectHandler) ListProjectGroups(ctx context.Context, request *connect
 	}
 
 	var groupsPB []*frontierv1beta1.Group
-	var rolePairPBs []*frontierv1beta1.ListProjectGroupsResponse_RolePair
+	rolePairPBs := []*frontierv1beta1.ListProjectGroupsResponse_RolePair{}
 	for _, g := range groups {
 		u, err := transformGroupToPB(g)
 		if err != nil {

--- a/internal/api/v1beta1connect/project_test.go
+++ b/internal/api/v1beta1connect/project_test.go
@@ -6,11 +6,14 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/authenticate"
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/core/project"
+	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
 	"github.com/raystack/frontier/pkg/errors"
 	"github.com/raystack/frontier/pkg/metadata"
+	"github.com/raystack/frontier/pkg/utils"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -49,7 +52,7 @@ var (
 	}
 )
 
-func TestListProjects(t *testing.T) {
+func TestHandler_ListProjects(t *testing.T) {
 	table := []struct {
 		title string
 		setup func(ps *mocks.ProjectService)
@@ -116,6 +119,616 @@ func TestListProjects(t *testing.T) {
 			}
 			mockDep := ConnectHandler{projectService: mockProjectSrv}
 			resp, err := mockDep.ListProjects(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestHandler_CreateProject(t *testing.T) {
+	email := "user@raystack.org"
+	table := []struct {
+		title string
+		setup func(ctx context.Context, ps *mocks.ProjectService) context.Context
+		req   *connect.Request[frontierv1beta1.CreateProjectRequest]
+		want  *connect.Response[frontierv1beta1.CreateProjectResponse]
+		err   error
+	}{
+		{
+			title: "should return unauthenticated error if auth email in context is empty and project service return invalid user email",
+			setup: func(ctx context.Context, ps *mocks.ProjectService) context.Context {
+				ps.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), project.Project{
+					Name: "raystack-1",
+					Metadata: metadata.Metadata{
+						"team": "Platforms",
+					},
+				}).Return(project.Project{}, user.ErrInvalidEmail)
+				return authenticate.SetContextWithEmail(ctx, email)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
+				Name: "raystack-1",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"team": structpb.NewStringValue("Platforms"),
+					},
+				},
+			}}),
+			err: connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated),
+		},
+		{
+			title: "should return internal error if project service return some error",
+			setup: func(ctx context.Context, ps *mocks.ProjectService) context.Context {
+				ps.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), project.Project{
+					Name: "raystack-1",
+					Metadata: metadata.Metadata{
+						"team": "Platforms",
+					},
+				}).Return(project.Project{}, errors.New("test error"))
+				return authenticate.SetContextWithEmail(ctx, email)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
+				Name: "raystack-1",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"team": structpb.NewStringValue("Platforms"),
+					},
+				},
+			}}),
+			err: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			title: "should return bad request error if org id is not uuid",
+			setup: func(ctx context.Context, ps *mocks.ProjectService) context.Context {
+				ps.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), project.Project{
+					Name: "raystack-1",
+					Metadata: metadata.Metadata{
+						"team": "Platforms",
+					},
+				}).Return(project.Project{}, organization.ErrInvalidUUID)
+				return authenticate.SetContextWithEmail(ctx, email)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
+				Name: "raystack-1",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"team": structpb.NewStringValue("Platforms"),
+					},
+				},
+			}}),
+			err: connect.NewError(connect.CodeInvalidArgument, ErrBadRequest),
+		},
+		{
+			title: "should return already exist error if project service return error conflict",
+			setup: func(ctx context.Context, ps *mocks.ProjectService) context.Context {
+				ps.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), project.Project{
+					Name: "raystack-1",
+					Metadata: metadata.Metadata{
+						"team": "Platforms",
+					},
+				}).Return(project.Project{}, project.ErrConflict)
+				return authenticate.SetContextWithEmail(ctx, email)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
+				Name: "raystack-1",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"team": structpb.NewStringValue("Platforms"),
+					},
+				},
+			}}),
+			err: connect.NewError(connect.CodeAlreadyExists, ErrConflictRequest),
+		},
+		{
+			title: "should return bad request error if name is empty",
+			setup: func(ctx context.Context, ps *mocks.ProjectService) context.Context {
+				ps.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), project.Project{
+					Name: "raystack-1",
+					Metadata: metadata.Metadata{
+						"team": "Platforms",
+					},
+				}).Return(project.Project{}, project.ErrInvalidDetail)
+				return authenticate.SetContextWithEmail(ctx, email)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
+				Name: "raystack-1",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"team": structpb.NewStringValue("Platforms"),
+					},
+				},
+			}}),
+			err: connect.NewError(connect.CodeInvalidArgument, ErrBadRequest),
+		},
+		{
+			title: "should return success if project service return nil",
+			req: connect.NewRequest(&frontierv1beta1.CreateProjectRequest{Body: &frontierv1beta1.ProjectRequestBody{
+				Name: testProjectMap[testProjectID].Name,
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"email": structpb.NewStringValue("org1@org1.com"),
+					},
+				},
+			}}),
+			setup: func(ctx context.Context, ps *mocks.ProjectService) context.Context {
+				ps.EXPECT().Create(mock.AnythingOfType("*context.valueCtx"), project.Project{
+					Name: testProjectMap[testProjectID].Name,
+					Metadata: metadata.Metadata{
+						"email": "org1@org1.com",
+					},
+				}).Return(project.Project{
+					ID:   testProjectMap[testProjectID].ID,
+					Name: testProjectMap[testProjectID].Name,
+					Metadata: metadata.Metadata{
+						"email": "org1@org1.com",
+					},
+				}, nil)
+				return authenticate.SetContextWithEmail(ctx, email)
+			},
+			want: connect.NewResponse(&frontierv1beta1.CreateProjectResponse{Project: &frontierv1beta1.Project{
+				Id:   testProjectMap[testProjectID].ID,
+				Name: testProjectMap[testProjectID].Name,
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"email": structpb.NewStringValue("org1@org1.com"),
+					},
+				},
+				CreatedAt: timestamppb.New(time.Time{}),
+				UpdatedAt: timestamppb.New(time.Time{}),
+			}}),
+			err: nil,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			ctx := context.Background()
+			if tt.setup != nil {
+				ctx = tt.setup(ctx, mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.CreateProject(ctx, tt.req)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestHandler_GetProject(t *testing.T) {
+	someProjectID := utils.NewString()
+	table := []struct {
+		title string
+		setup func(ps *mocks.ProjectService)
+		req   *connect.Request[frontierv1beta1.GetProjectRequest]
+		want  *connect.Response[frontierv1beta1.GetProjectResponse]
+		err   error
+	}{
+		{
+			title: "should return internal error if project service return some error",
+			req: connect.NewRequest(&frontierv1beta1.GetProjectRequest{
+				Id: someProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(project.Project{}, errors.New("test error"))
+			},
+			err: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			title: "should return not found error if project doesnt exist",
+			req: connect.NewRequest(&frontierv1beta1.GetProjectRequest{
+				Id: someProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(project.Project{}, project.ErrNotExist)
+			},
+			err: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			title: "should return project not found if project id is not uuid",
+			req: connect.NewRequest(&frontierv1beta1.GetProjectRequest{
+				Id: "some-id",
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(project.Project{}, project.ErrInvalidUUID)
+			},
+			err: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			title: "should return project not found if project id is empty",
+			req:   connect.NewRequest(&frontierv1beta1.GetProjectRequest{}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(project.Project{}, project.ErrInvalidUUID)
+			},
+			err: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			title: "should return success if project service return nil error",
+			req: connect.NewRequest(&frontierv1beta1.GetProjectRequest{
+				Id: someProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), someProjectID).Return(
+					testProjectMap[testProjectID], nil)
+			},
+			want: connect.NewResponse(&frontierv1beta1.GetProjectResponse{Project: &frontierv1beta1.Project{
+				Id:    testProjectMap[testProjectID].ID,
+				Name:  testProjectMap[testProjectID].Name,
+				OrgId: testProjectMap[testProjectID].Organization.ID,
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"email": structpb.NewStringValue("org1@org1.com"),
+					},
+				},
+				CreatedAt: timestamppb.New(time.Time{}),
+				UpdatedAt: timestamppb.New(time.Time{}),
+			}}),
+			err: nil,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			if tt.setup != nil {
+				tt.setup(mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.GetProject(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestHandler_UpdateProject(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(ps *mocks.ProjectService)
+		request *connect.Request[frontierv1beta1.UpdateProjectRequest]
+		want    *connect.Response[frontierv1beta1.UpdateProjectResponse]
+		wantErr error
+	}{
+		{
+			name: "should return internal error if project service return some error",
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, errors.New("test error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.UpdateProjectRequest{
+				Id: testProjectID,
+				Body: &frontierv1beta1.ProjectRequestBody{
+					Name:  testProjectMap[testProjectID].Name,
+					OrgId: testProjectMap[testProjectID].Organization.ID,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"email": structpb.NewStringValue(testProjectMap[testProjectID].Metadata["email"].(string)),
+						},
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should return bad request error if org id is not uuid",
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, organization.ErrInvalidUUID)
+			},
+			request: connect.NewRequest(&frontierv1beta1.UpdateProjectRequest{
+				Id: testProjectID,
+				Body: &frontierv1beta1.ProjectRequestBody{
+					Name:  testProjectMap[testProjectID].Name,
+					OrgId: testProjectMap[testProjectID].Organization.ID,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"email": structpb.NewStringValue(testProjectMap[testProjectID].Metadata["email"].(string)),
+						},
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrBadRequest),
+		},
+		{
+			name: "should return not found error if project not exist",
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrNotExist)
+			},
+			request: connect.NewRequest(&frontierv1beta1.UpdateProjectRequest{
+				Id: testProjectID,
+				Body: &frontierv1beta1.ProjectRequestBody{
+					Name:  testProjectMap[testProjectID].Name,
+					OrgId: testProjectMap[testProjectID].Organization.ID,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"email": structpb.NewStringValue(testProjectMap[testProjectID].Metadata["email"].(string)),
+						},
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return conflict error if project service return err conflict",
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(project.Project{}, project.ErrConflict)
+			},
+			request: connect.NewRequest(&frontierv1beta1.UpdateProjectRequest{
+				Id: testProjectID,
+				Body: &frontierv1beta1.ProjectRequestBody{
+					Name:  testProjectMap[testProjectID].Name,
+					OrgId: testProjectMap[testProjectID].Organization.ID,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"email": structpb.NewStringValue(testProjectMap[testProjectID].Metadata["email"].(string)),
+						},
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeAlreadyExists, ErrConflictRequest),
+		},
+		{
+			name: "should return success if project service return nil error",
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Update(mock.AnythingOfType("context.backgroundCtx"), testProjectMap[testProjectID]).Return(testProjectMap[testProjectID], nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.UpdateProjectRequest{
+				Id: testProjectID,
+				Body: &frontierv1beta1.ProjectRequestBody{
+					Name:  testProjectMap[testProjectID].Name,
+					OrgId: testProjectMap[testProjectID].Organization.ID,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"email": structpb.NewStringValue(testProjectMap[testProjectID].Metadata["email"].(string)),
+						},
+					},
+				},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.UpdateProjectResponse{
+				Project: &frontierv1beta1.Project{
+					Id:    testProjectMap[testProjectID].ID,
+					Name:  testProjectMap[testProjectID].Name,
+					OrgId: testProjectMap[testProjectID].Organization.ID,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"email": structpb.NewStringValue(testProjectMap[testProjectID].Metadata["email"].(string)),
+						},
+					},
+					CreatedAt: timestamppb.New(time.Time{}),
+					UpdatedAt: timestamppb.New(time.Time{}),
+				},
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			if tt.setup != nil {
+				tt.setup(mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.UpdateProject(context.Background(), tt.request)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestHandler_ListProjectAdmins(t *testing.T) {
+	table := []struct {
+		title string
+		setup func(ps *mocks.ProjectService)
+		req   *connect.Request[frontierv1beta1.ListProjectAdminsRequest]
+		want  *connect.Response[frontierv1beta1.ListProjectAdminsResponse]
+		err   error
+	}{
+		{
+			title: "should return internal error if project service return some error",
+			req: connect.NewRequest(&frontierv1beta1.ListProjectAdminsRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.AdminPermission).Return([]user.User{}, errors.New("test error"))
+			},
+			want: nil,
+			err:  connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			title: "should return success if project service return nil error",
+			req: connect.NewRequest(&frontierv1beta1.ListProjectAdminsRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.AdminPermission).Return([]user.User{
+					{
+						ID:        "user-1",
+						Name:      "User One",
+						Email:     "user1@example.com",
+						Metadata:  metadata.Metadata{},
+						CreatedAt: time.Time{},
+						UpdatedAt: time.Time{},
+					},
+				}, nil)
+			},
+			want: connect.NewResponse(&frontierv1beta1.ListProjectAdminsResponse{
+				Users: []*frontierv1beta1.User{
+					{
+						Id:        "user-1",
+						Name:      "User One",
+						Email:     "user1@example.com",
+						Metadata:  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+						CreatedAt: timestamppb.New(time.Time{}),
+						UpdatedAt: timestamppb.New(time.Time{}),
+					},
+				},
+			}),
+			err: nil,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			if tt.setup != nil {
+				tt.setup(mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.ListProjectAdmins(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestHandler_EnableProject(t *testing.T) {
+	table := []struct {
+		title string
+		setup func(ps *mocks.ProjectService)
+		req   *connect.Request[frontierv1beta1.EnableProjectRequest]
+		want  *connect.Response[frontierv1beta1.EnableProjectResponse]
+		err   error
+	}{
+		{
+			title: "should return internal error if project service return some error",
+			req: connect.NewRequest(&frontierv1beta1.EnableProjectRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("test error"))
+			},
+			want: nil,
+			err:  connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			title: "should return success if project service return nil error",
+			req: connect.NewRequest(&frontierv1beta1.EnableProjectRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Enable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(nil)
+			},
+			want: connect.NewResponse(&frontierv1beta1.EnableProjectResponse{}),
+			err:  nil,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			if tt.setup != nil {
+				tt.setup(mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.EnableProject(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestHandler_DisableProject(t *testing.T) {
+	table := []struct {
+		title string
+		setup func(ps *mocks.ProjectService)
+		req   *connect.Request[frontierv1beta1.DisableProjectRequest]
+		want  *connect.Response[frontierv1beta1.DisableProjectResponse]
+		err   error
+	}{
+		{
+			title: "should return internal error if project service return some error",
+			req: connect.NewRequest(&frontierv1beta1.DisableProjectRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(errors.New("test error"))
+			},
+			want: nil,
+			err:  connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			title: "should return success if project service return nil error",
+			req: connect.NewRequest(&frontierv1beta1.DisableProjectRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().Disable(mock.AnythingOfType("context.backgroundCtx"), testProjectID).Return(nil)
+			},
+			want: connect.NewResponse(&frontierv1beta1.DisableProjectResponse{}),
+			err:  nil,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			if tt.setup != nil {
+				tt.setup(mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.DisableProject(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestHandler_ListProjectUsers(t *testing.T) {
+	table := []struct {
+		title string
+		setup func(ps *mocks.ProjectService)
+		req   *connect.Request[frontierv1beta1.ListProjectUsersRequest]
+		want  *connect.Response[frontierv1beta1.ListProjectUsersResponse]
+		err   error
+	}{
+		{
+			title: "should return internal error if project service return some error",
+			req: connect.NewRequest(&frontierv1beta1.ListProjectUsersRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.MemberPermission).Return([]user.User{}, errors.New("test error"))
+			},
+			want: nil,
+			err:  connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			title: "should return success if project service return nil error",
+			req: connect.NewRequest(&frontierv1beta1.ListProjectUsersRequest{
+				Id: testProjectID,
+			}),
+			setup: func(ps *mocks.ProjectService) {
+				ps.EXPECT().ListUsers(mock.AnythingOfType("context.backgroundCtx"), testProjectID, project.MemberPermission).Return([]user.User{
+					{
+						ID:        "user-1",
+						Name:      "User One",
+						Email:     "user1@example.com",
+						Metadata:  metadata.Metadata{},
+						CreatedAt: time.Time{},
+						UpdatedAt: time.Time{},
+					},
+				}, nil)
+			},
+			want: connect.NewResponse(&frontierv1beta1.ListProjectUsersResponse{
+				Users: []*frontierv1beta1.User{
+					{
+						Id:        "user-1",
+						Name:      "User One",
+						Email:     "user1@example.com",
+						Metadata:  &structpb.Struct{Fields: map[string]*structpb.Value{}},
+						CreatedAt: timestamppb.New(time.Time{}),
+						UpdatedAt: timestamppb.New(time.Time{}),
+					},
+				},
+				RolePairs: []*frontierv1beta1.ListProjectUsersResponse_RolePair{},
+			}),
+			err: nil,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			mockProjectSrv := new(mocks.ProjectService)
+			if tt.setup != nil {
+				tt.setup(mockProjectSrv)
+			}
+			mockDep := ConnectHandler{projectService: mockProjectSrv}
+			resp, err := mockDep.ListProjectUsers(context.Background(), tt.req)
 			assert.EqualValues(t, tt.want, resp)
 			assert.EqualValues(t, tt.err, err)
 		})


### PR DESCRIPTION
## Migrate Projects RPCs to ConnectRPC server

The following RPCs are migrated. 

- [x] CreateProject
- [x] GetProject
- [x] UpdateProject
- [x] ListProjectAdmins
- [x] ListProjectUsers
- [x] ListProjectServiceUsers
- [x] ListProjectGroups
- [x] EnableProject
- [x] DisableProject

The implementation of the handlers is similar to that of the gRPC handlers. 
I have just made it compatible with the ConnectRPC signature. 
We have used connect errors instead of gRPC errors.