### PR TITLE
refactor: clean up gRPC dependencies and config references

### DIFF
--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -34,16 +34,6 @@ ui:
   organization_types: []
 
 app:
-  port: 8000
-  grpc:
-    port: 8001
-    # gRPC message size limits
-    # max_recv_msg_size: 33554432
-    # max_send_msg_size: 33554432
-    # optional tls config
-    # tls_cert_file: "temp/server-cert.pem"
-    # tls_key_file: "temp/server-key.pem"
-    # tls_client_ca_file: "temp/ca-cert.pem"
   connect:
     port: 8002
   # port for application metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,9 +54,9 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     ports:
-      - "8081:8080" # rest endpoint
-      - "8082:8081" # grpc endpoint
+      - "8002:8002" # connect endpoint
       - "8083:8083" # ui
+      - "9000:9000" # metrics
     command: ["server", "start"]
     restart: on-failure
     depends_on:

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48
 	github.com/go-webauthn/webauthn v0.8.6
 	github.com/golang-migrate/migrate/v4 v4.16.0
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.1
@@ -48,7 +47,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/stripe/stripe-go/v79 v79.5.0
 	github.com/ua-parser/uap-go v0.0.0-20250917011043-9c86a9b0f8f0
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.uber.org/zap v1.26.0
 	gocloud.dev v0.28.0
@@ -101,13 +99,13 @@ require (
 	github.com/go-webauthn/x v0.1.4 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-tpm v0.9.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/oklog/run v1.1.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
@@ -119,6 +117,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 // indirect
 	go.opentelemetry.io/otel v1.37.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
@@ -178,7 +177,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
-	github.com/gorilla/handlers v1.5.1
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1303,8 +1303,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
-github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
-github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -1737,7 +1735,6 @@ github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282 h1:TQMyrpijt
 github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282/go.mod h1:rW25Kyd08Wdn3UVn0YBsDTSvReu0jqpmJKzxITPSjks=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=


### PR DESCRIPTION
## Summary
- Remove `port` and `grpc` section from `config/sample.config.yaml`
- Update `callback_urls` to use ConnectRPC endpoint instead of old gRPC-gateway
- Update `docker-compose.yml` ports: replace REST (8080) and gRPC (8081) with ConnectRPC (8002) and metrics (9000)
- `go mod tidy`: remove `gorilla/handlers`, `oklog/run`; demote `golang/protobuf` and `otelgrpc` to indirect

Follow-up to #1404 which removed all gRPC/gRPC-gateway server code.

### Port mapping (before → after)

| Config key | Old port | Purpose | Status |
|---|---|---|---|
| `app.port` | 8000 (local) / 80 (prod) | gRPC-gateway REST API | **Removed** — code deleted in #1404 |
| `app.grpc.port` | 8001 (local) / 8081 (prod) | Native gRPC server | **Removed** — code deleted in #1404 |
| `app.connect.port` | 8002 / 8082 | ConnectRPC (REST + gRPC + Connect protocol) | **Active** — replaces both above |
| `ui.port` | 8100 (local) / 3000 (prod) | Embedded admin UI console | **Active** — unchanged |
| `app.metrics_port` | 9000 | Prometheus metrics + pprof | **Active** — unchanged |

## Test plan
- [ ] `go build ./...` passes
- [ ] `docker-compose up` starts with correct port mappings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)