### PR TITLE
fix: change env prefix to avoid K8s service env var collision

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,9 @@ func Load(serverConfigFileFromFlag string) (*Frontier, error) {
 	conf := &Frontier{}
 
 	var options []config.Option
-	options = append(options, config.WithEnvPrefix("FRONTIER"))
+	// use FRONTIER_SERVICE_ prefix to avoid collision with K8s service env vars
+	// K8s auto-creates env vars like FRONTIER_APP_PORT for service named frontier-app
+	options = append(options, config.WithEnvPrefix("FRONTIER_SERVICE"))
 
 	// override all config sources and prioritize one from file
 	if serverConfigFileFromFlag != "" {


### PR DESCRIPTION
## Summary

Change env prefix from `FRONTIER` to `FRONTIER_SERVICE` to prevent collision with Kubernetes service environment variables.

## Problem

Kubernetes automatically creates environment variables for services. For a service named `frontier-app`, K8s creates:

```
FRONTIER_APP_PORT=tcp://172.20.58.102:80
FRONTIER_APP_SERVICE_HOST=172.20.58.102
FRONTIER_APP_SERVICE_PORT=80
```

With Viper's `FRONTIER` prefix, `FRONTIER_APP_PORT` maps to `app.port` and overrides config file values. This causes errors like:

```
cannot parse 'app.port' as int: strconv.ParseInt: parsing "tcp://172.20.58.102:80": invalid syntax
```

## Solution

Change env prefix to `FRONTIER_SERVICE`. Now env vars need to be `FRONTIER_SERVICE_APP_PORT` to affect `app.port`, avoiding the collision with K8s-generated env vars.

## Breaking Change

Existing deployments using env vars with `FRONTIER_` prefix will need to update to `FRONTIER_SERVICE_` prefix. However, most K8s deployments use config files via `-c` flag, so impact should be minimal.