### PR TITLE
migrate(sdk): user tokens hook to ConnectRPC

### DIFF
--- a/sdks/js/packages/core/react/hooks/useTokens.ts
+++ b/sdks/js/packages/core/react/hooks/useTokens.ts
@@ -5,7 +5,13 @@ import { FrontierServiceQueries, GetBillingBalanceRequestSchema } from '@raystac
 import { useFrontier } from '../contexts/FrontierContext';
 import { toast } from '@raystack/apsara';
 
-export const useTokens = () => {
+interface UseTokensReturn {
+  tokenBalance: number;
+  isTokensLoading: boolean;
+  fetchTokenBalance: () => Promise<any>;
+}
+
+export const useTokens = (): UseTokensReturn => {
   const { billingAccount } = useFrontier();
 
   const {


### PR DESCRIPTION
## Summary
- Migrated useTokens hook from REST client to Connect RPC
- Replaced manual state management with React Query's useQuery
- Used useMemo for derived tokenBalance value for optimal performance
- Error handling via useEffect (React Query v5 pattern)

## Benefits
- Automatic caching and request deduplication
- Simpler code (removed manual loading states and callbacks)
- Runtime type validation using create() with GetBillingBalanceRequestSchema
- Better performance with single render cycle