### PR TITLE
fix: dont retry get current user

### DIFF
--- a/sdks/js/packages/core/react/contexts/FrontierContext.tsx
+++ b/sdks/js/packages/core/react/contexts/FrontierContext.tsx
@@ -192,7 +192,12 @@ export const FrontierContextProvider = ({
   );
 
   const { data: currentUserData, isLoading: isUserLoading } = useConnectQuery(
-    FrontierServiceQueries.getCurrentUser
+    FrontierServiceQueries.getCurrentUser,
+    {},
+    {
+      retry: false,
+      refetchOnWindowFocus: false
+    }
   );
 
   const user = currentUserData?.user;


### PR DESCRIPTION
This PR removes the `getCurrentUser` api call retry.
The issue is the `useQuery` refetch on 401, which will rerender the whole app because a lot of data depends on `user` data.
Ideally, we should only fetch one, and the host app should refetch.
As we are using connect-query, if the host app refetches `getCurrentUser` after successful login, the data in `FrontierContext` will also update, since they share the same key.
This will give more control to host app to make the api call and prevent rerender of the app.
