### PR TITLE
fix(web-sdk): pnpm version mismatch

### DIFF
--- a/.github/workflows/web-sdk.yml
+++ b/.github/workflows/web-sdk.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: Setup pnpm 8
+      - name: Setup pnpm 9
         uses: pnpm/action-setup@v2
         with:
           version: 9.3.0


### PR DESCRIPTION
## Summary
Upgrade pnpm version to 9.x.x in web-sdk as it was breaking the build.


## Test Plan
<!-- Describe how you tested these changes -->
- [x] Manual testing completed
- [x] Build and type checking passes
