### PR TITLE
feat: return default KYC record instead of 404 for non-existent orgs

### DIFF
--- a/internal/api/v1beta1connect/kyc.go
+++ b/internal/api/v1beta1connect/kyc.go
@@ -52,7 +52,12 @@ func (h *ConnectHandler) GetOrganizationKyc(ctx context.Context, request *connec
 	if err != nil {
 		switch {
 		case errors.Is(err, kyc.ErrNotExist):
-			return nil, connect.NewError(connect.CodeNotFound, kyc.ErrNotExist)
+			// Return default KYC record instead of 404
+			orgKyc = kyc.KYC{
+				OrgID:  request.Msg.GetOrgId(),
+				Status: false,
+				Link:   "",
+			}
 		default:
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}

--- a/internal/api/v1beta1connect/kyc_test.go
+++ b/internal/api/v1beta1connect/kyc_test.go
@@ -157,14 +157,14 @@ func TestGetOrganizationKyc(t *testing.T) {
 		},
 		{
 			mockService: mocks.NewKycService(t),
-			name:        "error case - KYC record not found",
+			name:        "KYC record not found - returns default",
 			request: connect.NewRequest(&frontierv1beta1.GetOrganizationKycRequest{
 				OrgId: "nonexistent-org",
 			}),
 			mockResponse:  kyc.KYC{},
 			mockError:     kyc.ErrNotExist,
-			expectError:   connect.NewError(connect.CodeNotFound, kyc.ErrNotExist),
-			expectNilResp: true,
+			expectError:   nil,
+			expectNilResp: false,
 		},
 	}
 
@@ -188,6 +188,11 @@ func TestGetOrganizationKyc(t *testing.T) {
 			} else {
 				assert.NotNil(t, resp)
 				assert.Equal(t, tt.request.Msg.GetOrgId(), resp.Msg.GetOrganizationKyc().GetOrgId())
+				if tt.mockError == kyc.ErrNotExist {
+					// Verify default values are returned
+					assert.False(t, resp.Msg.GetOrganizationKyc().GetStatus())
+					assert.Empty(t, resp.Msg.GetOrganizationKyc().GetLink())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Problem
`GetOrganizationKyc` API returned 404 error when no KYC record existed for an organization, forcing clients to handle error states unnecessarily.

## Solution
Modified the API to return a default KYC record (status=false, link="") instead of 404 when the record doesn't exist. This aligns with the behavior of `ListOrganizationsKyc` which already returns default values for orgs without KYC records.