### PR TITLE
fix: install pnpm in Dockerfile.dev for admin app build

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,10 @@
 # Build the UI
 FROM node:18-alpine3.18 as admin-builder
 RUN apk add --no-cache make
+RUN npm install -g pnpm@9.3.0
 WORKDIR /app
 
-COPY web/apps/admin ./web/apps/admin
+COPY web ./web
 COPY Makefile .
 RUN make admin-app
 

--- a/web/apps/admin/Makefile
+++ b/web/apps/admin/Makefile
@@ -9,4 +9,4 @@ test:
 	@pnpm run test
 
 dep:
-	@pnpm install --legacy-peer-deps -f
+	@pnpm install --force


### PR DESCRIPTION
## Summary
- Fixes the failing Main workflow on main branch
- Installs pnpm globally in the admin-builder stage
- Copies entire web directory instead of just web/apps/admin to support workspace dependencies

## Problem
The `Main` workflow was failing with error:
```
make[1]: pnpm: No such file or directory
make[1]: *** [Makefile:12: dep] Error 127
```

This occurred because:
1. The Dockerfile.dev was trying to run `make admin-app`
2. This target calls `pnpm install` and `pnpm run build`
3. The node:18-alpine3.18 base image doesn't include pnpm by default

## Solution  
- Install pnpm@9.3.0 globally (matching version in web/package.json)
- Copy entire web directory to support pnpm workspace structure

## Test Plan
- CI will verify the Docker build succeeds
- Main workflow should now pass