### PR TITLE
feat: migrate relations, permissions and namespaces RPC to ConnectRPC

### DIFF
--- a/internal/api/v1beta1connect/namespace.go
+++ b/internal/api/v1beta1connect/namespace.go
@@ -1,0 +1,67 @@
+package v1beta1connect
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/namespace"
+	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type NamespaceService interface {
+	Get(ctx context.Context, id string) (namespace.Namespace, error)
+	List(ctx context.Context) ([]namespace.Namespace, error)
+	Upsert(ctx context.Context, ns namespace.Namespace) (namespace.Namespace, error)
+	Update(ctx context.Context, ns namespace.Namespace) (namespace.Namespace, error)
+}
+
+func (h *ConnectHandler) ListNamespaces(ctx context.Context, request *connect.Request[frontierv1beta1.ListNamespacesRequest]) (*connect.Response[frontierv1beta1.ListNamespacesResponse], error) {
+	var namespaces []*frontierv1beta1.Namespace
+
+	nsList, err := h.namespaceService.List(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+
+	for _, ns := range nsList {
+		nsPB, err := transformNamespaceToPB(ns)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+
+		namespaces = append(namespaces, &nsPB)
+	}
+
+	return connect.NewResponse(&frontierv1beta1.ListNamespacesResponse{Namespaces: namespaces}), nil
+}
+
+func (h *ConnectHandler) GetNamespace(ctx context.Context, request *connect.Request[frontierv1beta1.GetNamespaceRequest]) (*connect.Response[frontierv1beta1.GetNamespaceResponse], error) {
+	fetchedNS, err := h.namespaceService.Get(ctx, request.Msg.GetId())
+	if err != nil {
+		switch {
+		case errors.Is(err, namespace.ErrNotExist),
+			errors.Is(err, namespace.ErrInvalidID):
+			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
+		default:
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+	}
+
+	nsPB, err := transformNamespaceToPB(fetchedNS)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+
+	return connect.NewResponse(&frontierv1beta1.GetNamespaceResponse{Namespace: &nsPB}), nil
+}
+
+func transformNamespaceToPB(ns namespace.Namespace) (frontierv1beta1.Namespace, error) {
+	return frontierv1beta1.Namespace{
+		Id:        ns.ID,
+		Name:      ns.Name,
+		CreatedAt: timestamppb.New(ns.CreatedAt),
+		UpdatedAt: timestamppb.New(ns.UpdatedAt),
+	}, nil
+}

--- a/internal/api/v1beta1connect/namespace_test.go
+++ b/internal/api/v1beta1connect/namespace_test.go
@@ -1,3 +1,186 @@
 package v1beta1connect
 
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/namespace"
+	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
 var testNSID = "team"
+var testNSMap = map[string]namespace.Namespace{
+	"team": {
+		ID:        "team",
+		Name:      "Team",
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	},
+	"org": {
+		ID:        "org",
+		Name:      "Org",
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	},
+	"project": {
+		ID:        "project",
+		Name:      "Project",
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	},
+}
+
+func TestHandler_ListNamespaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(ns *mocks.NamespaceService)
+		request *connect.Request[frontierv1beta1.ListNamespacesRequest]
+		want    *connect.Response[frontierv1beta1.ListNamespacesResponse]
+		wantErr error
+	}{
+		{
+			name: "should return internal error if namespace service return some error",
+			setup: func(ns *mocks.NamespaceService) {
+				ns.EXPECT().List(mock.Anything).Return([]namespace.Namespace{}, errors.New("test error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.ListNamespacesRequest{}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should return success if namespace service return nil error",
+			setup: func(ns *mocks.NamespaceService) {
+				var testNSList []namespace.Namespace
+				for _, ns := range testNSMap {
+					testNSList = append(testNSList, ns)
+				}
+				sort.Slice(testNSList, func(i, j int) bool {
+					return strings.Compare(testNSList[i].ID, testNSList[j].ID) < 1
+				})
+				ns.EXPECT().List(mock.Anything).Return(testNSList, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.ListNamespacesRequest{}),
+			want: connect.NewResponse(&frontierv1beta1.ListNamespacesResponse{
+				Namespaces: []*frontierv1beta1.Namespace{
+					{
+						Id:        "org",
+						Name:      "Org",
+						CreatedAt: timestamppb.New(time.Time{}),
+						UpdatedAt: timestamppb.New(time.Time{}),
+					},
+					{
+						Id:        "project",
+						Name:      "Project",
+						CreatedAt: timestamppb.New(time.Time{}),
+						UpdatedAt: timestamppb.New(time.Time{}),
+					},
+					{
+						Id:        "team",
+						Name:      "Team",
+						CreatedAt: timestamppb.New(time.Time{}),
+						UpdatedAt: timestamppb.New(time.Time{}),
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockNamespaceSrv := new(mocks.NamespaceService)
+			if tt.setup != nil {
+				tt.setup(mockNamespaceSrv)
+			}
+			mockDep := &ConnectHandler{namespaceService: mockNamespaceSrv}
+			resp, err := mockDep.ListNamespaces(context.Background(), tt.request)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, resp)
+		})
+	}
+}
+
+func TestHandler_GetNamespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(as *mocks.NamespaceService)
+		request *connect.Request[frontierv1beta1.GetNamespaceRequest]
+		want    *connect.Response[frontierv1beta1.GetNamespaceResponse]
+		wantErr error
+	}{
+		{
+			name: "should return internal error if namespace service return some error",
+			setup: func(ns *mocks.NamespaceService) {
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{}, errors.New("test error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetNamespaceRequest{
+				Id: testNSID,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should return not found error if namespace id is empty",
+			setup: func(ns *mocks.NamespaceService) {
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(namespace.Namespace{}, namespace.ErrInvalidID)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetNamespaceRequest{}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return not found error if namespace id not exist",
+			setup: func(ns *mocks.NamespaceService) {
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{}, namespace.ErrNotExist)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetNamespaceRequest{
+				Id: testNSID,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return success is namespace service return nil error",
+			setup: func(ns *mocks.NamespaceService) {
+				ns.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testNSID).Return(namespace.Namespace{
+					ID:   testNSMap[testNSID].ID,
+					Name: testNSMap[testNSID].Name,
+				}, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetNamespaceRequest{
+				Id: testNSID,
+			}),
+			want: connect.NewResponse(&frontierv1beta1.GetNamespaceResponse{
+				Namespace: &frontierv1beta1.Namespace{
+					Id:        testNSMap[testNSID].ID,
+					Name:      testNSMap[testNSID].Name,
+					CreatedAt: timestamppb.New(time.Time{}),
+					UpdatedAt: timestamppb.New(time.Time{}),
+				},
+			}),
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockNamespaceSrv := new(mocks.NamespaceService)
+			if tt.setup != nil {
+				tt.setup(mockNamespaceSrv)
+			}
+			mockDep := &ConnectHandler{namespaceService: mockNamespaceSrv}
+			resp, err := mockDep.GetNamespace(context.Background(), tt.request)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, resp)
+		})
+	}
+}

--- a/internal/api/v1beta1connect/permission_check.go
+++ b/internal/api/v1beta1connect/permission_check.go
@@ -124,7 +124,7 @@ func (h *ConnectHandler) CheckResourcePermission(ctx context.Context, req *conne
 
 	permissionName, err := h.getPermissionName(ctx, objectNamespace, req.Msg.GetPermission())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, ErrInternalServerError)
+		return nil, err
 	}
 	result, err := h.resourceService.CheckAuthz(ctx, resource.Check{
 		Object: relation.Object{
@@ -154,7 +154,7 @@ func (h *ConnectHandler) BatchCheckPermission(ctx context.Context, req *connect.
 
 		permissionName, err := h.getPermissionName(ctx, objectNamespace, body.GetPermission())
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, ErrInternalServerError)
+			return nil, err
 		}
 		checks = append(checks, resource.Check{
 			Object: relation.Object{

--- a/internal/api/v1beta1connect/permission_check_test.go
+++ b/internal/api/v1beta1connect/permission_check_test.go
@@ -1,0 +1,139 @@
+package v1beta1connect
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/permission"
+	"github.com/raystack/frontier/core/relation"
+	"github.com/raystack/frontier/core/resource"
+	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/pkg/errors"
+	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	testPermission = permission.Permission{
+		Name:        schema.UpdatePermission,
+		NamespaceID: testRelationV2.Object.Namespace,
+	}
+)
+
+func TestHandler_CheckResourcePermission(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(res *mocks.ResourceService, perm *mocks.PermissionService)
+		request *connect.Request[frontierv1beta1.CheckResourcePermissionRequest]
+		want    *connect.Response[frontierv1beta1.CheckResourcePermissionResponse]
+		wantErr error
+	}{
+		{
+			name: "should return bad request error if object id is empty or namespace is empty",
+			request: connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+				Resource: "not-namespace-uuid-format",
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrBadRequest),
+		},
+		{
+			name: "should return user unauthenticated error if CheckAuthz function returns ErrUnauthenticated",
+			setup: func(res *mocks.ResourceService, perm *mocks.PermissionService) {
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					}, Permission: schema.UpdatePermission,
+				}).Return(false, errors.ErrUnauthenticated)
+				perm.EXPECT().Get(mock.Anything, schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, schema.UpdatePermission)).
+					Return(testPermission, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+				Permission: schema.UpdatePermission,
+				Resource:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated),
+		},
+		{
+			name: "should return internal error if relation service's CheckAuthz function returns some error",
+			setup: func(res *mocks.ResourceService, perm *mocks.PermissionService) {
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					}, Permission: schema.UpdatePermission,
+				}).Return(false, errors.New("test error"))
+				perm.EXPECT().Get(mock.Anything, schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, schema.UpdatePermission)).
+					Return(testPermission, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+				Permission: schema.UpdatePermission,
+				Resource:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should return true when CheckAuthz function returns true bool",
+			setup: func(res *mocks.ResourceService, perm *mocks.PermissionService) {
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					}, Permission: schema.UpdatePermission,
+				}).Return(true, nil)
+				perm.EXPECT().Get(mock.Anything, schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, schema.UpdatePermission)).
+					Return(testPermission, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+				ObjectId:        testRelationV2.Object.ID,
+				ObjectNamespace: testRelationV2.Object.Namespace,
+				Permission:      schema.UpdatePermission,
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CheckResourcePermissionResponse{
+				Status: true,
+			}),
+			wantErr: nil,
+		},
+		{
+			name: "should return false when CheckAuthz function returns false bool",
+			setup: func(res *mocks.ResourceService, perm *mocks.PermissionService) {
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("context.backgroundCtx"), resource.Check{
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					}, Permission: schema.UpdatePermission,
+				}).Return(false, nil)
+				perm.EXPECT().Get(mock.Anything, schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, schema.UpdatePermission)).
+					Return(testPermission, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+				ObjectId:        testRelationV2.Object.ID,
+				ObjectNamespace: testRelationV2.Object.Namespace,
+				Permission:      schema.UpdatePermission,
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CheckResourcePermissionResponse{
+				Status: false,
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockResourceSrv := new(mocks.ResourceService)
+			mockPermissionSrv := new(mocks.PermissionService)
+			if tt.setup != nil {
+				tt.setup(mockResourceSrv, mockPermissionSrv)
+			}
+
+			mockDep := &ConnectHandler{resourceService: mockResourceSrv, permissionService: mockPermissionSrv}
+			resp, err := mockDep.CheckResourcePermission(context.Background(), tt.request)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, resp)
+		})
+	}
+}

--- a/internal/api/v1beta1connect/relation.go
+++ b/internal/api/v1beta1connect/relation.go
@@ -2,10 +2,12 @@ package v1beta1connect
 
 import (
 	"context"
+	"errors"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/pkg/utils"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -56,6 +58,119 @@ func (h *ConnectHandler) ListRelations(ctx context.Context, request *connect.Req
 	return connect.NewResponse(&frontierv1beta1.ListRelationsResponse{
 		Relations: relations,
 	}), nil
+}
+
+func (h *ConnectHandler) CreateRelation(ctx context.Context, request *connect.Request[frontierv1beta1.CreateRelationRequest]) (*connect.Response[frontierv1beta1.CreateRelationResponse], error) {
+	if request.Msg.GetBody() == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
+	}
+
+	subjectNamespace, subjectID, err := schema.SplitNamespaceAndResourceID(request.Msg.GetBody().GetSubject())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation)
+	}
+	objectNamespace, objectID, err := schema.SplitNamespaceAndResourceID(request.Msg.GetBody().GetObject())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation)
+	}
+
+	// If Principal is a user, then we will get ID for that user as Subject.ID
+	if subjectNamespace == schema.UserPrincipal {
+		if !utils.IsValidUUID(subjectID) {
+			// could be email
+			fetchedUser, err := h.userService.GetByEmail(ctx, subjectID)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeNotFound, ErrUserNotExist)
+			}
+			subjectID = fetchedUser.ID
+		}
+	}
+
+	newRelation, err := h.relationService.Create(ctx, relation.Relation{
+		Object: relation.Object{
+			ID:        objectID,
+			Namespace: objectNamespace,
+		},
+		Subject: relation.Subject{
+			ID:              subjectID,
+			Namespace:       subjectNamespace,
+			SubRelationName: request.Msg.GetBody().GetSubjectSubRelation(),
+		},
+		RelationName: request.Msg.GetBody().GetRelation(),
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, relation.ErrInvalidDetail):
+			return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
+		default:
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+	}
+
+	relationPB, err := transformRelationV2ToPB(newRelation)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+
+	return connect.NewResponse(&frontierv1beta1.CreateRelationResponse{
+		Relation: relationPB,
+	}), nil
+}
+
+func (h *ConnectHandler) GetRelation(ctx context.Context, request *connect.Request[frontierv1beta1.GetRelationRequest]) (*connect.Response[frontierv1beta1.GetRelationResponse], error) {
+	fetchedRelation, err := h.relationService.Get(ctx, request.Msg.GetId())
+	if err != nil {
+		switch {
+		case errors.Is(err, relation.ErrNotExist),
+			errors.Is(err, relation.ErrInvalidUUID),
+			errors.Is(err, relation.ErrInvalidID):
+			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
+		default:
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+	}
+	relationPB, err := transformRelationV2ToPB(fetchedRelation)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+	return connect.NewResponse(&frontierv1beta1.GetRelationResponse{
+		Relation: relationPB,
+	}), nil
+}
+
+func (h *ConnectHandler) DeleteRelation(ctx context.Context, request *connect.Request[frontierv1beta1.DeleteRelationRequest]) (*connect.Response[frontierv1beta1.DeleteRelationResponse], error) {
+	subjectNamespace, subjectID, err := schema.SplitNamespaceAndResourceID(request.Msg.GetSubject())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation)
+	}
+	objectNamespace, objectID, err := schema.SplitNamespaceAndResourceID(request.Msg.GetObject())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation)
+	}
+
+	err = h.relationService.Delete(ctx, relation.Relation{
+		Object: relation.Object{
+			Namespace: objectNamespace,
+			ID:        objectID,
+		},
+		Subject: relation.Subject{
+			Namespace: subjectNamespace,
+			ID:        subjectID,
+		},
+		RelationName: request.Msg.GetRelation(),
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, relation.ErrNotExist),
+			errors.Is(err, relation.ErrInvalidUUID),
+			errors.Is(err, relation.ErrInvalidID):
+			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
+		default:
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+	}
+
+	return connect.NewResponse(&frontierv1beta1.DeleteRelationResponse{}), nil
 }
 
 func transformRelationV2ToPB(relation relation.Relation) (*frontierv1beta1.Relation, error) {

--- a/internal/api/v1beta1connect/relation_test.go
+++ b/internal/api/v1beta1connect/relation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/relation"
+	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -18,8 +19,9 @@ var (
 	testRelationV2 = relation.Relation{
 		ID: "relation-id-1",
 		Subject: relation.Subject{
-			ID:        "subject-id",
-			Namespace: "ns1",
+			ID:              "subject-id",
+			Namespace:       "ns1",
+			SubRelationName: "member",
 		},
 		Object: relation.Object{
 			ID:        "object-id",
@@ -29,10 +31,11 @@ var (
 	}
 
 	testRelationPB = &frontierv1beta1.Relation{
-		Id:       "relation-id-1",
-		Object:   schema.JoinNamespaceAndResourceID("ns2", "object-id"),
-		Subject:  schema.JoinNamespaceAndResourceID("ns1", "subject-id"),
-		Relation: "relation1",
+		Id:                 "relation-id-1",
+		Object:             schema.JoinNamespaceAndResourceID("ns2", "object-id"),
+		Subject:            schema.JoinNamespaceAndResourceID("ns1", "subject-id"),
+		SubjectSubRelation: "member",
+		Relation:           "relation1",
 	}
 )
 
@@ -76,6 +79,345 @@ func TestHandler_ListRelations(t *testing.T) {
 			resp, err := mockDep.ListRelations(context.Background(), connect.NewRequest(&frontierv1beta1.ListRelationsRequest{}))
 			assert.Equal(t, tt.want, resp)
 			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestHandler_CreateRelation(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService)
+		request *connect.Request[frontierv1beta1.CreateRelationRequest]
+		want    *connect.Response[frontierv1beta1.CreateRelationResponse]
+		wantErr error
+	}{
+		{
+			name: "should return bad request error if request body is nil",
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: nil,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrBadRequest),
+		},
+		{
+			name: "should return bad request error if subject is not in namepsace:uuid format",
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: &frontierv1beta1.RelationRequestBody{
+					Subject: "subject",
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation),
+		},
+		{
+			name: "should return bad request error if object is not in namepsace:uuid format",
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: &frontierv1beta1.RelationRequestBody{
+					Subject: schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+					Object:  "object",
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation),
+		},
+		{
+			name: "should return error if unable to get the user id from the user email in case subject namespace is app/user",
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: &frontierv1beta1.RelationRequestBody{
+					Subject: schema.JoinNamespaceAndResourceID(schema.UserPrincipal, "not-a-valid-email"),
+					Object:  schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+				},
+			}),
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
+				us.EXPECT().GetByEmail(mock.AnythingOfType("context.backgroundCtx"), "not-a-valid-email").Return(user.User{}, user.ErrNotExist)
+			},
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrUserNotExist),
+		},
+		{
+			name: "should return internal error if relation service return some error",
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
+				us.EXPECT().GetByEmail(mock.AnythingOfType("context.backgroundCtx"), "user@raystack.org").Return(user.User{
+					ID: "subject-id",
+				}, nil)
+				rs.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
+					Subject: relation.Subject{
+						ID:              testRelationV2.Subject.ID,
+						Namespace:       "app/user",
+						SubRelationName: "",
+					},
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					},
+					RelationName: testRelationV2.Subject.SubRelationName,
+				}).Return(relation.Relation{}, errors.New("test error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: &frontierv1beta1.RelationRequestBody{
+					Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+					Subject:  schema.JoinNamespaceAndResourceID("app/user", "user@raystack.org"),
+					Relation: testRelationV2.Subject.SubRelationName,
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should return bad request error if field value not exist in foreign reference",
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
+				rs.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
+					Subject: relation.Subject{
+						ID:              testRelationV2.Subject.ID,
+						Namespace:       testRelationV2.Subject.Namespace,
+						SubRelationName: "",
+					},
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					},
+					RelationName: testRelationV2.Subject.SubRelationName,
+				}).Return(relation.Relation{}, relation.ErrInvalidDetail)
+			},
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: &frontierv1beta1.RelationRequestBody{
+					Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+					Subject:  schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+					Relation: testRelationV2.Subject.SubRelationName,
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrBadRequest),
+		},
+		{
+			name: "should return success if relation service return nil",
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService, us *mocks.UserService) {
+				rs.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
+					Subject: relation.Subject{
+						ID:              testRelationV2.Subject.ID,
+						Namespace:       testRelationV2.Subject.Namespace,
+						SubRelationName: "",
+					},
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					},
+					RelationName: testRelationV2.Subject.SubRelationName,
+				}).Return(testRelationV2, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.CreateRelationRequest{
+				Body: &frontierv1beta1.RelationRequestBody{
+					Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+					Subject:  schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+					Relation: testRelationV2.Subject.SubRelationName,
+				},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CreateRelationResponse{
+				Relation: testRelationPB,
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRelationSrv := new(mocks.RelationService)
+			mockResourceSrv := new(mocks.ResourceService)
+			mockUserSrc := new(mocks.UserService)
+			if tt.setup != nil {
+				tt.setup(mockRelationSrv, mockResourceSrv, mockUserSrc)
+			}
+			mockDep := ConnectHandler{relationService: mockRelationSrv, resourceService: mockResourceSrv, userService: mockUserSrc}
+			resp, err := mockDep.CreateRelation(context.Background(), tt.request)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestHandler_GetRelation(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(rs *mocks.RelationService)
+		request *connect.Request[frontierv1beta1.GetRelationRequest]
+		want    *connect.Response[frontierv1beta1.GetRelationResponse]
+		wantErr error
+	}{
+		{
+			name: "should return internal error if relation service return some error",
+			setup: func(rs *mocks.RelationService) {
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(relation.Relation{}, errors.New("test error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetRelationRequest{
+				Id: testRelationV2.ID,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should return not found error if id is empty",
+			setup: func(rs *mocks.RelationService) {
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "").Return(relation.Relation{}, relation.ErrInvalidID)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetRelationRequest{}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return not found error if id is not uuid",
+			setup: func(rs *mocks.RelationService) {
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), "some-id").Return(relation.Relation{}, relation.ErrInvalidUUID)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetRelationRequest{
+				Id: "some-id",
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return not found error if id not exist",
+			setup: func(rs *mocks.RelationService) {
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(relation.Relation{}, relation.ErrNotExist)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetRelationRequest{
+				Id: testRelationV2.ID,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return success if relation service return nil error",
+			setup: func(rs *mocks.RelationService) {
+				rs.EXPECT().Get(mock.AnythingOfType("context.backgroundCtx"), testRelationV2.ID).Return(testRelationV2, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.GetRelationRequest{
+				Id: testRelationV2.ID,
+			}),
+			want: connect.NewResponse(&frontierv1beta1.GetRelationResponse{
+				Relation: testRelationPB,
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRelationSrv := new(mocks.RelationService)
+			if tt.setup != nil {
+				tt.setup(mockRelationSrv)
+			}
+			mockDep := ConnectHandler{relationService: mockRelationSrv}
+			resp, err := mockDep.GetRelation(context.Background(), tt.request)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestHandler_DeleteRelation(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(rs *mocks.RelationService, res *mocks.ResourceService)
+		request *connect.Request[frontierv1beta1.DeleteRelationRequest]
+		want    *connect.Response[frontierv1beta1.DeleteRelationResponse]
+		wantErr error
+	}{
+		{
+			name: "should return bad request error if subject is not in namepsace:uuid format",
+			request: connect.NewRequest(&frontierv1beta1.DeleteRelationRequest{
+				Subject: "not-namespace-uuid-format",
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation),
+		},
+		{
+			name: "should return bad request error if object is not in namepsace:uuid format",
+			request: connect.NewRequest(&frontierv1beta1.DeleteRelationRequest{
+				Subject: schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+				Object:  "not-namespace-uuid-format",
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, ErrNamespaceSplitNotation),
+		},
+		{
+			name: "should return not found error when relation service returns not exist error while deletion",
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService) {
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
+					Subject: relation.Subject{
+						Namespace: testRelationV2.Subject.Namespace,
+						ID:        testRelationV2.Subject.ID,
+					},
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					},
+					RelationName: testRelationV2.Subject.SubRelationName,
+				}).Return(relation.ErrNotExist)
+			},
+			request: connect.NewRequest(&frontierv1beta1.DeleteRelationRequest{
+				Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+				Subject:  schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+				Relation: testRelationV2.Subject.SubRelationName,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeNotFound, ErrNotFound),
+		},
+		{
+			name: "should return internal server error when relation service returns some error while deletion",
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService) {
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
+					Subject: relation.Subject{
+						Namespace: testRelationV2.Subject.Namespace,
+						ID:        testRelationV2.Subject.ID,
+					},
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					},
+					RelationName: testRelationV2.Subject.SubRelationName,
+				}).Return(errors.New("test error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.DeleteRelationRequest{
+				Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+				Subject:  schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+				Relation: testRelationV2.Subject.SubRelationName,
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should successfully delete when relation exist",
+			setup: func(rs *mocks.RelationService, res *mocks.ResourceService) {
+				rs.EXPECT().Delete(mock.AnythingOfType("context.backgroundCtx"), relation.Relation{
+					Subject: relation.Subject{
+						Namespace: testRelationV2.Subject.Namespace,
+						ID:        testRelationV2.Subject.ID,
+					},
+					Object: relation.Object{
+						ID:        testRelationV2.Object.ID,
+						Namespace: testRelationV2.Object.Namespace,
+					},
+					RelationName: testRelationV2.Subject.SubRelationName,
+				}).Return(nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.DeleteRelationRequest{
+				Object:   schema.JoinNamespaceAndResourceID(testRelationV2.Object.Namespace, testRelationV2.Object.ID),
+				Subject:  schema.JoinNamespaceAndResourceID(testRelationV2.Subject.Namespace, testRelationV2.Subject.ID),
+				Relation: testRelationV2.Subject.SubRelationName,
+			}),
+			want:    connect.NewResponse(&frontierv1beta1.DeleteRelationResponse{}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRelationSrv := new(mocks.RelationService)
+			mockResourceSrv := new(mocks.ResourceService)
+			if tt.setup != nil {
+				tt.setup(mockRelationSrv, mockResourceSrv)
+			}
+			mockDep := ConnectHandler{relationService: mockRelationSrv, resourceService: mockResourceSrv}
+			resp, err := mockDep.DeleteRelation(context.Background(), tt.request)
+			assert.EqualValues(t, tt.want, resp)
+			assert.EqualValues(t, tt.wantErr, err)
 		})
 	}
 }


### PR DESCRIPTION
## Migrate Relations, Permissions, and Namespaces RPCs to ConnectRPC server

The following RPCs are migrated. 

- [x] CreateRelation
- [x] GetRelation 
- [x] DeleteRelation
- [x] ListPermissions
- [x] GetPermission
- [x] CheckResourcePermission
- [x] BatchCheckPermission  
- [x] ListNamespaces
- [x] GetNamespace

The implementation of the handlers is similar to that of the gRPC handlers. 
I have just made it compatible with the ConnectRPC signature. 
We have used connect errors instead of gRPC errors.

**One crucial change** made is that the following APIs have been put behind an Authentication check, which was not implemented in the GPRC handler. 

- [x] ListPermissions
- [x] GetPermission
- [x] ListNamespaces
- [x] GetNamespace

The reason is that these APIs store Frontier resource-level permission names. They should at least be checked for authentication.