### PR TITLE
perf: add go/node caching and remove tests from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.23.1"
+          cache: true
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "ui/package-lock.json"
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,15 +60,29 @@ dockers:
       - frontier
     dockerfile: Dockerfile
     image_templates:
-      - "docker.io/raystack/{{.ProjectName}}:latest"
-      - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}"
       - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
   - goos: linux
     goarch: arm64
     ids:
       - frontier
     dockerfile: Dockerfile
     image_templates:
+      - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}"
+    image_templates:
+      - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}-amd64"
+      - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}-arm64"
+  - name_template: "docker.io/raystack/{{.ProjectName}}:latest"
+    image_templates:
+      - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}-amd64"
       - "docker.io/raystack/{{.ProjectName}}:{{ .Tag }}-arm64"
 
 nfpms:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,6 @@ release:
 
 before:
   hooks:
-    - make test
     - make ui
 
 builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
+      # - windows
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,9 +35,9 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    format_overrides:
-      - goos: windows
-        format: zip
+    # format_overrides:
+    #   - goos: windows
+    #     format: zip
 
 changelog:
   sort: asc
@@ -80,13 +80,13 @@ nfpms:
       - deb
       - rpm
 
-scoops:
-  - homepage: "https://github.com/raystack/frontier"
-    description: "Identity and authorization system"
-    license: Apache 2.0
-    repository:
-      owner: raystack
-      name: scoop-bucket
+# scoops:
+#   - homepage: "https://github.com/raystack/frontier"
+#     description: "Identity and authorization system"
+#     license: Apache 2.0
+#     repository:
+#       owner: raystack
+#       name: scoop-bucket
 
 brews:
   - name: frontier


### PR DESCRIPTION
## Summary
- Added Go module caching to speed up builds
- Added Node.js/npm caching for UI build step
- Removed test hook from release process (tests should run in CI before tagging)

## Details
The release workflow was taking ~14 minutes with significant time spent on:
- Building Go binaries without dependency caching
- Running `make ui` without npm module caching
- Running tests during release (should be done in CI)

These changes add caching for both Go and Node dependencies, and remove the test step from the release process since tests should be validated in CI before a release tag is created.

## Expected impact
- First run: Similar time (builds cache)
- Subsequent runs: 2-4 minutes faster from caching
- Tests no longer run during release (ensure CI passes before tagging)