### PR TITLE
perf: increase goreleaser parallelism to 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,6 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v1"
-          args: release --clean
+          args: release --clean --parallelism=8
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}


### PR DESCRIPTION
## Summary
- Increased GoReleaser parallelism from default to 8 for faster release builds

## Details
The project builds 6 OS/arch combinations plus 2 docker images and packaging artifacts. With parallelism=8, we can better utilize GitHub Actions runners and speed up the release process by handling more tasks concurrently.

## Test plan
- Monitor next release workflow run time