### PR TITLE
fix: prevent listPolicies call for project viewers without permission

### DIFF
--- a/web/sdk/react/views/projects/details/project-member-columns.tsx
+++ b/web/sdk/react/views/projects/details/project-member-columns.tsx
@@ -164,7 +164,7 @@ const MembersActions = ({
             userId: member.isTeam ? undefined : (member.id as string),
             groupId: member.isTeam ? (member.id as string) : undefined
         }),
-        { enabled: !!projectId && !!member?.id }
+        { enabled: !!projectId && !!member?.id && !!canUpdateProject }
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix permission error when project viewers access the project members page
- The `listPolicies` API requires `PolicyManagePermission` which project viewers don't have
- Added `canUpdateProject` check to conditionally enable the query only for users with update permissions
- Project viewers will now see fallback text ("Project Viewer" or "Inherited role") without triggering permission errors

## Changes
- Updated `useQuery` enabled condition in `project-member-columns.tsx` to include `canUpdateProject` check
- This prevents unnecessary API calls and eliminates permission errors for users without policy management access

## Test plan
- [ ] Verify project viewers can access the project members page without errors
- [ ] Confirm project managers/owners can still view and update member roles
- [ ] Check that fallback role text displays correctly for project viewers
- [ ] Verify no console errors for project viewers on members page