### PR TITLE
feat: migrate remaining APIs to connectRPC

### DIFF
--- a/internal/api/v1beta1connect/deleter.go
+++ b/internal/api/v1beta1connect/deleter.go
@@ -7,6 +7,13 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 )
 
+func (h *ConnectHandler) DeleteProject(ctx context.Context, request *connect.Request[frontierv1beta1.DeleteProjectRequest]) (*connect.Response[frontierv1beta1.DeleteProjectResponse], error) {
+	if err := h.deleterService.DeleteProject(ctx, request.Msg.GetId()); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+	}
+	return connect.NewResponse(&frontierv1beta1.DeleteProjectResponse{}), nil
+}
+
 func (h *ConnectHandler) DeleteOrganization(ctx context.Context, request *connect.Request[frontierv1beta1.DeleteOrganizationRequest]) (*connect.Response[frontierv1beta1.DeleteOrganizationResponse], error) {
 	if err := h.deleterService.DeleteOrganization(ctx, request.Msg.GetId()); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)


### PR DESCRIPTION
## Migrate RPCs to ConnectRPC server

The following RPCs are migrated. 

- [x] CreateFeature 
- [x] DeleteProject 
- [x] UpdateFeature

The implementation of the handlers is similar to that of the gRPC handlers. 
I have just made it compatible with the ConnectRPC signature. 
We have used connect errors instead of gRPC errors.

There are some GRPC handler functions (which are not part of Proto Spec) that we are not migrating to ConnectHandler as they are used in enrichment of Req/Response which is not applicable in Connect Handler case.

The functions are 
- GetRequestCustomerID
- IsUserIDSuperUser
