### PR TITLE
fix: updated_at for org state change

### DIFF
--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -463,7 +463,8 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 func (r OrganizationRepository) SetState(ctx context.Context, id string, state organization.State) error {
 	query, params, err := dialect.Update(TABLE_ORGANIZATIONS).Set(
 		goqu.Record{
-			"state": state.String(),
+			"state":      state.String(),
+			"updated_at": goqu.L("now()"),
 		}).Where(
 		goqu.Ex{
 			"id": id,


### PR DESCRIPTION
Currently updated_at field is not being set when we are doing any state change. This PR fixes it