### PR TITLE
fix: nest session header config under headers key in sample configs

### DIFF
--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -111,10 +111,12 @@ app:
       validity: "720h"
       # secure flag for cookies
       secure: false
-      client_ip: "x-forwarded-for"
-      client_country: "x-frontier-country"
-      client_city: "x-frontier-city"
-      client_user_agent: "User-Agent"
+      # headers configuration for session metadata collection
+      headers:
+        client_ip: "x-forwarded-for"
+        client_country: "x-frontier-country"
+        client_city: "x-frontier-city"
+        client_user_agent: "User-Agent"
     # once authenticated, server responds with a jwt with user context
     # this jwt works as a bearer access token for all APIs
     token:


### PR DESCRIPTION
Fixes session location data not being populated.

The session header config fields (client_ip, client_country, client_city, client_user_agent) need to be nested under 'headers' key to match the SessionConfig struct.