### PR TITLE
fix(sdk): upgrade react-image-crop to v11 and fix TS errors

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^7.57.0
         version: 7.71.2(react@19.2.4)
       react-image-crop:
-        specifier: ^10.1.8
-        version: 10.1.8(react@19.2.4)
+        specifier: ^11.0.10
+        version: 11.0.10(react@19.2.4)
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -6195,8 +6195,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-image-crop@10.1.8:
-    resolution: {integrity: sha512-4rb8XtXNx7ZaOZarKKnckgz4xLMvds/YrU6mpJfGhGAsy2Mg4mIw1x+DCCGngVGq2soTBVVOxx2s/C6mTX9+pA==}
+  react-image-crop@11.0.10:
+    resolution: {integrity: sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==}
     peerDependencies:
       react: '>=16.13.1'
 
@@ -14165,7 +14165,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  react-image-crop@10.1.8(react@19.2.4):
+  react-image-crop@11.0.10(react@19.2.4):
     dependencies:
       react: 19.2.4
 

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -111,7 +111,7 @@
     "lodash": "^4.17.21",
     "query-string": "^8.2.0",
     "react-hook-form": "^7.57.0",
-    "react-image-crop": "^10.1.8",
+    "react-image-crop": "^11.0.10",
     "slugify": "^1.6.6",
     "uuid": "^10.0.0",
     "validator": "^13.15.15",

--- a/web/sdk/react/components/avatar-upload/index.tsx
+++ b/web/sdk/react/components/avatar-upload/index.tsx
@@ -1,5 +1,7 @@
 import ReactCrop, {
   type Crop,
+  type PixelCrop,
+  type PercentCrop,
   centerCrop,
   makeAspectCrop
 } from 'react-image-crop';
@@ -116,7 +118,7 @@ function CropModal({ onClose, imgSrc, onSave }: CropModalProps) {
             {imgSrc ? (
               <ReactCrop
                 crop={crop}
-                onChange={(_, percentCrop) => setCrop(percentCrop)}
+                onChange={(_: PixelCrop, percentCrop: PercentCrop) => setCrop(percentCrop)}
                 aspect={1}
                 className={styles.reactCrop}
                 data-test-id="frontier-sdk-image-crop-preview"

--- a/web/sdk/react/components/image-upload/image-upload.tsx
+++ b/web/sdk/react/components/image-upload/image-upload.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react';
 import ReactCrop, {
   type Crop,
+  type PixelCrop,
+  type PercentCrop,
   centerCrop,
   makeAspectCrop
 } from 'react-image-crop';
@@ -107,7 +109,7 @@ function CropDialog({ open, onOpenChange, imgSrc, onSave }: CropDialogProps) {
             {imgSrc ? (
               <ReactCrop
                 crop={crop}
-                onChange={(_, percentCrop) => setCrop(percentCrop)}
+                onChange={(_: PixelCrop, percentCrop: PercentCrop) => setCrop(percentCrop)}
                 aspect={1}
                 className={styles.reactCrop}
                 data-test-id="frontier-sdk-image-crop-preview"


### PR DESCRIPTION
## Summary
- Upgrade `react-image-crop` from v10 (class component) to v11 (function component)
- v10 uses `PureComponent` which is incompatible with React 19's JSX type system, causing TS build errors
- v11 is a function component and works correctly with React 19
- Add explicit `PixelCrop`/`PercentCrop` types to `onChange` callbacks in `avatar-upload` and `image-upload`

## Test plan
- [x] Build passes (no new errors)
- [x] No API changes in react-image-crop v11 — same props and usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)