### PR TITLE
fix(profile): improve full name validation with clearer error messages

### DIFF
--- a/web/sdk/react/components/organization/user/update.tsx
+++ b/web/sdk/react/components/organization/user/update.tsx
@@ -33,7 +33,7 @@ const generalSchema = yup
         /^\p{L}[\p{L} .'-]*\p{L}$|^\p{L}$/u,
         'Name must end with a letter'
       )
-      .matches(/^(?!.*  ).*$/, 'Name cannot have consecutive spaces')
+      .matches(/^(?!.* {2}).*$/, 'Name cannot have consecutive spaces')
       .matches(/^(?!.* [^\p{L}]).*$/u, 'Spaces must be followed by a letter')
       .matches(/^(?!.*-[^\p{L}]).*$/u, 'Hyphens must be followed by a letter')
       .matches(


### PR DESCRIPTION
## Summary
- Improved full name validation in user profile to allow only letters, spaces, periods, hyphens, and apostrophes
- Ensured special characters (spaces, hyphens, apostrophes) can only appear after at least one letter
- Added multiple validation rules with clear, specific error messages for better UX

## Changes
- Reordered validation checks to show most relevant error message first
- Name must start and end with a letter
- Special characters must be followed by a letter
- No consecutive spaces allowed

## Test plan
- [ ] Test with valid names: "John Doe", "Mary-Jane O'Connor", "Dr. Smith"
- [ ] Test invalid: trailing space shows "Name must end with a letter"
- [ ] Test invalid: trailing hyphen shows "Name must end with a letter"
- [ ] Test invalid: trailing apostrophe shows "Name must end with a letter"
- [ ] Test invalid: numbers/symbols show "Name can only contain..."
- [ ] Test invalid: space not followed by letter shows "Spaces must be followed by a letter"