### PR TITLE
feat: migrate Preferences APIs to Connect RPC

### DIFF
--- a/internal/api/v1beta1connect/errors.go
+++ b/internal/api/v1beta1connect/errors.go
@@ -55,4 +55,7 @@ var (
 	ErrGroupMinOwnerCount          = errors.New("group must have at least one owner, consider adding another owner before removing")
 	ErrPortalChangesKycCompleted   = errors.New("customer portal changes not allowed: organization kyc completed")
 	ErrResourceNotFound            = errors.New("resource doesn't exist")
+	ErrInvalidPreferenceFilter     = errors.New("invalid preference filter set")
+	ErrTraitNotFound               = errors.New("preference trait not found, preferences can only be created with valid trait")
+	ErrInvalidPreferenceValue      = errors.New("invalid value for preference")
 )

--- a/internal/api/v1beta1connect/preferences.go
+++ b/internal/api/v1beta1connect/preferences.go
@@ -57,6 +57,17 @@ func (h *ConnectHandler) CreatePreferences(ctx context.Context, req *connect.Req
 	}), nil
 }
 
+func (h *ConnectHandler) DescribePreferences(ctx context.Context, req *connect.Request[frontierv1beta1.DescribePreferencesRequest]) (*connect.Response[frontierv1beta1.DescribePreferencesResponse], error) {
+	prefTraits := h.preferenceService.Describe(ctx)
+	var pbTraits []*frontierv1beta1.PreferenceTrait
+	for _, trait := range prefTraits {
+		pbTraits = append(pbTraits, transformPreferenceTraitToPB(trait))
+	}
+	return connect.NewResponse(&frontierv1beta1.DescribePreferencesResponse{
+		Traits: pbTraits,
+	}), nil
+}
+
 func (h *ConnectHandler) ListPlatformPreferences(ctx context.Context) (map[string]string, error) {
 	return h.preferenceService.LoadPlatformPreferences(ctx)
 }
@@ -71,4 +82,36 @@ func transformPreferenceToPB(pref preference.Preference) *frontierv1beta1.Prefer
 		CreatedAt:    timestamppb.New(pref.CreatedAt),
 		UpdatedAt:    timestamppb.New(pref.UpdatedAt),
 	}
+}
+
+func transformPreferenceTraitToPB(pref preference.Trait) *frontierv1beta1.PreferenceTrait {
+	pbTrait := &frontierv1beta1.PreferenceTrait{
+		ResourceType:    pref.ResourceType,
+		Name:            pref.Name,
+		Title:           pref.Title,
+		Description:     pref.Description,
+		LongDescription: pref.LongDescription,
+		Heading:         pref.Heading,
+		SubHeading:      pref.SubHeading,
+		Breadcrumb:      pref.Breadcrumb,
+		InputHints:      pref.InputHints,
+		Default:         pref.Default,
+	}
+	switch pref.Input {
+	case preference.TraitInputText:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Text{}
+	case preference.TraitInputTextarea:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Textarea{}
+	case preference.TraitInputSelect:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Select{}
+	case preference.TraitInputCombobox:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Combobox{}
+	case preference.TraitInputCheckbox:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Checkbox{}
+	case preference.TraitInputMultiselect:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Multiselect{}
+	case preference.TraitInputNumber:
+		pbTrait.Input = &frontierv1beta1.PreferenceTrait_Number{}
+	}
+	return pbTrait
 }

--- a/internal/api/v1beta1connect/preferences.go
+++ b/internal/api/v1beta1connect/preferences.go
@@ -85,6 +85,24 @@ func (h *ConnectHandler) CreateOrganizationPreferences(ctx context.Context, req 
 	}), nil
 }
 
+func (h *ConnectHandler) ListOrganizationPreferences(ctx context.Context, req *connect.Request[frontierv1beta1.ListOrganizationPreferencesRequest]) (*connect.Response[frontierv1beta1.ListOrganizationPreferencesResponse], error) {
+	prefs, err := h.preferenceService.List(ctx, preference.Filter{
+		OrgID: req.Msg.GetId(),
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+
+	var pbPrefs []*frontierv1beta1.Preference
+	for _, pref := range prefs {
+		pbPrefs = append(pbPrefs, transformPreferenceToPB(pref))
+	}
+
+	return connect.NewResponse(&frontierv1beta1.ListOrganizationPreferencesResponse{
+		Preferences: pbPrefs,
+	}), nil
+}
+
 func (h *ConnectHandler) DescribePreferences(ctx context.Context, req *connect.Request[frontierv1beta1.DescribePreferencesRequest]) (*connect.Response[frontierv1beta1.DescribePreferencesResponse], error) {
 	prefTraits := h.preferenceService.Describe(ctx)
 	var pbTraits []*frontierv1beta1.PreferenceTrait

--- a/internal/api/v1beta1connect/preferences.go
+++ b/internal/api/v1beta1connect/preferences.go
@@ -103,6 +103,34 @@ func (h *ConnectHandler) ListOrganizationPreferences(ctx context.Context, req *c
 	}), nil
 }
 
+func (h *ConnectHandler) CreateUserPreferences(ctx context.Context, req *connect.Request[frontierv1beta1.CreateUserPreferencesRequest]) (*connect.Response[frontierv1beta1.CreateUserPreferencesResponse], error) {
+	var createdPreferences []preference.Preference
+	for _, prefBody := range req.Msg.GetBodies() {
+		pref, err := h.preferenceService.Create(ctx, preference.Preference{
+			Name:         prefBody.GetName(),
+			Value:        prefBody.GetValue(),
+			ResourceID:   req.Msg.GetId(),
+			ResourceType: schema.UserPrincipal,
+		})
+		if err != nil {
+			if errors.Is(err, preference.ErrTraitNotFound) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, err)
+			}
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+		}
+		createdPreferences = append(createdPreferences, pref)
+	}
+
+	var pbPrefs []*frontierv1beta1.Preference
+	for _, pref := range createdPreferences {
+		pbPrefs = append(pbPrefs, transformPreferenceToPB(pref))
+	}
+
+	return connect.NewResponse(&frontierv1beta1.CreateUserPreferencesResponse{
+		Preferences: pbPrefs,
+	}), nil
+}
+
 func (h *ConnectHandler) DescribePreferences(ctx context.Context, req *connect.Request[frontierv1beta1.DescribePreferencesRequest]) (*connect.Response[frontierv1beta1.DescribePreferencesResponse], error) {
 	prefTraits := h.preferenceService.Describe(ctx)
 	var pbTraits []*frontierv1beta1.PreferenceTrait

--- a/internal/api/v1beta1connect/preferences_test.go
+++ b/internal/api/v1beta1connect/preferences_test.go
@@ -424,3 +424,161 @@ func TestConnectHandler_ListOrganizationPreferences(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectHandler_CreateUserPreferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(m *mocks.PreferenceService)
+		req     *connect.Request[frontierv1beta1.CreateUserPreferencesRequest]
+		want    *connect.Response[frontierv1beta1.CreateUserPreferencesResponse]
+		wantErr error
+	}{
+		{
+			name: "should create user preferences on success",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "theme",
+					Value:        "dark",
+					ResourceID:   "user_id_123",
+					ResourceType: schema.UserPrincipal,
+				}).Return(preference.Preference{
+					ID:           "pref_id_123",
+					Name:         "theme",
+					Value:        "dark",
+					ResourceID:   "user_id_123",
+					ResourceType: schema.UserPrincipal,
+				}, nil)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateUserPreferencesRequest{
+				Id: "user_id_123",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{
+						Name:  "theme",
+						Value: "dark",
+					},
+				},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CreateUserPreferencesResponse{
+				Preferences: []*frontierv1beta1.Preference{
+					{
+						Id:           "pref_id_123",
+						Name:         "theme",
+						Value:        "dark",
+						ResourceId:   "user_id_123",
+						ResourceType: schema.UserPrincipal,
+						UpdatedAt:    timestamppb.New(time.Time{}),
+						CreatedAt:    timestamppb.New(time.Time{}),
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+		{
+			name: "should return internal error when service fails",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "language",
+					Value:        "en",
+					ResourceID:   "user_id_456",
+					ResourceType: schema.UserPrincipal,
+				}).Return(preference.Preference{}, errors.New("database connection failed"))
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateUserPreferencesRequest{
+				Id: "user_id_456",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{
+						Name:  "language",
+						Value: "en",
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should create multiple user preferences successfully",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "theme",
+					Value:        "light",
+					ResourceID:   "user_id_789",
+					ResourceType: schema.UserPrincipal,
+				}).Return(preference.Preference{
+					ID:           "pref_1",
+					Name:         "theme",
+					Value:        "light",
+					ResourceID:   "user_id_789",
+					ResourceType: schema.UserPrincipal,
+				}, nil)
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "timezone",
+					Value:        "UTC",
+					ResourceID:   "user_id_789",
+					ResourceType: schema.UserPrincipal,
+				}).Return(preference.Preference{
+					ID:           "pref_2",
+					Name:         "timezone",
+					Value:        "UTC",
+					ResourceID:   "user_id_789",
+					ResourceType: schema.UserPrincipal,
+				}, nil)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateUserPreferencesRequest{
+				Id: "user_id_789",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{Name: "theme", Value: "light"},
+					{Name: "timezone", Value: "UTC"},
+				},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CreateUserPreferencesResponse{
+				Preferences: []*frontierv1beta1.Preference{
+					{
+						Id:           "pref_1",
+						Name:         "theme",
+						Value:        "light",
+						ResourceId:   "user_id_789",
+						ResourceType: schema.UserPrincipal,
+						UpdatedAt:    timestamppb.New(time.Time{}),
+						CreatedAt:    timestamppb.New(time.Time{}),
+					},
+					{
+						Id:           "pref_2",
+						Name:         "timezone",
+						Value:        "UTC",
+						ResourceId:   "user_id_789",
+						ResourceType: schema.UserPrincipal,
+						UpdatedAt:    timestamppb.New(time.Time{}),
+						CreatedAt:    timestamppb.New(time.Time{}),
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+		{
+			name: "should handle empty preferences list",
+			setup: func(m *mocks.PreferenceService) {
+				// No expectations since no preferences to create
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateUserPreferencesRequest{
+				Id:     "user_empty",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CreateUserPreferencesResponse{
+				Preferences: nil,
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPreferenceServ := new(mocks.PreferenceService)
+			if tt.setup != nil {
+				tt.setup(mockPreferenceServ)
+			}
+			h := &ConnectHandler{preferenceService: mockPreferenceServ}
+			got, err := h.CreateUserPreferences(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, got)
+			assert.EqualValues(t, tt.wantErr, err)
+		})
+	}
+}

--- a/internal/api/v1beta1connect/preferences_test.go
+++ b/internal/api/v1beta1connect/preferences_test.go
@@ -3,13 +3,17 @@ package v1beta1connect
 import (
 	"context"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/preference"
 	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/pkg/errors"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestConnectHandler_DescribePreferences(t *testing.T) {
@@ -116,6 +120,172 @@ func TestConnectHandler_DescribePreferences(t *testing.T) {
 			}
 			h := &ConnectHandler{preferenceService: mockPreferenceServ}
 			got, err := h.DescribePreferences(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, got)
+			assert.EqualValues(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestConnectHandler_CreateOrganizationPreferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(m *mocks.PreferenceService)
+		req     *connect.Request[frontierv1beta1.CreateOrganizationPreferencesRequest]
+		want    *connect.Response[frontierv1beta1.CreateOrganizationPreferencesResponse]
+		wantErr error
+	}{
+		{
+			name: "should create organization preferences on success",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "some_name",
+					Value:        "some_value",
+					ResourceID:   "some_resource_id",
+					ResourceType: schema.OrganizationNamespace,
+				}).Return(preference.Preference{
+					ID:           "some_id",
+					Name:         "some_name",
+					Value:        "some_value",
+					ResourceID:   "some_resource_id",
+					ResourceType: schema.OrganizationNamespace,
+				}, nil)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateOrganizationPreferencesRequest{
+				Id: "some_resource_id",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{
+						Name:  "some_name",
+						Value: "some_value",
+					},
+				},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CreateOrganizationPreferencesResponse{
+				Preferences: []*frontierv1beta1.Preference{
+					{
+						Id:           "some_id",
+						Name:         "some_name",
+						Value:        "some_value",
+						ResourceId:   "some_resource_id",
+						ResourceType: schema.OrganizationNamespace,
+						UpdatedAt:    timestamppb.New(time.Time{}),
+						CreatedAt:    timestamppb.New(time.Time{}),
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+		{
+			name: "should return invalid argument error if trait not found",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "invalid_name",
+					Value:        "some_value",
+					ResourceID:   "some_resource_id",
+					ResourceType: schema.OrganizationNamespace,
+				}).Return(preference.Preference{}, preference.ErrTraitNotFound)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateOrganizationPreferencesRequest{
+				Id: "some_resource_id",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{
+						Name:  "invalid_name",
+						Value: "some_value",
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInvalidArgument, preference.ErrTraitNotFound),
+		},
+		{
+			name: "should return internal error for other service errors",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "some_name",
+					Value:        "some_value",
+					ResourceID:   "some_resource_id",
+					ResourceType: schema.OrganizationNamespace,
+				}).Return(preference.Preference{}, errors.New("database error"))
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateOrganizationPreferencesRequest{
+				Id: "some_resource_id",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{
+						Name:  "some_name",
+						Value: "some_value",
+					},
+				},
+			}),
+			want:    nil,
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+		{
+			name: "should create multiple preferences successfully",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "pref1",
+					Value:        "value1",
+					ResourceID:   "org_id",
+					ResourceType: schema.OrganizationNamespace,
+				}).Return(preference.Preference{
+					ID:           "id1",
+					Name:         "pref1",
+					Value:        "value1",
+					ResourceID:   "org_id",
+					ResourceType: schema.OrganizationNamespace,
+				}, nil)
+				m.EXPECT().Create(mock.AnythingOfType("context.backgroundCtx"), preference.Preference{
+					Name:         "pref2",
+					Value:        "value2",
+					ResourceID:   "org_id",
+					ResourceType: schema.OrganizationNamespace,
+				}).Return(preference.Preference{
+					ID:           "id2",
+					Name:         "pref2",
+					Value:        "value2",
+					ResourceID:   "org_id",
+					ResourceType: schema.OrganizationNamespace,
+				}, nil)
+			},
+			req: connect.NewRequest(&frontierv1beta1.CreateOrganizationPreferencesRequest{
+				Id: "org_id",
+				Bodies: []*frontierv1beta1.PreferenceRequestBody{
+					{Name: "pref1", Value: "value1"},
+					{Name: "pref2", Value: "value2"},
+				},
+			}),
+			want: connect.NewResponse(&frontierv1beta1.CreateOrganizationPreferencesResponse{
+				Preferences: []*frontierv1beta1.Preference{
+					{
+						Id:           "id1",
+						Name:         "pref1",
+						Value:        "value1",
+						ResourceId:   "org_id",
+						ResourceType: schema.OrganizationNamespace,
+						UpdatedAt:    timestamppb.New(time.Time{}),
+						CreatedAt:    timestamppb.New(time.Time{}),
+					},
+					{
+						Id:           "id2",
+						Name:         "pref2",
+						Value:        "value2",
+						ResourceId:   "org_id",
+						ResourceType: schema.OrganizationNamespace,
+						UpdatedAt:    timestamppb.New(time.Time{}),
+						CreatedAt:    timestamppb.New(time.Time{}),
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPreferenceServ := new(mocks.PreferenceService)
+			if tt.setup != nil {
+				tt.setup(mockPreferenceServ)
+			}
+			h := &ConnectHandler{preferenceService: mockPreferenceServ}
+			got, err := h.CreateOrganizationPreferences(context.Background(), tt.req)
 			assert.EqualValues(t, tt.want, got)
 			assert.EqualValues(t, tt.wantErr, err)
 		})

--- a/internal/api/v1beta1connect/preferences_test.go
+++ b/internal/api/v1beta1connect/preferences_test.go
@@ -1,0 +1,123 @@
+package v1beta1connect
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/core/preference"
+	"github.com/raystack/frontier/internal/api/v1beta1/mocks"
+	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestConnectHandler_DescribePreferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(m *mocks.PreferenceService)
+		req     *connect.Request[frontierv1beta1.DescribePreferencesRequest]
+		want    *connect.Response[frontierv1beta1.DescribePreferencesResponse]
+		wantErr error
+	}{
+		{
+			name: "should describe preferences on success",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Describe(mock.AnythingOfType("context.backgroundCtx")).Return([]preference.Trait{{
+					ResourceType:    "resource",
+					Name:            "some_name",
+					Title:           "some_title",
+					Description:     "some_description",
+					LongDescription: "some_long_description",
+					Heading:         "some_heading",
+					SubHeading:      "some_sub_heading",
+					Breadcrumb:      "some_breadcrumb",
+					InputHints:      "some_inputHints",
+				}})
+			},
+			req: connect.NewRequest(&frontierv1beta1.DescribePreferencesRequest{}),
+			want: connect.NewResponse(&frontierv1beta1.DescribePreferencesResponse{
+				Traits: []*frontierv1beta1.PreferenceTrait{
+					{
+						ResourceType:    "resource",
+						Name:            "some_name",
+						Title:           "some_title",
+						Description:     "some_description",
+						LongDescription: "some_long_description",
+						Heading:         "some_heading",
+						SubHeading:      "some_sub_heading",
+						Breadcrumb:      "some_breadcrumb",
+						InputHints:      "some_inputHints",
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+		{
+			name: "should return empty traits list when service returns empty slice",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Describe(mock.AnythingOfType("context.backgroundCtx")).Return([]preference.Trait{})
+			},
+			req: connect.NewRequest(&frontierv1beta1.DescribePreferencesRequest{}),
+			want: connect.NewResponse(&frontierv1beta1.DescribePreferencesResponse{
+				Traits: nil,
+			}),
+			wantErr: nil,
+		},
+		{
+			name: "should handle traits with different input types",
+			setup: func(m *mocks.PreferenceService) {
+				m.EXPECT().Describe(mock.AnythingOfType("context.backgroundCtx")).Return([]preference.Trait{
+					{
+						ResourceType: "organization",
+						Name:         "text_input",
+						Input:        preference.TraitInputText,
+					},
+					{
+						ResourceType: "organization",
+						Name:         "select_input",
+						Input:        preference.TraitInputSelect,
+					},
+					{
+						ResourceType: "organization",
+						Name:         "checkbox_input",
+						Input:        preference.TraitInputCheckbox,
+					},
+				})
+			},
+			req: connect.NewRequest(&frontierv1beta1.DescribePreferencesRequest{}),
+			want: connect.NewResponse(&frontierv1beta1.DescribePreferencesResponse{
+				Traits: []*frontierv1beta1.PreferenceTrait{
+					{
+						ResourceType: "organization",
+						Name:         "text_input",
+						Input:        &frontierv1beta1.PreferenceTrait_Text{},
+					},
+					{
+						ResourceType: "organization",
+						Name:         "select_input",
+						Input:        &frontierv1beta1.PreferenceTrait_Select{},
+					},
+					{
+						ResourceType: "organization",
+						Name:         "checkbox_input",
+						Input:        &frontierv1beta1.PreferenceTrait_Checkbox{},
+					},
+				},
+			}),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPreferenceServ := new(mocks.PreferenceService)
+			if tt.setup != nil {
+				tt.setup(mockPreferenceServ)
+			}
+			h := &ConnectHandler{preferenceService: mockPreferenceServ}
+			got, err := h.DescribePreferences(context.Background(), tt.req)
+			assert.EqualValues(t, tt.want, got)
+			assert.EqualValues(t, tt.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
# Preferences APIs Migration to Connect RPC

This PR migrates Preferences management APIs from gRPC to Connect RPC framework, following the established patterns from previous API migrations.

## Migration Overview

Converting Preferences APIs from traditional gRPC handlers to buf Connect RPC handlers with proper error handling, request/response wrapping, and comprehensive test coverage.

## APIs Migration Progress

### ✅ Completed APIs (7/X)

| API | Status | Commit | Implementation | Tests |
|-----|--------|--------|---------------|-------|
| `DescribePreferences` | ✅ Complete | 0f38720 | `internal/api/v1beta1connect/preferences.go:155-164` | 3 test cases |
| `CreateOrganizationPreferences` | ✅ Complete | 3821b31 | `internal/api/v1beta1connect/preferences.go:60-86` | 4 test cases |
| `ListOrganizationPreferences` | ✅ Complete | 8bc0396 | `internal/api/v1beta1connect/preferences.go:91-106` | 4 test cases |
| `CreateUserPreferences` | ✅ Complete | e382f38 | `internal/api/v1beta1connect/preferences.go:106-132` | 4 test cases |
| `ListUserPreferences` | ✅ Complete | a998a96 | `internal/api/v1beta1connect/preferences.go:134-150` | 4 test cases |
| `CreateCurrentUserPreferences` | ✅ Complete | 43e4393 | `internal/api/v1beta1connect/preferences.go:161-194` | 5 test cases |
| `ListCurrentUserPreferences` | ✅ Complete | aad5a22 | `internal/api/v1beta1connect/preferences.go:196-220` | 5 test cases |

### 🔄 Remaining APIs

- Additional Preferences APIs to be identified and migrated

## Technical Changes

### API Implementation Updates
- Updated function signatures to use Connect RPC types:
  - Request: `*connect.Request[frontierv1beta1.RequestType]`
  - Response: `(*connect.Response[frontierv1beta1.ResponseType], error)`
- Changed request field access from `request.GetField()` to `request.Msg.GetField()`
- Updated response wrapping with `connect.NewResponse()`
- Converted error handling to Connect error codes

### Test Migration
- Enhanced test suite for Connect RPC patterns
- Comprehensive test coverage with error scenarios
- Updated mock service expectations to match Connect RPC patterns

## Key Implementation Details

### ListCurrentUserPreferences
- **Authentication-Aware**: Uses `GetLoggedInPrincipal` to get current user context
- **User-Scoped Filtering**: Lists preferences using `preference.Filter{UserID: principal.ID}`
- **Enhanced Error Handling**: Improved error mapping over original gRPC implementation:
  - `preference.ErrInvalidFilter` → `InvalidArgument` (filter validation)
  - Authentication errors → proper Connect error propagation
  - Other errors → `InternalServerError`
- **Transformation**: Uses existing `transformPreferenceToPB()` for each preference
- **Response Structure**: Returns preferences list in response wrapper
- **Test Coverage**: 5 comprehensive test cases:
  1. Success scenario with single preference
  2. Empty preferences list handling (proper nil vs empty slice handling)
  3. Authentication failure handling
  4. Preference service error handling
  5. Multiple preferences listing for current user

### CreateCurrentUserPreferences
- **Authentication-Aware**: Uses `GetLoggedInPrincipal` to get current user context
- **Enhanced Error Handling**: Improved error mapping over original gRPC implementation:
  - `preference.ErrTraitNotFound` → `InvalidArgument` (trait validation)
  - `preference.ErrInvalidValue` → `InvalidArgument` (value validation)  
  - Authentication errors → proper Connect error propagation
  - Other errors → `InternalServerError`
- **Batch Processing**: Supports multiple preference creation for current user
- **Resource Context**: Uses `ResourceID: principal.ID` and `ResourceType: schema.UserPrincipal`
- **Test Coverage**: 5 comprehensive test cases:
  1. Success scenario with single preference
  2. Authentication failure handling
  3. Trait not found error handling
  4. Invalid value error handling
  5. Multiple preferences creation (batch operation)

### ListUserPreferences
- **User-Scoped Filtering**: Lists preferences for specific user using `preference.Filter{UserID: req.Msg.GetId()}`
- **Enhanced Error Handling**: Improved error mapping over original gRPC implementation:
  - `preference.ErrInvalidFilter` → `InvalidArgument` (filter validation)
  - Other errors → `InternalServerError`
- **Transformation**: Uses existing `transformPreferenceToPB()` for each preference
- **Response Structure**: Returns user preferences list in response wrapper
- **Test Coverage**: 4 comprehensive test cases:
  1. Success scenario with single preference
  2. Empty preferences list handling
  3. Service error handling (internal error)
  4. Multiple preferences listing with comprehensive user data

### CreateUserPreferences
- **User-Scoped Creation**: Creates preferences for specific user using `ResourceID: req.Msg.GetId()` and `ResourceType: schema.UserPrincipal`
- **Enhanced Error Handling**: Improved error mapping over original gRPC implementation:
  - `preference.ErrTraitNotFound` → `InvalidArgument` (trait validation)
  - Other errors → `InternalServerError`
- **Batch Processing**: Supports multiple preference creation in single request
- **Transformation**: Uses existing `transformPreferenceToPB()` for response formatting
- **Test Coverage**: 4 comprehensive test cases:
  1. Success scenario with single preference
  2. Service error handling (internal error)
  3. Multiple preferences creation (batch operation)  
  4. Empty preferences list handling

### ListOrganizationPreferences
- **Organization Filtering**: Lists preferences for specific organization using `preference.Filter{OrgID: req.Msg.GetId()}`
- **Enhanced Error Handling**: Improved error mapping:
  - `preference.ErrInvalidFilter` → `InvalidArgument` (filter validation)
  - Other errors → `InternalServerError`
- **Transformation**: Uses existing `transformPreferenceToPB()` for each preference
- **Response Structure**: Returns preferences list in response wrapper
- **Test Coverage**: 4 comprehensive test cases:
  1. Success scenario with single preference
  2. Empty preferences list handling
  3. Service error handling (internal error)
  4. Multiple preferences listing

### CreateOrganizationPreferences  
- **Batch Creation**: Creates multiple preferences for an organization in a single request
- **Resource Mapping**: Uses `ResourceID: req.Msg.GetId()` and `ResourceType: schema.OrganizationNamespace`
- **Error Handling**: Comprehensive error mapping:
  - `preference.ErrTraitNotFound` → `InvalidArgument` (trait validation failed)
  - Other errors → `InternalServerError`
- **Transformation**: Uses existing `transformPreferenceToPB()` for each created preference
- **Test Coverage**: 4 comprehensive test cases:
  1. Success scenario with single preference
  2. Trait not found error handling  
  3. Internal service error handling
  4. Multiple preferences creation (batch operation)

### DescribePreferences
- **Simple Trait Listing**: Lists all preference traits using `preferenceService.Describe(ctx)`
- **No Error Handling**: Since the service method doesn't return errors
- **Trait Transformation**: Uses `transformPreferenceTraitToPB()` for each trait
- **Input Type Mapping**: Maps preference input types to protobuf oneof variants:
  - `TraitInputText` → `PreferenceTrait_Text{}`
  - `TraitInputSelect` → `PreferenceTrait_Select{}`
  - `TraitInputCheckbox` → `PreferenceTrait_Checkbox{}`
  - And more input types (textarea, combobox, multiselect, number)
- **Test Coverage**: 3 comprehensive test cases:
  1. Success scenario with full trait data
  2. Empty traits list handling
  3. Different input types transformation

## Verification

Each migrated API goes through:
- ✅ Build verification (`make build`)  
- ✅ Test execution (`make test`)
- ✅ Lint checking (`make lint`)
- ✅ Functionality validation

Current test coverage: Enhanced for v1beta1connect package (29 test cases total)

## Files Modified

### Implementation Files
- `internal/api/v1beta1connect/preferences.go` - Added all seven Preferences Connect RPC handlers
- `internal/api/v1beta1connect/preferences_test.go` - Comprehensive test suite with 29 test cases

## Migration Methodology

Following established systematic approach:
1. **Analysis** - Study original gRPC implementation  
2. **API Migration** - Convert handler to Connect RPC format
3. **Test Migration** - Create comprehensive test coverage
4. **Verification** - Build, test, and lint validation
5. **Integration** - Commit and push changes

## Enhanced Error Handling

The Connect RPC implementations provide **improved error handling** over the original gRPC handlers:
- **Authentication Validation**: Current user operations properly validate authentication with enhanced error propagation
- **Filter Validation**: List operations now validate filter parameters (`ErrInvalidFilter`)
- **Trait Validation**: Create operations validate preference traits (`ErrTraitNotFound`)
- **Value Validation**: Enhanced validation for preference values (`ErrInvalidValue`)
- **Consistent Error Codes**: Proper Connect RPC error codes for different failure scenarios
- **Better User Experience**: More specific error messages for different validation failures
- **Nil vs Empty Slice Handling**: Proper handling of empty preference lists in responses

## Next Steps

- Continue with remaining Preferences APIs migration
- Update authorization configurations if needed
- Ensure comprehensive test coverage across all Preferences endpoints