### PR TITLE
feat: use actor.title and actor.name in audit ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "^0.53.0",
     "@raystack/frontier": "^0.78.0",
-    "@raystack/proton": "0.1.0-a1dcf6bc73a67f383c852060b5129e492d4160d7",
+    "@raystack/proton": "0.1.0-bd066ec9145b8dfd7c882f28762bef5049d9e865",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.10.0))(@raystack/apsara@0.53.0(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/query-core@5.83.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@raystack/proton':
-        specifier: 0.1.0-a1dcf6bc73a67f383c852060b5129e492d4160d7
-        version: 0.1.0-a1dcf6bc73a67f383c852060b5129e492d4160d7(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.1.0-bd066ec9145b8dfd7c882f28762bef5049d9e865
+        version: 0.1.0-bd066ec9145b8dfd7c882f28762bef5049d9e865(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@18.3.1)
@@ -1307,8 +1307,8 @@ packages:
       vue:
         optional: true
 
-  '@raystack/proton@0.1.0-a1dcf6bc73a67f383c852060b5129e492d4160d7':
-    resolution: {integrity: sha512-NSCetley/RSo6fqjwBxFPLzenF5j+VVMt3I8iJdOSIknBbXOq+VdxcESIBPczAyLzlbf/1i4c/h/alkMLGmG2g==}
+  '@raystack/proton@0.1.0-bd066ec9145b8dfd7c882f28762bef5049d9e865':
+    resolution: {integrity: sha512-C3nqSfKLHGRMoeglTh+5+SCWi4hWFmA6EKAGmFrVT+7+9Hn3cOp8qZ+VW1Qsp0vvHlDl9EW+NQi243kD7eGgKg==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -4046,7 +4046,7 @@ snapshots:
       - debug
       - react-dom
 
-  '@raystack/proton@0.1.0-a1dcf6bc73a67f383c852060b5129e492d4160d7(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@raystack/proton@0.1.0-bd066ec9145b8dfd7c882f28762bef5049d9e865(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@bufbuild/protobuf': 2.10.0
       '@connectrpc/connect': 2.1.0(@bufbuild/protobuf@2.10.0)

--- a/ui/src/pages/audit-logs/util.ts
+++ b/ui/src/pages/audit-logs/util.ts
@@ -8,7 +8,7 @@ import {
 export const getAuditLogActorName = (actor?: AuditRecordActor) => {
   if (actor?.type === ACTOR_TYPES.SYSTEM) return "System";
 
-  const name = actor?.name || "-";
+  const name = actor?.title || actor?.name || "-";
 
   if (actor?.metadata?.["is_super_user"] === true) return name + " (Admin)";
 


### PR DESCRIPTION
This PR uses `actor.title` as primary and `actor.name` as fallback for displaying actor names in Audit UI