### PR TITLE
chore: update apsara to 0.56.5

### DIFF
--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -18,7 +18,7 @@
     "@hookform/resolvers": "^3.0.1",
     "@radix-ui/react-form": "^0.0.2",
     "@radix-ui/react-icons": "^1.3.0",
-    "@raystack/apsara": "0.56.4",
+    "@raystack/apsara": "0.56.5",
     "@raystack/frontier": "workspace:^",
     "@raystack/proton": "0.1.0-b1687af73f994fa9612a023c850aa97c35735af8",
     "@stitches/react": "^1.2.8",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.2(react@18.3.1)
       '@raystack/apsara':
-        specifier: 0.56.4
-        version: 0.56.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.56.5
+        version: 0.56.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@raystack/frontier':
         specifier: workspace:^
         version: link:../../sdk
@@ -286,8 +286,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2(react@18.3.1)
       '@raystack/apsara':
-        specifier: 0.56.4
-        version: 0.56.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.56.5
+        version: 0.56.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@raystack/eslint-config':
         specifier: workspace:^
         version: link:../tools/eslint-config
@@ -2277,8 +2277,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/apsara@0.56.4':
-    resolution: {integrity: sha512-l6VC6CdrkyMeq+AVqR+605lgz8TrFbspSkcy14ShtlAOe+zIUhbODGOHRASonjHJkRRg5wY7BOU7Xf5ihJIDwg==}
+  '@raystack/apsara@0.56.5':
+    resolution: {integrity: sha512-jpFknvaka2F3SsTpDl6de2u8PK1FlyyGvIt4BPL7GKGU6IE7Tm+1ZF0S9537z0UMSzCgyoNb4LGVu/9IX0nxhQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': ^18 || ^19
@@ -9630,7 +9630,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
-  '@raystack/apsara@0.56.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@raystack/apsara@0.56.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons': 1.3.2(react@18.3.1)

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -68,7 +68,7 @@
     "@jest/globals": "^29.7.0",
     "@radix-ui/react-form": "^0.0.2",
     "@radix-ui/react-icons": "^1.3.2",
-    "@raystack/apsara": "0.56.4",
+    "@raystack/apsara": "0.56.5",
     "@raystack/eslint-config": "workspace:^",
     "@raystack/frontier-tsconfig": "workspace:^",
     "@size-limit/preset-small-lib": "^8.2.6",


### PR DESCRIPTION
## Summary
- Update `@raystack/apsara` from `0.56.4` to `0.56.5` in `web/sdk` and `web/apps/admin`

## Test plan
- [ ] Verify admin UI renders correctly
- [ ] Verify SDK build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)