### PR TITLE
feat: migrate admin org billing to ConnectRPC

### DIFF
--- a/ui/src/pages/organizations/details/edit/billing.tsx
+++ b/ui/src/pages/organizations/details/edit/billing.tsx
@@ -243,7 +243,7 @@ export function EditBillingPanel({ onClose }: EditBillingPanelProps) {
                 <InputField
                   disabled={isPrepaid}
                   label="Credit limit"
-                  type="string"
+                  type="text"
                   {...register("creditMin", {})}
                   error={errors?.creditMin?.message}
                 />
@@ -254,7 +254,7 @@ export function EditBillingPanel({ onClose }: EditBillingPanelProps) {
                 <InputField
                   disabled={isPrepaid}
                   label="Billing due date"
-                  type="string"
+                  type="text"
                   suffix="Days"
                   {...register("dueInDays", {})}
                   error={errors?.dueInDays?.message}


### PR DESCRIPTION
## Summary
Migrate admin organization billing edit panel from REST API (Axios) to ConnectRPC.

## Changes
- Replace `getBillingAccountDetails` REST API call with `useQuery` + `AdminServiceQueries.getBillingAccountDetails`
- Replace `updateBillingAccountDetails` REST API call with `useMutation` + `AdminServiceQueries.updateBillingAccountDetails`  
- Replace `getBillingAccount` REST API call with `useMutation` + `FrontierServiceQueries.getBillingAccount`
- Handle bigint conversions for `creditMin` and `dueInDays` fields
- Add proper postpaid/prepaid logic with conditional negative value conversion for API
- Update form schema to use string fields with regex validation
- Add error handling with toast notifications and console logging
- Remove manual loading state management (now handled by useQuery)

## Technical Details
- API expects negative `creditMin` for postpaid, positive/zero for prepaid
- Form displays positive values, converts on submit based on payment type
- Form fields are disabled for prepaid mode