### PR TITLE
fix (projects): table height breaking

### DIFF
--- a/web/sdk/admin/views/organizations/details/projects/members/members.module.css
+++ b/web/sdk/admin/views/organizations/details/projects/members/members.module.css
@@ -22,7 +22,6 @@
 
 .table {
     width: 100%;
-    height: 100%;
     table-layout: fixed;
 }
 
@@ -70,6 +69,7 @@
 .add-member-dropdown-member {
     width: 100%;
 }
+
 .add-member-dropdown-member-name {
     max-width: 100%;
     overflow: hidden;


### PR DESCRIPTION
## Summary
fix (projects): table height breaking

<img width="1697" height="831" alt="Screenshot 2026-04-10 at 3 38 46 PM" src="https://github.com/user-attachments/assets/206e90b3-bf34-42dd-9d5a-dcde28671bbf" />



## Changes
Remove height: 100% to prevent table stretching full height.


## Technical Details
<!-- Optional: Add implementation-specific details, architectural decisions, or technical context -->


## Test Plan
<!-- Describe how you tested these changes -->
- [ ] Manual testing completed
- [ ] Build and type checking passes
