### PR TITLE
feat: migrate admin organization add tokens to ConnectRPC

### DIFF
--- a/ui/src/pages/organizations/details/layout/add-tokens-dialog.tsx
+++ b/ui/src/pages/organizations/details/layout/add-tokens-dialog.tsx
@@ -17,7 +17,7 @@ import { AppContext } from "~/contexts/App";
 import { defaultConfig } from "~/utils/constants";
 import { useMutation, createConnectQueryKey, useTransport } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { AdminServiceQueries, CheckoutProductBodySchema, DelegatedCheckoutRequestSchema, FrontierServiceQueries } from "@raystack/proton/frontier";
+import { AdminServiceQueries, CheckoutProductBodySchema, DelegatedCheckoutRequestSchema } from "@raystack/proton/frontier";
 import { create } from "@bufbuild/protobuf";
 
 interface InviteUsersDialogProps {


### PR DESCRIPTION
Replace REST API call with ConnectRPC + TanStack Query in the admin organization add tokens dialog.

## Changes
- Replace `api.adminServiceDelegatedCheckout()` with `useMutation(AdminServiceQueries.delegatedCheckout)`
- Add runtime validation using `create()` with `DelegatedCheckoutRequestSchema` and `CheckoutProductBodySchema`
- Use `onSuccess` callback for success handling and query invalidation
- Use `onError` callback for error handling with console logging
- Invalidate `searchOrganizationTokens` query after successful token addition