### PR TITLE
feat: add hook to poll connect query rpcs

### DIFF
--- a/sdks/js/packages/core/package.json
+++ b/sdks/js/packages/core/package.json
@@ -96,6 +96,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.6.3",
+    "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-query": "^2.1.1",
     "@connectrpc/connect-web": "^2.0.2",
     "@hookform/resolvers": "^3.10.0",

--- a/sdks/js/packages/core/react/hooks/useConnectQueryPolling.tsx
+++ b/sdks/js/packages/core/react/hooks/useConnectQueryPolling.tsx
@@ -1,0 +1,76 @@
+import { useRef, useState } from 'react';
+import { useQuery } from '@connectrpc/connect-query';
+import type { ConnectError } from '@connectrpc/connect';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type {
+  DescMessage,
+  DescMethodUnary,
+  MessageInitShape,
+  MessageShape
+} from '@bufbuild/protobuf';
+
+type UseConnectQueryPollingResult<TData> = UseQueryResult<
+  TData,
+  ConnectError
+> & {
+  isPollingFailed: boolean;
+};
+
+export function useConnectQueryPolling<
+  I extends DescMessage,
+  O extends DescMessage,
+  SelectOutData = MessageShape<O>
+>(params: {
+  method: DescMethodUnary<I, O>;
+  input: MessageInitShape<I> | undefined;
+  enabled: boolean;
+  select: (data: MessageShape<O>) => SelectOutData;
+  isComplete: (data: SelectOutData) => boolean;
+  maxPoll?: number;
+  pollingInterval?: number;
+}): UseConnectQueryPollingResult<SelectOutData> {
+  const {
+    method,
+    input,
+    enabled,
+    select,
+    isComplete,
+    maxPoll = 40,
+    pollingInterval = 3000
+  } = params;
+  const [isPollingFailed, setIsPollingFailed] = useState(false);
+  const pollCountRef = useRef(0);
+
+  const result = useQuery<I, O, SelectOutData>(method, input, {
+    enabled,
+    select,
+    retry: false,
+    refetchInterval: query => {
+      if (query.state.error) {
+        setIsPollingFailed(true);
+        return false;
+      }
+
+      if (pollCountRef.current >= maxPoll) {
+        setIsPollingFailed(true);
+        return false;
+      }
+
+      pollCountRef.current++;
+
+      if (query.state.data !== undefined) {
+        const transformed = select(query.state.data);
+        if (transformed !== undefined && isComplete(transformed)) {
+          return false;
+        }
+      }
+
+      return pollingInterval;
+    }
+  });
+
+  return {
+    ...result,
+    isPollingFailed
+  } as UseConnectQueryPollingResult<SelectOutData>;
+}

--- a/sdks/js/packages/core/react/index.ts
+++ b/sdks/js/packages/core/react/index.ts
@@ -15,13 +15,11 @@ export { Window } from './components/window';
 
 export { useFrontier } from './contexts/FrontierContext';
 export { FrontierProvider, queryClient } from './contexts/FrontierProvider';
-export { 
-  CustomizationProvider
-} from './contexts/CustomizationContext';
-
+export { CustomizationProvider } from './contexts/CustomizationContext';
 
 export { useTokens } from './hooks/useTokens';
 export { useBillingPermission } from './hooks/useBillingPermission';
+export { useConnectQueryPolling } from './hooks/useConnectQueryPolling';
 export { usePreferences } from './hooks/usePreferences';
 export { Layout } from './components/Layout';
 
@@ -33,5 +31,9 @@ export type {
 
 export { PREFERENCE_OPTIONS } from './utils/constants';
 
-export { timestampToDate, timestampToDayjs, isNullTimestamp } from '../utils/timestamp';
+export {
+  timestampToDate,
+  timestampToDayjs,
+  isNullTimestamp
+} from '../utils/timestamp';
 export type { TimeStamp } from '../utils/timestamp';

--- a/sdks/js/pnpm-lock.yaml
+++ b/sdks/js/pnpm-lock.yaml
@@ -36,12 +36,15 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.6.3
         version: 2.6.3
+      '@connectrpc/connect':
+        specifier: ^2.0.2
+        version: 2.0.2(@bufbuild/protobuf@2.6.3)
       '@connectrpc/connect-query':
         specifier: ^2.1.1
-        version: 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@connectrpc/connect-web':
         specifier: ^2.0.2
-        version: 2.0.2(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))
+        version: 2.0.2(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3))
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.57.0(react@18.3.1))
@@ -574,10 +577,15 @@ packages:
       '@bufbuild/protobuf': ^2.2.0
       '@connectrpc/connect': 2.0.2
 
-  '@connectrpc/connect@2.0.3':
-    resolution: {integrity: sha512-jAbVMHVtDCydGt2P20VpmLjbLtERqSV0RMSyQF3k2zhK8pzQ2QaCAcyVhufClqrOAFZUKL5BqVYtttaxvhmRgg==}
+  '@connectrpc/connect@2.0.2':
+    resolution: {integrity: sha512-xZuylIUNvNlH52e/4eQsZvY4QZyDJRtEFEDnn/yBrv5Xi5ZZI/p8X+GAHH35ucVaBvv9u7OzHZo8+tEh1EFTxA==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.2.0
+
+  '@connectrpc/connect@2.1.0':
+    resolution: {integrity: sha512-xhiwnYlJNHzmFsRw+iSPIwXR/xweTvTw8x5HiwWp10sbVtd4OpOXbRgE7V58xs1EC17fzusF1f5uOAy24OkBuA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7721,29 +7729,50 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
-  '@connectrpc/connect-query-core@2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)':
+  '@connectrpc/connect-query-core@2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)':
     dependencies:
       '@bufbuild/protobuf': 2.6.3
-      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.3)
+      '@connectrpc/connect': 2.0.2(@bufbuild/protobuf@2.6.3)
       '@tanstack/query-core': 5.83.0
 
-  '@connectrpc/connect-query@2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@connectrpc/connect-query-core@2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)':
     dependencies:
       '@bufbuild/protobuf': 2.6.3
-      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.3)
-      '@connectrpc/connect-query-core': 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)
+      '@connectrpc/connect': 2.1.0(@bufbuild/protobuf@2.6.3)
+      '@tanstack/query-core': 5.83.0
+
+  '@connectrpc/connect-query@2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.6.3
+      '@connectrpc/connect': 2.0.2(@bufbuild/protobuf@2.6.3)
+      '@connectrpc/connect-query-core': 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)
       '@tanstack/react-query': 5.83.0(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@tanstack/query-core'
 
-  '@connectrpc/connect-web@2.0.2(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))':
+  '@connectrpc/connect-query@2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@bufbuild/protobuf': 2.6.3
-      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.3)
+      '@connectrpc/connect': 2.1.0(@bufbuild/protobuf@2.6.3)
+      '@connectrpc/connect-query-core': 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)
+      '@tanstack/react-query': 5.83.0(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@tanstack/query-core'
 
-  '@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3)':
+  '@connectrpc/connect-web@2.0.2(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3))':
+    dependencies:
+      '@bufbuild/protobuf': 2.6.3
+      '@connectrpc/connect': 2.0.2(@bufbuild/protobuf@2.6.3)
+
+  '@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.6.3)':
+    dependencies:
+      '@bufbuild/protobuf': 2.6.3
+
+  '@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.6.3)':
     dependencies:
       '@bufbuild/protobuf': 2.6.3
 
@@ -9169,8 +9198,8 @@ snapshots:
   '@raystack/proton@0.1.0-fba39927b8b974dc1cc1ae0f05f1390580ec6d58(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@bufbuild/protobuf': 2.6.3
-      '@connectrpc/connect': 2.0.3(@bufbuild/protobuf@2.6.3)
-      '@connectrpc/connect-query': 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.0.3(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@connectrpc/connect': 2.1.0(@bufbuild/protobuf@2.6.3)
+      '@connectrpc/connect-query': 2.1.1(@bufbuild/protobuf@2.6.3)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.6.3))(@tanstack/query-core@5.83.0)(@tanstack/react-query@5.83.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
     optionalDependencies:


### PR DESCRIPTION
This PR adds the hook to poll the connect rpc query and stop if required data is available from the backend or the maximum number of calls has been reached. 


It use refs for polling similar to this https://github.com/TanStack/query/discussions/5279#discussioncomment-9315767