### PR TITLE
fix: update authorization logic for CreateAuditRecord RPC to use platform-level permissions

### DIFF
--- a/pkg/server/connect_interceptors/authorization.go
+++ b/pkg/server/connect_interceptors/authorization.go
@@ -701,8 +701,7 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 
 	// audit records
 	frontierv1beta1connect.FrontierServiceCreateAuditRecordProcedure: func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {
-		pbreq := req.(*connect.Request[frontierv1beta1.CreateAuditRecordRequest])
-		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.OrganizationNamespace, ID: pbreq.Msg.GetOrgId()}, schema.GetPermission, req)
+		return handler.IsAuthorized(ctx, relation.Object{Namespace: schema.PlatformNamespace, ID: schema.PlatformID}, schema.PlatformCheckPermission, req)
 	},
 
 	frontierv1beta1connect.AdminServiceListAuditRecordsProcedure: func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {


### PR DESCRIPTION
## Summary
Currently CreateAuditRecord RPC checks if the user has get permission to the given org. However, this RPC will be called by internal services using their service user credentials which works with platform level checks (similar to what we have for CreateBillingUsage & RevertBillingUsage)


## Changes
Updated the authorization.go file for the mentioned RPC


## Test
Manually tested on local by upgrading a service key to platform level by calling AddPlatformUser RPC.