### PR TITLE
fix(cli): add --header flag to all CLI subcommands

### DIFF
--- a/cmd/group.go
+++ b/cmd/group.go
@@ -152,6 +152,7 @@ func editGroupCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the group body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -230,6 +231,7 @@ func viewGroupCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -293,6 +295,7 @@ func listGroupCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/group.go
+++ b/cmd/group.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -100,7 +99,7 @@ func createGroupCommand(cliConfig *Config) *cli.Command {
 }
 
 func editGroupCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -132,10 +131,14 @@ func editGroupCommand(cliConfig *Config) *cli.Command {
 			}
 
 			groupID := args[0]
-			_, err = client.UpdateGroup(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdateGroupRequest{
+			req, err := newRequest(&frontierv1beta1.UpdateGroupRequest{
 				Id:   groupID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdateGroup(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -148,12 +151,14 @@ func editGroupCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the group body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewGroupCommand(cliConfig *Config) *cli.Command {
 	var metadata bool
+	var header string
 
 	cmd := &cli.Command{
 		Use:   "view",
@@ -176,10 +181,14 @@ func viewGroupCommand(cliConfig *Config) *cli.Command {
 
 			orgID := args[0]
 			groupID := args[1]
-			res, err := client.GetGroup(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetGroupRequest{
+			req, err := newRequest(&frontierv1beta1.GetGroupRequest{
 				Id:    groupID,
 				OrgId: orgID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetGroup(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -220,11 +229,13 @@ func viewGroupCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func listGroupCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all groups",
@@ -244,9 +255,13 @@ func listGroupCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListOrganizationGroups(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListOrganizationGroupsRequest{
+			req, err := newRequest(&frontierv1beta1.ListOrganizationGroupsRequest{
 				OrgId: args[0],
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListOrganizationGroups(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -276,6 +291,8 @@ func listGroupCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/group_test.go
+++ b/cmd/group_test.go
@@ -56,7 +56,7 @@ func TestClientGroup(t *testing.T) {
 				name:        "`group` edit with host flag should throw error missing required flag",
 				want:        "",
 				subCommands: []string{"edit", "123", "-h", "test"},
-				err:         errors.New("required flag(s) \"file\" not set"),
+				err:         errors.New("required flag(s) \"file\", \"header\" not set"),
 			},
 			{
 				name:        "`group` view without host should throw error host not found",

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/raystack/salt/cli/printer"
@@ -38,6 +37,7 @@ func NamespaceCommand(cliConfig *Config) *cli.Command {
 }
 
 func viewNamespaceCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "view",
 		Short: "View a namespace",
@@ -58,9 +58,13 @@ func viewNamespaceCommand(cliConfig *Config) *cli.Command {
 			}
 
 			namespaceID := args[0]
-			res, err := client.GetNamespace(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetNamespaceRequest{
+			req, err := newRequest(&frontierv1beta1.GetNamespaceRequest{
 				Id: namespaceID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetNamespace(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -84,10 +88,13 @@ func viewNamespaceCommand(cliConfig *Config) *cli.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+
 	return cmd
 }
 
 func listNamespaceCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all namespaces",
@@ -107,7 +114,11 @@ func listNamespaceCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListNamespaces(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListNamespacesRequest{}))
+			req, err := newRequest(&frontierv1beta1.ListNamespacesRequest{}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListNamespaces(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -133,6 +144,8 @@ func listNamespaceCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -89,6 +89,7 @@ func viewNamespaceCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -146,6 +147,7 @@ func listNamespaceCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -101,7 +101,7 @@ func createOrganizationCommand(cliConfig *Config) *cli.Command {
 }
 
 func editOrganizationCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -133,10 +133,14 @@ func editOrganizationCommand(cliConfig *Config) *cli.Command {
 			}
 
 			organizationID := args[0]
-			_, err = client.UpdateOrganization(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdateOrganizationRequest{
+			req, err := newRequest(&frontierv1beta1.UpdateOrganizationRequest{
 				Id:   organizationID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdateOrganization(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -149,12 +153,14 @@ func editOrganizationCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the organization body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewOrganizationCommand(cliConfig *Config) *cli.Command {
 	var metadata bool
+	var header string
 
 	cmd := &cli.Command{
 		Use:   "view",
@@ -176,9 +182,13 @@ func viewOrganizationCommand(cliConfig *Config) *cli.Command {
 			}
 
 			organizationID := args[0]
-			res, err := client.GetOrganization(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetOrganizationRequest{
+			req, err := newRequest(&frontierv1beta1.GetOrganizationRequest{
 				Id: organizationID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetOrganization(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -218,11 +228,13 @@ func viewOrganizationCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func listOrganizationCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all organizations",
@@ -242,7 +254,11 @@ func listOrganizationCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListOrganizations(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListOrganizationsRequest{}))
+			req, err := newRequest(&frontierv1beta1.ListOrganizationsRequest{}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListOrganizations(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -271,6 +287,8 @@ func listOrganizationCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -153,6 +153,7 @@ func editOrganizationCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the organization body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -228,6 +229,7 @@ func viewOrganizationCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -288,6 +290,7 @@ func listOrganizationCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -347,6 +350,7 @@ func admlistOrganizationCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -294,6 +293,7 @@ func listOrganizationCommand(cliConfig *Config) *cli.Command {
 }
 
 func admlistOrganizationCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "admlist",
 		Short: "list admins of an organization",
@@ -314,9 +314,13 @@ func admlistOrganizationCommand(cliConfig *Config) *cli.Command {
 			}
 
 			organizationID := args[0]
-			res, err := client.ListOrganizationAdmins(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListOrganizationAdminsRequest{
+			req, err := newRequest(&frontierv1beta1.ListOrganizationAdminsRequest{
 				Id: organizationID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListOrganizationAdmins(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -341,6 +345,8 @@ func admlistOrganizationCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/organization_test.go
+++ b/cmd/organization_test.go
@@ -53,7 +53,7 @@ func TestClientOrganization(t *testing.T) {
 				name:        "`organization` edit with host flag should throw error missing required flag",
 				want:        "",
 				subCommands: []string{"edit", "123", "-h", "test"},
-				err:         errors.New("required flag(s) \"file\" not set"),
+				err:         errors.New("required flag(s) \"file\", \"header\" not set"),
 			},
 			{
 				name:        "`organization` view without host should throw error host not found",

--- a/cmd/permission.go
+++ b/cmd/permission.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -100,7 +99,7 @@ func createPermissionCommand(cliConfig *Config) *cli.Command {
 }
 
 func editPermissionCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -132,10 +131,14 @@ func editPermissionCommand(cliConfig *Config) *cli.Command {
 			}
 
 			permissionID := args[0]
-			_, err = client.UpdatePermission(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdatePermissionRequest{
+			req, err := newRequest(&frontierv1beta1.UpdatePermissionRequest{
 				Id:   permissionID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdatePermission(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -148,11 +151,13 @@ func editPermissionCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the permission body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewPermissionCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "view",
 		Short: "View a permission",
@@ -173,9 +178,13 @@ func viewPermissionCommand(cliConfig *Config) *cli.Command {
 			}
 
 			permissionID := args[0]
-			res, err := client.GetPermission(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetPermissionRequest{
+			req, err := newRequest(&frontierv1beta1.GetPermissionRequest{
 				Id: permissionID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetPermission(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -198,10 +207,13 @@ func viewPermissionCommand(cliConfig *Config) *cli.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+
 	return cmd
 }
 
 func listPermissionCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all permissions",
@@ -221,7 +233,11 @@ func listPermissionCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListPermissions(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListPermissionsRequest{}))
+			req, err := newRequest(&frontierv1beta1.ListPermissionsRequest{}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListPermissions(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -251,6 +267,8 @@ func listPermissionCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/permission.go
+++ b/cmd/permission.go
@@ -152,6 +152,7 @@ func editPermissionCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the permission body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -208,6 +209,7 @@ func viewPermissionCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -269,6 +271,7 @@ func listPermissionCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/permission_test.go
+++ b/cmd/permission_test.go
@@ -53,7 +53,7 @@ func TestClientAction(t *testing.T) {
 				name:        "`permission` edit with host flag should throw error missing required flag",
 				want:        "",
 				subCommands: []string{"edit", "123", "-h", "test"},
-				err:         errors.New("required flag(s) \"file\" not set"),
+				err:         errors.New("required flag(s) \"file\", \"header\" not set"),
 			},
 			{
 				name:        "`permission` view without host should throw error host not found",

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -98,7 +97,7 @@ func createPolicyCommand(cliConfig *Config) *cli.Command {
 }
 
 func editPolicyCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -130,10 +129,14 @@ func editPolicyCommand(cliConfig *Config) *cli.Command {
 			}
 
 			policyID := args[0]
-			_, err = client.UpdatePolicy(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdatePolicyRequest{
+			req, err := newRequest(&frontierv1beta1.UpdatePolicyRequest{
 				Id:   policyID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdatePolicy(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -146,11 +149,13 @@ func editPolicyCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the policy body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewPolicyCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "view",
 		Short: "View a policy",
@@ -171,9 +176,13 @@ func viewPolicyCommand(cliConfig *Config) *cli.Command {
 			}
 
 			policyID := args[0]
-			res, err := client.GetPolicy(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetPolicyRequest{
+			req, err := newRequest(&frontierv1beta1.GetPolicyRequest{
 				Id: policyID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetPolicy(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -196,6 +205,8 @@ func viewPolicyCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -150,6 +150,7 @@ func editPolicyCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the policy body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -207,6 +208,7 @@ func viewPolicyCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -41,7 +41,7 @@ func TestClientPolicy(t *testing.T) {
 				name:        "`policy` edit with host flag should throw error missing required flag",
 				want:        "",
 				subCommands: []string{"edit", "123", "-h", "test"},
-				err:         errors.New("required flag(s) \"file\" not set"),
+				err:         errors.New("required flag(s) \"file\", \"header\" not set"),
 			},
 			{
 				name:        "`policy` view without host should throw error host not found",

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -152,6 +152,7 @@ func editProjectCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the project body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -228,6 +229,7 @@ func viewProjectCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -291,6 +293,7 @@ func listProjectCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -100,7 +99,7 @@ func createProjectCommand(cliConfig *Config) *cli.Command {
 }
 
 func editProjectCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -132,10 +131,14 @@ func editProjectCommand(cliConfig *Config) *cli.Command {
 			}
 
 			projectID := args[0]
-			_, err = client.UpdateProject(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdateProjectRequest{
+			req, err := newRequest(&frontierv1beta1.UpdateProjectRequest{
 				Id:   projectID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdateProject(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -148,12 +151,14 @@ func editProjectCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the project body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewProjectCommand(cliConfig *Config) *cli.Command {
 	var metadata bool
+	var header string
 
 	cmd := &cli.Command{
 		Use:   "view",
@@ -175,9 +180,13 @@ func viewProjectCommand(cliConfig *Config) *cli.Command {
 			}
 
 			projectID := args[0]
-			res, err := client.GetProject(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetProjectRequest{
+			req, err := newRequest(&frontierv1beta1.GetProjectRequest{
 				Id: projectID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetProject(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -218,11 +227,13 @@ func viewProjectCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func listProjectCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all projects",
@@ -242,9 +253,13 @@ func listProjectCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListOrganizationProjects(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListOrganizationProjectsRequest{
+			req, err := newRequest(&frontierv1beta1.ListOrganizationProjectsRequest{
 				Id: args[0],
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListOrganizationProjects(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -274,6 +289,8 @@ func listProjectCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -56,7 +56,7 @@ func TestClientProject(t *testing.T) {
 				name:        "`project` edit with host flag should throw error missing required flag",
 				want:        "",
 				subCommands: []string{"edit", "123", "-h", "test"},
-				err:         errors.New("required flag(s) \"file\" not set"),
+				err:         errors.New("required flag(s) \"file\", \"header\" not set"),
 			},
 			{
 				name:        "`project` view without host should throw error host not found",

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -101,7 +100,7 @@ func createRoleCommand(cliConfig *Config) *cli.Command {
 }
 
 func editRoleCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -133,10 +132,14 @@ func editRoleCommand(cliConfig *Config) *cli.Command {
 			}
 
 			roleID := args[0]
-			_, err = client.UpdateOrganizationRole(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdateOrganizationRoleRequest{
+			req, err := newRequest(&frontierv1beta1.UpdateOrganizationRoleRequest{
 				Id:   roleID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdateOrganizationRole(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -149,12 +152,14 @@ func editRoleCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the role body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewRoleCommand(cliConfig *Config) *cli.Command {
 	var metadata bool
+	var header string
 
 	cmd := &cli.Command{
 		Use:   "view",
@@ -176,9 +181,13 @@ func viewRoleCommand(cliConfig *Config) *cli.Command {
 			}
 
 			roleID := args[0]
-			res, err := client.GetOrganizationRole(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetOrganizationRoleRequest{
+			req, err := newRequest(&frontierv1beta1.GetOrganizationRoleRequest{
 				Id: roleID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetOrganizationRole(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -220,11 +229,13 @@ func viewRoleCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func listRoleCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all roles",
@@ -244,7 +255,11 @@ func listRoleCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListRoles(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListRolesRequest{}))
+			req, err := newRequest(&frontierv1beta1.ListRolesRequest{}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListRoles(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -275,6 +290,8 @@ func listRoleCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -153,6 +153,7 @@ func editRoleCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the role body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -230,6 +231,7 @@ func viewRoleCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -292,6 +294,7 @@ func listRoleCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }

--- a/cmd/role_test.go
+++ b/cmd/role_test.go
@@ -53,7 +53,7 @@ func TestClientRole(t *testing.T) {
 				name:        "`role` edit with host flag should throw error missing required flag",
 				want:        "",
 				subCommands: []string{"edit", "123", "-h", "test"},
-				err:         errors.New("required flag(s) \"file\" not set"),
+				err:         errors.New("required flag(s) \"file\", \"header\" not set"),
 			},
 			{
 				name:        "`role` view without host should throw error host not found",

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -89,6 +89,7 @@ func SeedCommand(cliConfig *Config) *cli.Command {
 
 	bindFlagsFromClientConfig(cmd)
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>")
+	cmd.MarkFlagRequired("header")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file path")
 	return cmd
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"connectrpc.com/connect"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/pkg/file"
 	"github.com/raystack/frontier/pkg/str"
@@ -105,7 +104,7 @@ func createUserCommand(cliConfig *Config) *cli.Command {
 }
 
 func editUserCommand(cliConfig *Config) *cli.Command {
-	var filePath string
+	var filePath, header string
 
 	cmd := &cli.Command{
 		Use:   "edit",
@@ -138,10 +137,14 @@ func editUserCommand(cliConfig *Config) *cli.Command {
 			}
 
 			userID := args[0]
-			_, err = client.UpdateUser(cmd.Context(), connect.NewRequest(&frontierv1beta1.UpdateUserRequest{
+			req, err := newRequest(&frontierv1beta1.UpdateUserRequest{
 				Id:   userID,
 				Body: &reqBody,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			_, err = client.UpdateUser(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -154,12 +157,14 @@ func editUserCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the user body file")
 	cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func viewUserCommand(cliConfig *Config) *cli.Command {
 	var metadata bool
+	var header string
 
 	cmd := &cli.Command{
 		Use:   "view",
@@ -182,9 +187,13 @@ func viewUserCommand(cliConfig *Config) *cli.Command {
 			}
 
 			userID := args[0]
-			res, err := client.GetUser(cmd.Context(), connect.NewRequest(&frontierv1beta1.GetUserRequest{
+			req, err := newRequest(&frontierv1beta1.GetUserRequest{
 				Id: userID,
-			}))
+			}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.GetUser(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -221,11 +230,13 @@ func viewUserCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }
 
 func listUserCommand(cliConfig *Config) *cli.Command {
+	var header string
 	cmd := &cli.Command{
 		Use:   "list",
 		Short: "List all users",
@@ -245,7 +256,11 @@ func listUserCommand(cliConfig *Config) *cli.Command {
 				return err
 			}
 
-			res, err := client.ListUsers(cmd.Context(), connect.NewRequest(&frontierv1beta1.ListUsersRequest{}))
+			req, err := newRequest(&frontierv1beta1.ListUsersRequest{}, header)
+			if err != nil {
+				return err
+			}
+			res, err := client.ListUsers(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -271,6 +286,8 @@ func listUserCommand(cliConfig *Config) *cli.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
 
 	return cmd
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -158,6 +158,7 @@ func editUserCommand(cliConfig *Config) *cli.Command {
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the user body file")
 	cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -231,6 +232,7 @@ func viewUserCommand(cliConfig *Config) *cli.Command {
 
 	cmd.Flags().BoolVarP(&metadata, "metadata", "m", false, "Set this flag to see metadata")
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }
@@ -288,6 +290,7 @@ func listUserCommand(cliConfig *Config) *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&header, "header", "H", "", "Header <key>:<value>")
+	cmd.MarkFlagRequired("header")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
<!-- List the key changes made in this PR -->
- Added --header / -H flag in all missing CLI subcommands
- All affected subcommands now use the **newRequest** helper

## Test Plan
<!-- Describe how you tested these changes -->
- [ ] Manual testing completed
- [ ] Build and type checking passes
