### PR TITLE
fix: update security page description text

### DIFF
--- a/sdks/js/packages/core/react/components/organization/domain/index.tsx
+++ b/sdks/js/packages/core/react/components/organization/domain/index.tsx
@@ -92,8 +92,7 @@ const AllowedEmailDomains = () => {
           Allowed email domains
         </Text>
         <Text size="regular" variant="secondary">
-          Anyone with an email address at these domains is allowed to sign up
-          for this workspace.
+          Anyone with an email address from these domains can sign up for this workspace.
         </Text>
       </Flex>
     </Flex>


### PR DESCRIPTION
## Summary
- Updated allowed email domains description for better clarity

## Test plan
- Navigate to Security page
- Verify description text reads correctly