### PR TITLE
feat: migrate admin organization invite user to ConnectRPC

### DIFF
--- a/ui/src/pages/organizations/details/layout/invite-users-dialog.tsx
+++ b/ui/src/pages/organizations/details/layout/invite-users-dialog.tsx
@@ -40,9 +40,16 @@ export const InviteUsersDialog = ({ onOpenChange }: InviteUsersDialogProps) => {
   const transport = useTransport();
   const organizationId = organization?.id || "";
 
+  const defaultRoleId = useMemo(
+    () => roles?.find((role) => role.name === DEFAULT_INVITE_ROLE)?.id,
+    [roles],
+  );
+
   const methods = useForm<InviteSchemaType>({
     resolver: zodResolver(inviteSchema),
-    defaultValues: {},
+    defaultValues: {
+      role: defaultRoleId,
+    },
   });
 
   const { mutateAsync: createInvitation } = useMutation(
@@ -79,11 +86,6 @@ export const InviteUsersDialog = ({ onOpenChange }: InviteUsersDialogProps) => {
       }),
     );
   };
-
-  const defaultRoleId = useMemo(
-    () => roles?.find((role) => role.name === DEFAULT_INVITE_ROLE)?.id,
-    [roles],
-  );
 
   const isSubmitting = methods?.formState?.isSubmitting;
   const errors = methods?.formState?.errors;
@@ -133,7 +135,6 @@ export const InviteUsersDialog = ({ onOpenChange }: InviteUsersDialogProps) => {
                         <Select
                           {...rest}
                           onValueChange={(value: any) => field.onChange(value)}
-                          defaultValue={defaultRoleId}
                         >
                           <Select.Trigger ref={ref}>
                             <Select.Value placeholder="Select Role" />


### PR DESCRIPTION
Replace REST API call with ConnectRPC + TanStack Query in the admin organization invite user dialog.

## Changes
- Replace \`api.frontierServiceCreateOrganizationInvitation()\` with \`useMutation(FrontierServiceQueries.createOrganizationInvitation)\`
- Add runtime validation using \`create()\` with \`CreateOrganizationInvitationRequestSchema\`
- Use \`onSuccess\` callback for success handling and query invalidation
- Use \`onError\` callback for error handling with console logging
- Invalidate \`listOrganizationInvitations\` query after successful invitation
- Remove \`AxiosError\` handling in favor of ConnectRPC error handling
- Fix default role selection by setting it in form \`defaultValues\` instead of Select component \`defaultValue\` prop