### PR TITLE
fix(vite): add config to dedupe dependencies

### DIFF
--- a/web/apps/admin/vite.config.ts
+++ b/web/apps/admin/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig(() => {
         allow: [".."],
       },
     },
+    resolve: {
+      dedupe: ["react", "react-dom", "react-router-dom", "react-router"],
+    },
     plugins: [react(), svgr(), tsconfigPaths()],
     define: {
       "process.env": process.env,


### PR DESCRIPTION
**Problem**: The SDK (@raystack/frontier/admin) imports react-router-dom internally (for <Outlet>, useLocation, etc.). When the app is built for production, the bundler can end up with two separate copies of react-router-dom — one from the app and one from the SDK. Since React Router uses internal context to connect <Route> to <Outlet>, two copies means two separate contexts. The app's <Route> tree writes to context A, but the SDK's <Outlet> reads from context B — finding nothing, so it renders blank.

**Why it works locally:** Vite dev mode resolves the SDK via workspace link (source files directly), so all react-router-dom imports resolve to the same single copy.

**Fix**: resolve.dedupe tells Vite (and its production bundler, Rollup) to always resolve those packages to a single copy, regardless of where the import originates. This ensures the app and SDK share the same React Router context.