### PR TITLE
fix: validate UUID in user Enable and Disable RPCs

### DIFF
--- a/core/user/service.go
+++ b/core/user/service.go
@@ -129,10 +129,16 @@ func (s Service) UpdateByEmail(ctx context.Context, toUpdate User) (User, error)
 }
 
 func (s Service) Enable(ctx context.Context, id string) error {
+	if !utils.IsValidUUID(id) {
+		return ErrInvalidID
+	}
 	return s.repository.SetState(ctx, id, Enabled)
 }
 
 func (s Service) Disable(ctx context.Context, id string) error {
+	if !utils.IsValidUUID(id) {
+		return ErrInvalidID
+	}
 	return s.repository.SetState(ctx, id, Disabled)
 }
 

--- a/core/user/service_test.go
+++ b/core/user/service_test.go
@@ -556,6 +556,128 @@ func TestService_Update(t *testing.T) {
 	}
 }
 
+func TestService_Disable(t *testing.T) {
+	validID := uuid.New().String()
+	tests := []struct {
+		name    string
+		id      string
+		setup   func() *user.Service
+		wantErr error
+	}{
+		{
+			name: "disable user with valid uuid",
+			id:   validID,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				repo.EXPECT().SetState(mock.Anything, validID, user.Disabled).Return(nil)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+		{
+			name:    "return invalid id error for non-uuid string",
+			id:      "not-a-uuid",
+			wantErr: user.ErrInvalidID,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+		{
+			name:    "return invalid id error for empty string",
+			id:      "",
+			wantErr: user.ErrInvalidID,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+		{
+			name:    "return not exist error if user not found",
+			id:      validID,
+			wantErr: user.ErrNotExist,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				repo.EXPECT().SetState(mock.Anything, validID, user.Disabled).Return(user.ErrNotExist)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup()
+			err := s.Disable(context.Background(), tt.id)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("Disable() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Errorf("Disable() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestService_Enable(t *testing.T) {
+	validID := uuid.New().String()
+	tests := []struct {
+		name    string
+		id      string
+		setup   func() *user.Service
+		wantErr error
+	}{
+		{
+			name: "enable user with valid uuid",
+			id:   validID,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				repo.EXPECT().SetState(mock.Anything, validID, user.Enabled).Return(nil)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+		{
+			name:    "return invalid id error for non-uuid string",
+			id:      "not-a-uuid",
+			wantErr: user.ErrInvalidID,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+		{
+			name:    "return invalid id error for empty string",
+			id:      "",
+			wantErr: user.ErrInvalidID,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+		{
+			name:    "return not exist error if user not found",
+			id:      validID,
+			wantErr: user.ErrNotExist,
+			setup: func() *user.Service {
+				repo, relationService, policyService, roleService := mockService(t)
+				repo.EXPECT().SetState(mock.Anything, validID, user.Enabled).Return(user.ErrNotExist)
+				return user.NewService(repo, relationService, policyService, roleService)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup()
+			err := s.Enable(context.Background(), tt.id)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("Enable() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Errorf("Enable() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
 func TestService_Delete(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Add UUID validation in `user.Service.Enable()` and `user.Service.Disable()` before calling the repository, returning `ErrInvalidID` for invalid UUIDs
- Previously, invalid IDs were passed directly to PostgreSQL, resulting in confusing "not found" errors instead of proper "invalid argument" errors
- Consistent with existing validation in `GetByID` and `Update` methods in the same service
- Add unit tests for both methods covering valid UUID, non-UUID string, empty string, and user-not-found cases

## Test plan
- [x] Unit tests pass for `TestService_Disable` and `TestService_Enable` (8 new test cases)
- [x] Existing handler tests pass for `TestConnectHandler_DisableUser` and `TestConnectHandler_EnableUser`
- [x] Full `core/user` test suite passes
- [x] Manually verified with a running server — invalid UUID now returns `invalid_argument`:
```
2026-03-05T13:22:38.879+0530    error    DisableUser.Disable operation failed    {"operation": "DisableUser.Disable", "request_id": "", "error_type": "*errors.errorString", "error": "user id is invalid", "user_id": "abcd"}
2026-03-05T13:22:38.879+0530    warn    finished call    {"system": "connect_rpc", "start_time": "2026-03-05T13:22:38.813+0530", "method": "/raystack.frontier.v1beta1.FrontierService/DisableUser", "time_ms": 65, "code": "invalid_argument", "request_id": "", "error": "invalid_argument: invalid syntax in body"}

2026-03-05T13:23:49.271+0530    error    EnableUser operation failed    {"operation": "EnableUser", "request_id": "", "error_type": "*errors.errorString", "error": "user id is invalid", "user_id": "abcd"}
2026-03-05T13:23:49.271+0530    warn    finished call    {"system": "connect_rpc", "start_time": "2026-03-05T13:23:49.194+0530", "method": "/raystack.frontier.v1beta1.FrontierService/EnableUser", "time_ms": 76, "code": "invalid_argument", "request_id": "", "error": "invalid_argument: invalid syntax in body"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)