### PR TITLE
refactor(preference): rename custom_traits_path to additional_traits_path

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -326,10 +326,10 @@ func buildAPIDependencies(
 	resourceBlobRepository *blob.ResourcesRepository,
 	planBlobRepository *blob.PlanRepository,
 ) (api.Deps, error) {
-	// Load custom traits from config file if specified
-	traits, err := preference.LoadTraitsFromFile(cfg.App.CustomTraitsPath)
+	// Load additional traits from config file if specified
+	traits, err := preference.LoadTraitsFromFile(cfg.App.AdditionalTraitsPath)
 	if err != nil {
-		return api.Deps{}, fmt.Errorf("failed to load custom traits: %w", err)
+		return api.Deps{}, fmt.Errorf("failed to load additional traits: %w", err)
 	}
 	preferenceService := preference.NewService(postgres.NewPreferenceRepository(dbc), traits)
 

--- a/core/preference/config.go
+++ b/core/preference/config.go
@@ -7,12 +7,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TraitsConfig represents the YAML config file structure for custom traits
+// TraitsConfig represents the YAML config file structure for additional traits
 type TraitsConfig struct {
 	Traits []Trait `yaml:"traits"`
 }
 
-// LoadTraitsFromFile loads custom traits from a YAML configuration file
+// LoadTraitsFromFile loads additional traits from a YAML configuration file
 // and merges them with DefaultTraits
 func LoadTraitsFromFile(path string) ([]Trait, error) {
 	if path == "" {
@@ -29,23 +29,23 @@ func LoadTraitsFromFile(path string) ([]Trait, error) {
 		return nil, fmt.Errorf("parse traits file: %w", err)
 	}
 
-	// Merge custom traits with default traits
-	// Custom traits with same resource_type and name override defaults
+	// Merge additional traits with default traits
+	// Additional traits with same resource_type and name override defaults
 	traits := make([]Trait, 0, len(DefaultTraits)+len(config.Traits))
 	traits = append(traits, DefaultTraits...)
 
-	for _, customTrait := range config.Traits {
-		// Check if custom trait overrides a default trait
+	for _, additionalTrait := range config.Traits {
+		// Check if additional trait overrides a default trait
 		found := false
 		for i, defaultTrait := range traits {
-			if defaultTrait.ResourceType == customTrait.ResourceType && defaultTrait.Name == customTrait.Name {
-				traits[i] = customTrait
+			if defaultTrait.ResourceType == additionalTrait.ResourceType && defaultTrait.Name == additionalTrait.Name {
+				traits[i] = additionalTrait
 				found = true
 				break
 			}
 		}
 		if !found {
-			traits = append(traits, customTrait)
+			traits = append(traits, additionalTrait)
 		}
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -90,7 +90,7 @@ type Config struct {
 
 	Webhook webhook.Config `yaml:"webhook" mapstructure:"webhook"`
 
-	// CustomTraitsPath is a file path to a YAML file containing custom preference traits
+	// AdditionalTraitsPath is a file path to a YAML file containing additional preference traits
 	// These traits are merged with DefaultTraits at startup
-	CustomTraitsPath string `yaml:"custom_traits_path" mapstructure:"custom_traits_path"`
+	AdditionalTraitsPath string `yaml:"additional_traits_path" mapstructure:"additional_traits_path"`
 }


### PR DESCRIPTION
## Summary
- Renames `custom_traits_path` config field to `additional_traits_path` in app config
- Updates all related references (comments, variable names) from "custom traits" to "additional traits"

## Test plan
- [x] `go build` passes
- [x] `TestLoadTraitsFromFile` tests pass
- [x] Verify local run

🤖 Generated with [Claude Code](https://claude.com/claude-code)