### PR TITLE
refactor: remove REST endpoint from SDK and admin config

### DIFF
--- a/web/apps/admin/src/configs/frontier.tsx
+++ b/web/apps/admin/src/configs/frontier.tsx
@@ -1,13 +1,10 @@
 const getFrontierConfig = () => {
-  const frontierEndpoint =
-    process.env.NEXT_PUBLIC_FRONTIER_URL || "/frontier-api";
-  const frontierConnectEndpoint =
+  const connectEndpoint =
     process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL || "/frontier-connect";
 
   const currentHost = window?.location?.origin || "http://localhost:3000";
   return {
-    frontierEndpoint: frontierConnectEndpoint,
-    endpoint: frontierEndpoint,
+    connectEndpoint,
     redirectLogin: `${currentHost}/login`,
     redirectSignup: `${currentHost}/signup`,
     redirectMagicLinkVerify: `${currentHost}/magiclink-verify`,

--- a/web/sdk/react/contexts/FrontierContext.tsx
+++ b/web/sdk/react/contexts/FrontierContext.tsx
@@ -106,7 +106,6 @@ interface FrontierContextProviderProps {
 }
 
 const defaultConfig: FrontierClientOptions = {
-  endpoint: 'http://localhost:8080',
   redirectLogin: 'http://localhost:3000',
   redirectSignup: 'http://localhost:3000/signup',
   redirectMagicLinkVerify: 'http://localhost:3000/magiclink-verify',

--- a/web/sdk/shared/types.ts
+++ b/web/sdk/shared/types.ts
@@ -36,7 +36,6 @@ export interface FrontierClientCustomizationOptions {
 }
 
 export interface FrontierClientOptions {
-  endpoint: string;
   locale?: string;
   connectEndpoint?: string;
   redirectSignup?: string;

--- a/web/sdk/src/types.ts
+++ b/web/sdk/src/types.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Feature, Plan } from '@raystack/proton/frontier';
 
 export interface Strategy {
@@ -47,22 +46,6 @@ export interface Role {
   id: string;
   name: string;
   types: string[];
-}
-
-export interface FrontierClientOptions {
-  endpoint?: string;
-  redirectSignup?: string;
-  redirectLogin?: string;
-}
-
-export interface InitialState {
-  sessionId?: string | null;
-}
-
-export interface FrontierProviderProps {
-  config: FrontierClientOptions;
-  children: React.ReactNode;
-  initialState?: InitialState;
 }
 
 export const IntervalLabelMap = {

--- a/web/turbo.json
+++ b/web/turbo.json
@@ -3,7 +3,6 @@
   "globalEnv": [
     "FRONTIER_API_URL",
     "FRONTIER_CONNECTRPC_URL",
-    "NEXT_PUBLIC_FRONTIER_URL",
     "NEXT_PUBLIC_FRONTIER_CONNECT_URL"
   ],
   "tasks": {


### PR DESCRIPTION
## Summary
- Remove `endpoint` from `FrontierClientOptions` in SDK (both `shared/types.ts` and legacy `src/types.ts`)
- Remove `NEXT_PUBLIC_FRONTIER_URL` from admin config and `turbo.json`
- Admin config now uses only `connectEndpoint` (`NEXT_PUBLIC_FRONTIER_CONNECT_URL`)
- Remove legacy duplicate `FrontierClientOptions`, `FrontierProviderProps`, `InitialState` from `sdk/src/types.ts`

## Test plan
- [x] Build passes (no new errors)
- [x] Lint passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)