### PR TITLE
migrate(sdk): migrate member page api

### DIFF
--- a/sdks/js/packages/core/react/hooks/useOrganizationMembers.ts
+++ b/sdks/js/packages/core/react/hooks/useOrganizationMembers.ts
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
-import { V1Beta1User, V1Beta1Role, V1Beta1Invitation } from '~/src';
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@connectrpc/connect-query';
+import { FrontierServiceQueries } from '@raystack/proton/frontier';
+import { V1Beta1User, V1Beta1Invitation } from '~/src';
 import { PERMISSIONS } from '~/utils';
 import { useFrontier } from '../contexts/FrontierContext';
 
@@ -9,107 +11,55 @@ export type MemberWithInvite = V1Beta1User & V1Beta1Invitation & {invited?: bool
 
 
 export const useOrganizationMembers = ({ showInvitations = false }) => {
-  const [users, setUsers] = useState<V1Beta1User[]>([]);
-  const [roles, setRoles] = useState<V1Beta1Role[]>([]);
-  const [invitations, setInvitations] = useState<MemberWithInvite[]>([]);
+  const { activeOrganization: organization } = useFrontier();
 
-  const [isUsersLoading, setIsUsersLoading] = useState(false);
-  const [isRolesLoading, setIsRolesLoading] = useState(false);
-  const [isInvitationsLoading, setIsInvitationsLoading] = useState(false);
-  const [memberRoles, setMemberRoles] = useState<Record<string, V1Beta1Role[]>>({});
+  // List organization users
+  const { data: usersData, isLoading: isUsersLoading, refetch: refetchUsers } = useQuery(
+    FrontierServiceQueries.listOrganizationUsers,
+    { orgId: organization?.id ?? '', withRoles: true },
+    { enabled: !!organization?.id }
+  );
 
-  const { client, activeOrganization: organization } = useFrontier();
+  // List roles
+  const { data: rolesData, isLoading: isRolesLoading } = useQuery(
+    FrontierServiceQueries.listRoles,
+    { state: 'enabled', scopes: [PERMISSIONS.OrganizationNamespace] },
+    { enabled: !!organization?.id }
+  );
 
-  const fetchOrganizationUser = useCallback(async () => {
-    if (!organization?.id) return;
-    try {
-      setIsUsersLoading(true);
-      const {
-        // @ts-ignore
-        data: { users, role_pairs }
-      } = await client?.frontierServiceListOrganizationUsers(organization?.id, {
-        with_roles: true
-      });
-      setUsers(users);
-      setMemberRoles(
-        role_pairs.reduce((previous: any, mr: any) => {
-          return { ...previous, [mr.user_id]: mr.roles };
-        }, {})
-      );
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsUsersLoading(false);
-    }
-  }, [client, organization?.id]);
+  // List organization invitations
+  const { data: invitationsData, isLoading: isInvitationsLoading, refetch: refetchInvitations } = useQuery(
+    FrontierServiceQueries.listOrganizationInvitations,
+    { orgId: organization?.id ?? '' },
+    { enabled: !!organization?.id && showInvitations }
+  );
 
-  const fetchOrganizationRoles = useCallback(async () => {
-    if (!organization?.id) return;
-    try {
-      setIsRolesLoading(true);
-      const {
-        // @ts-ignore
-        data: { roles }
-      } = await client?.frontierServiceListRoles({
-        state: 'enabled',
-        scopes: [PERMISSIONS.OrganizationNamespace]
-      });
-      setRoles(roles);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsRolesLoading(false);
-    }
-  }, [client, organization?.id]);
+  const users = usersData?.users || [];
+  const roles = rolesData?.roles || [];
+  const invitations = useMemo(() => {
+    const invites = invitationsData?.invitations || [];
+    return invites.map((user: V1Beta1User) => ({
+      ...user,
+      invited: true
+    })) as MemberWithInvite[];
+  }, [invitationsData?.invitations]);
 
-  const fetchInvitations = useCallback(async () => {
-    if (!organization?.id) return;
-    try {
-      setIsInvitationsLoading(true);
-
-      const {
-        // @ts-ignore
-        data: { invitations }
-      } = await client?.frontierServiceListOrganizationInvitations(
-        organization?.id
-      );
-      const invitedUsers : MemberWithInvite[] = invitations.map((user: V1Beta1User) => ({
-        ...user,
-        invited: true
-      }));
-      setInvitations(invitedUsers);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsInvitationsLoading(false);
-    }
-  }, [client, organization?.id]);
-
-  useEffect(() => {
-    fetchOrganizationUser();
-  }, [fetchOrganizationUser]);
-
-  useEffect(() => {
-    fetchOrganizationRoles();
-  }, [fetchOrganizationRoles]);
-
-  useEffect(() => {
-    if (showInvitations) {
-      fetchInvitations();
-    }
-  }, [showInvitations, fetchInvitations]);
+  const memberRoles = useMemo(() => {
+    const rolePairs = usersData?.rolePairs || [];
+    return rolePairs.reduce((previous: any, mr: any) => {
+      return { ...previous, [mr.userId]: mr.roles };
+    }, {});
+  }, [usersData?.rolePairs]);
 
   const isFetching = isUsersLoading || isInvitationsLoading || isRolesLoading;
-
-
   const updatedUsers = [...users, ...invitations];
 
   const refetch = useCallback(() => {
-    fetchOrganizationUser();
+    refetchUsers();
     if (showInvitations) {
-      fetchInvitations();
+      refetchInvitations();
     }
-  }, [fetchInvitations, fetchOrganizationUser, showInvitations]);
+  }, [refetchUsers, refetchInvitations, showInvitations]);
 
   return {
     isFetching,


### PR DESCRIPTION
1. List organization users - client.frontierServiceListOrganizationUsers
2. List roles - client.frontierServiceListRoles
3. List organization invitations - client.frontierServiceListOrganizationInvitations
4. Create organization invitation - client.frontierServiceCreateOrganizationInvitation
5. Delete organization invitation - client.frontierServiceDeleteOrganizationInvitation
6. Remove organization user - client.frontierServiceRemoveOrganizationUser
7. List policies - client.frontierServiceListPolicies
8. Delete policy - client.frontierServiceDeletePolicy
9. Create policy - client.frontierServiceCreatePolicy
10. List organization roles - client.frontierServiceListOrganizationRoles
11. List organization groups - client.frontierServiceListOrganizationGroups