### PR TITLE
feat: add logging inside handler on service errors

### DIFF
--- a/internal/api/v1beta1connect/error_handler.go
+++ b/internal/api/v1beta1connect/error_handler.go
@@ -70,4 +70,3 @@ func (e *ErrorLogger) LogTransformError(ctx context.Context, req connect.AnyRequ
 func (e *ErrorLogger) getRequestID(req connect.AnyRequest) string {
 	return req.Header().Get(consts.RequestIDHeader)
 }
-

--- a/internal/api/v1beta1connect/user.go
+++ b/internal/api/v1beta1connect/user.go
@@ -9,7 +9,6 @@ import (
 	"connectrpc.com/connect"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 	"github.com/raystack/frontier/core/audit"
 	"github.com/raystack/frontier/core/authenticate"
 	"github.com/raystack/frontier/core/group"
@@ -25,6 +24,7 @@ import (
 	"github.com/raystack/frontier/pkg/utils"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/raystack/salt/rql"
+	"go.uber.org/zap"
 	httpbody "google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/pkg/server/connect_interceptors/logger.go
+++ b/pkg/server/connect_interceptors/logger.go
@@ -10,8 +10,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const loggerContextKey = "logger"
-
 type LoggerOption struct {
 	// Decider returns true if method should be logged
 	Decider func(procedure string) bool


### PR DESCRIPTION
  ### Overview
  This PR implements centralized error logging for Connect RPC handlers to improve debugging capabilities while maintaining DRY (Don't Repeat Yourself) principles.

  ### Problem
  - Generic "Internal Server Error" responses provided minimal debugging context

  ### Solution
  - Created `ErrorLogger` utility class with standardized logging methods:
    - `LogServiceError()` - Service layer error logging
    - `LogUnexpectedError()` - Additional context for internal errors
    - `LogTransformError()` - Protobuf transformation error logging
  - Replaced repetitive logging across user handlers: CreateUser, GetUser, UpdateUser, EnableUser, DeleteUser
  - Enhanced structured logging with operation context, request IDs, error types, and entity-specific fields

  ### Example Enhanced Logging
  ```
  2025-11-04T15:28:39.675+0530	error	CreateUser operation failed	{"operation": "CreateUser", "request_id": "", "error_type": "*errors.errorString", "error": "test error for logging verification", "email": "abhisheksah+testlogging004@pixxel.co.in", "name": "logging004"}
2025-11-04T15:28:39.675+0530	error	unexpected error in CreateUser	{"operation": "CreateUser", "request_id": "", "error_chain": "test error for logging verification", "error": "test error for logging verification", "user_email": "abhisheksah+testlogging004@pixxel.co.in", "user_name": "logging004"}
2025-11-04T15:28:39.675+0530	error	finished call	{"system": "connect_rpc", "start_time": "2025-11-04T15:28:39.565+0530", "method": "/raystack.frontier.v1beta1.FrontierService/CreateUser", "time_ms": 110, "code": "internal", "request_id": "", "error": "internal: internal server error"}
  ```