### PR TITLE
fix(ci): remove dind service causing Docker version mismatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,6 @@ jobs:
 
   smoke:
     runs-on: ubuntu-latest
-    services:
-      dind:
-        image: docker:24.0.2-dind-rootless
-        ports:
-          - 2375:2375
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,18 +41,11 @@ jobs:
           go-version: "1.23.1"
       - name: install dependencies
         run: go mod tidy
-      - name: install spicedb binary
-        uses: authzed/action-spicedb@v1
       - name: run smoke tests
         run: make e2e-smoke-test
 
   regression:
     runs-on: ubuntu-latest
-    services:
-      dind:
-        image: docker:24.0.2-dind-rootless
-        ports:
-          - 2375:2375
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

Fix smoke and regression test failures caused by Docker API version mismatch.

## Problem

The CI was failing with:
```
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```

## Root Cause

Two issues were identified:

1. **Unnecessary `dind` service**: The Docker-in-Docker service was running Docker daemon v24.0.2 (API 1.44+), but the GitHub Actions runner's Docker client uses an older API (1.40), causing a version mismatch.

2. **Unnecessary `authzed/action-spicedb` action**: This action was not needed because the e2e tests use `ory/dockertest` Go library to spin up SpiceDB containers directly. The action was likely causing the Docker version mismatch by attempting to use Docker in an incompatible way.

Same changes applied to the `regression` job.

🤖 Generated with [Claude Code](https://claude.ai/code)