### PR TITLE
refactor: use PageHeader component in layout

### DIFF
--- a/sdks/js/packages/core/react/components/Layout/index.tsx
+++ b/sdks/js/packages/core/react/components/Layout/index.tsx
@@ -1,19 +1,23 @@
-import { Flex, Text } from '@raystack/apsara';
+import { Flex } from '@raystack/apsara';
 import { PropsWithChildren } from 'react';
-import styles from './layout.module.css';
+import { PageHeader } from '../common/page-header';
+import sharedStyles from '../organization/styles.module.css';
 
 interface LayoutProps {
   title: string;
+  description?: string;
 }
 
-export function Layout({ title, children }: PropsWithChildren<LayoutProps>) {
+export function Layout({ title, description, children }: PropsWithChildren<LayoutProps>) {
   return (
     <Flex direction="column" style={{ width: '100%' }}>
-      <Flex className={styles.header}>
-        <Text size="large">{title}</Text>
-      </Flex>
-      <Flex direction="column" gap={9} className={styles.container}>
-        {children}
+      <Flex direction="column" className={sharedStyles.container}>
+        <Flex direction="row" justify="between" align="center" className={sharedStyles.header}>
+          <PageHeader title={title} description={description} />
+        </Flex>
+        <Flex direction="column" gap={9}>
+          {children}
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/sdks/js/packages/core/react/index.ts
+++ b/sdks/js/packages/core/react/index.ts
@@ -22,6 +22,7 @@ export { useBillingPermission } from './hooks/useBillingPermission';
 export { useConnectQueryPolling } from './hooks/useConnectQueryPolling';
 export { usePreferences } from './hooks/usePreferences';
 export { Layout } from './components/Layout';
+export { PageHeader } from './components/common/page-header';
 
 export type {
   FrontierClientOptions,


### PR DESCRIPTION
## Summary

Updates the old header in SDK custom page and adds description prop to match the new header design. Other pages already using the new design.

Breaking change: NO


## Changes
1. Exports `PageHeader` component - `import { PageHeader } from '@raystack/frontier/react';`
2. Replace custom header in `Layout` component with `PageHeader` along with a new `description` prop.

<img width="1393" height="782" alt="Screenshot 2025-12-22 at 3 45 35 PM" src="https://github.com/user-attachments/assets/c513fb5c-d8da-4b61-acd2-64377ee09da8" />

[https://github.com/pixxelhq/studio/pull/2188](https://github.com/pixxelhq/studio/pull/2188)


## Test Plan
- [x] Manual testing completed
- [x] Build and type checking passes
