### PR TITLE
migrate(sdk): organization teams hook to ConnectRPC

### DIFF
--- a/sdks/js/packages/core/react/hooks/useOrganizationTeams.ts
+++ b/sdks/js/packages/core/react/hooks/useOrganizationTeams.ts
@@ -4,10 +4,10 @@ import { create } from '@bufbuild/protobuf';
 import {
   FrontierServiceQueries,
   ListOrganizationGroupsRequestSchema,
-  ListCurrentUserGroupsRequestSchema
+  ListCurrentUserGroupsRequestSchema,
+  Group
 } from '@raystack/proton/frontier';
 import { useFrontier } from '../contexts/FrontierContext';
-import type { V1Beta1Group } from '~/src';
 
 interface useOrganizationTeamsProps {
   withPermissions?: string[];
@@ -55,9 +55,9 @@ export const useOrganizationTeams = ({
 
   const teams = useMemo(() => {
     if (showOrgTeams) {
-      return (orgTeamsData?.groups ?? []) as V1Beta1Group[];
+      return (orgTeamsData?.groups ?? []) as Group[];
     }
-    return (userTeamsData?.groups ?? []) as V1Beta1Group[];
+    return (userTeamsData?.groups ?? []) as Group[];
   }, [showOrgTeams, orgTeamsData?.groups, userTeamsData?.groups]);
 
   const userAccessOnTeam = useMemo(() => {


### PR DESCRIPTION
## Summary
- Migrated useOrganizationTeams hook from REST client to Connect RPC
- Replaced manual state management with conditional React Query useQuery hooks
- Updated type imports to use Group from @raystack/proton/frontier instead of V1Beta1Group

## Key Changes
- Two conditional queries: one for all org teams, one for user-specific teams
- Used create() with ListOrganizationGroupsRequestSchema and ListCurrentUserGroupsRequestSchema for runtime validation
- Used useMemo for derived teams and userAccessOnTeam values
- Conditional query enabling based on showOrgTeams flag prevents unnecessary API calls
- Removed ~30 lines of manual state management code
- Proper TypeScript typing without any or @ts-ignore

## Benefits
- Automatic caching and request deduplication per mode
- Simpler code with no manual loading states or callbacks
- Better performance with proper query invalidation