### PR TITLE
fix(sdk): read redirectURL from props instead of search param

### DIFF
--- a/sdks/js/packages/core/react/components/onboarding/magiclink-verify.tsx
+++ b/sdks/js/packages/core/react/components/onboarding/magiclink-verify.tsx
@@ -73,7 +73,7 @@ export const MagicLinkVerify = ({
         setSubmitError('Please enter a valid OTP');
       }
     },
-    [otp, stateParam, authCallback, redirect_uri]
+    [otp, stateParam, authCallback, redirectURL]
   );
 
   return (


### PR DESCRIPTION
This PR fixes the redirect logic from the MagicLinkVerify component.

The issue is that the `MagicLink` component redirects to the `MagicLinkVerify` component.
It passes `state` and `code` as query param and never passes `redirect_uri`.

Now we take `redirectURL` as props. so the host app pass it to this component as per their logic and  MagicLinkVerify will redirect to it.