### PR TITLE
fix: preserve old values in audit records for org and billing customer updates

### DIFF
--- a/internal/store/postgres/audit_record.go
+++ b/internal/store/postgres/audit_record.go
@@ -277,8 +277,8 @@ func BuildAuditRecord(ctx context.Context, event pkgAuditRecord.Event, resource 
 
 // InsertAuditRecordInTx inserts an audit record within a transaction
 func InsertAuditRecordInTx(ctx context.Context, tx *sqlx.Tx, record AuditRecord) error {
-	// Enrich the organization name from DB
-	if record.OrganizationID != uuid.Nil {
+	// Enrich the organization name from DB only if not already set
+	if record.OrganizationID != uuid.Nil && record.OrganizationName == "" {
 		var orgName string
 		query, params, err := buildOrgNameQuery(record.OrganizationID)
 		if err == nil {


### PR DESCRIPTION
 ## Problem

When updating organizations or billing customers, audit records were capturing the **NEW** values instead of **OLD** values. This happened because we were reading the resource data after the UPDATE statement within the same transaction, which returns the updated values due to "read your own writes" behavior.

This broke audit trail continuity - we couldn't see what the resource was called *before* the update, making it difficult to trace changes over time.

 ### Example of the issue:
  Update org title: "Acme Corp" → "Acme Corporation"
  Audit record showed: resource_name="Acme Corporation" (NEW)
  Should have shown: resource_name="Acme Corp" (OLD)

  ## Solution

  ### 1. Fetch old values BEFORE the update
  - **Organization updates** (`UpdateByID`, `UpdateByName`): Fetch title before UPDATE statement
  - **Billing customer updates** (`UpdateByID`): Fetch customer name before UPDATE statement

  ### 2. Use old values in audit records
  - Store old title/name as the resource name in audit records
  - Add both old and new values to metadata only when they actually change
  - Follow existing naming convention: `title`/`updated_title`, `name`/`updated_name`

  ### 3. Pre-populate OrganizationName
  - Modified `InsertAuditRecordInTx` to only fetch org name if not already set
  - Pre-populate `AuditRecord.OrganizationName` with old title to prevent fetching updated value

  ### 4. Code quality improvements
  - Extracted common logic into `buildOrgUpdateAuditRecord` helper function
  - Eliminated duplication between UpdateByID and UpdateByName
  - Optimized to avoid copying metadata when values don't change

  ## Files Changed

  - `internal/store/postgres/organization_repository.go`
    - Added `buildOrgUpdateAuditRecord` helper
    - Modified `UpdateByID` and `UpdateByName` to fetch and preserve old title

  - `internal/store/postgres/billing_customer_repository.go`
    - Modified `UpdateByID` to fetch and preserve old customer name

  - `internal/store/postgres/audit_record.go`
    - Updated `InsertAuditRecordInTx` to respect pre-populated OrganizationName

