### PR TITLE
chore: include `principal_type` in error logging

### DIFF
--- a/internal/api/v1beta1connect/preferences.go
+++ b/internal/api/v1beta1connect/preferences.go
@@ -199,6 +199,7 @@ func (h *ConnectHandler) CreateCurrentUserPreferences(ctx context.Context, req *
 		if err != nil {
 			errorLogger.LogServiceError(ctx, req, "CreateCurrentUserPreferences", err,
 				zap.String("principal_id", principal.ID),
+				zap.String("principal_type", principal.Type),
 				zap.String("preference_name", prefBody.GetName()),
 				zap.String("preference_value", prefBody.GetValue()))
 			return nil, handlePreferenceError(err)
@@ -236,7 +237,8 @@ func (h *ConnectHandler) ListCurrentUserPreferences(ctx context.Context, req *co
 	})
 	if err != nil {
 		errorLogger.LogServiceError(ctx, req, "ListCurrentUserPreferences", err,
-			zap.String("principal_id", principal.ID))
+			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type))
 		return nil, handlePreferenceError(err)
 	}
 

--- a/internal/api/v1beta1connect/session.go
+++ b/internal/api/v1beta1connect/session.go
@@ -35,7 +35,8 @@ func (h *ConnectHandler) ListSessions(ctx context.Context, request *connect.Requ
 	sessions, err := h.sessionService.List(ctx, principal.ID)
 	if err != nil {
 		errorLogger.LogUnexpectedError(ctx, request, "ListSessions.List", err,
-			zap.String("principal_id", principal.ID))
+			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type))
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
@@ -115,7 +116,8 @@ func (h *ConnectHandler) RevokeSession(ctx context.Context, request *connect.Req
 	if err := h.sessionService.Delete(ctx, sessionID); err != nil {
 		errorLogger.LogUnexpectedError(ctx, request, "RevokeSession", err,
 			zap.String("session_id", sessionID.String()),
-			zap.String("principal_id", principal.ID))
+			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type))
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 

--- a/internal/api/v1beta1connect/user.go
+++ b/internal/api/v1beta1connect/user.go
@@ -353,7 +353,8 @@ func (h *ConnectHandler) UpdateCurrentUser(ctx context.Context, request *connect
 	})
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "UpdateCurrentUser.Update", err,
-			zap.String("principal_id", principal.ID))
+			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type))
 
 		switch {
 		case errors.Is(err, user.ErrNotExist):
@@ -362,7 +363,8 @@ func (h *ConnectHandler) UpdateCurrentUser(ctx context.Context, request *connect
 			return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
 		default:
 			errorLogger.LogUnexpectedError(ctx, request, "UpdateCurrentUser", err,
-				zap.String("principal_id", principal.ID))
+				zap.String("principal_id", principal.ID),
+				zap.String("principal_type", principal.Type))
 			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
@@ -507,6 +509,7 @@ func (h *ConnectHandler) ListCurrentUserGroups(ctx context.Context, request *con
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "ListCurrentUserGroups.ListByUser", err,
 			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type),
 			zap.String("org_id", request.Msg.GetOrgId()))
 
 		switch {
@@ -786,7 +789,8 @@ func (h *ConnectHandler) ListOrganizationsByCurrentUser(ctx context.Context, req
 	orgList, err := h.orgService.ListByUser(ctx, principal, orgFilter)
 	if err != nil {
 		errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByCurrentUser", err,
-			zap.String("principal_id", principal.ID))
+			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type))
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
@@ -807,6 +811,7 @@ func (h *ConnectHandler) ListOrganizationsByCurrentUser(ctx context.Context, req
 		if err != nil {
 			errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByCurrentUser", err,
 				zap.String("principal_id", principal.ID),
+				zap.String("principal_type", principal.Type),
 				zap.String("user_email", principal.User.Email))
 			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
@@ -816,6 +821,7 @@ func (h *ConnectHandler) ListOrganizationsByCurrentUser(ctx context.Context, req
 			if err != nil {
 				errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByCurrentUser", err,
 					zap.String("principal_id", principal.ID),
+					zap.String("principal_type", principal.Type),
 					zap.String("joinable_org_id", joinableOrg))
 				return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 			}
@@ -890,6 +896,7 @@ func (h *ConnectHandler) ListProjectsByCurrentUser(ctx context.Context, request 
 	if err != nil {
 		errorLogger.LogUnexpectedError(ctx, request, "ListProjectsByCurrentUser", err,
 			zap.String("principal_id", principal.ID),
+			zap.String("principal_type", principal.Type),
 			zap.String("org_id", request.Msg.GetOrgId()))
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
@@ -913,6 +920,7 @@ func (h *ConnectHandler) ListProjectsByCurrentUser(ctx context.Context, request 
 		if err != nil {
 			errorLogger.LogUnexpectedError(ctx, request, "ListProjectsByCurrentUser", err,
 				zap.String("principal_id", principal.ID),
+				zap.String("principal_type", principal.Type),
 				zap.String("org_id", request.Msg.GetOrgId()))
 			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}


### PR DESCRIPTION
Adds `principal_type` in error logging alongside `principal_id`