### PR TITLE
test: add SearchCurrentUserPATs handler and PAT List service tests

### DIFF
--- a/core/userpat/service_test.go
+++ b/core/userpat/service_test.go
@@ -2647,3 +2647,94 @@ func TestService_ValidateProjectAccess(t *testing.T) {
 		}
 	})
 }
+
+func TestService_List(t *testing.T) {
+	t.Run("should return ErrDisabled when PAT feature is disabled", func(t *testing.T) {
+		repo := mocks.NewRepository(t)
+		auditRepo := mocks.NewAuditRecordRepository(t)
+		svc := userpat.NewService(log.NewNoop(), repo, userpat.Config{Enabled: false}, nil, nil, nil, nil, auditRepo)
+
+		_, err := svc.List(context.Background(), "user-1", "org-1", nil)
+		if !errors.Is(err, paterrors.ErrDisabled) {
+			t.Fatalf("expected ErrDisabled, got %v", err)
+		}
+	})
+
+	t.Run("should return error when repo List fails", func(t *testing.T) {
+		repo := mocks.NewRepository(t)
+		repo.EXPECT().List(mock.Anything, "user-1", "org-1", mock.Anything).
+			Return(models.PATList{}, errors.New("db connection failed"))
+		auditRepo := mocks.NewAuditRecordRepository(t)
+		svc := userpat.NewService(log.NewNoop(), repo, defaultConfig, nil, nil, nil, nil, auditRepo)
+
+		_, err := svc.List(context.Background(), "user-1", "org-1", nil)
+		if err == nil || !strings.Contains(err.Error(), "db connection failed") {
+			t.Fatalf("expected db error, got %v", err)
+		}
+	})
+
+	t.Run("should return error when enrichWithScope fails", func(t *testing.T) {
+		repo := mocks.NewRepository(t)
+		repo.EXPECT().List(mock.Anything, "user-1", "org-1", mock.Anything).
+			Return(models.PATList{
+				PATs: []models.PAT{{ID: "pat-1", UserID: "user-1", OrgID: "org-1"}},
+			}, nil)
+		policySvc := mocks.NewPolicyService(t)
+		policySvc.EXPECT().List(mock.Anything, policy.Filter{
+			PrincipalID:   "pat-1",
+			PrincipalType: schema.PATPrincipal,
+		}).Return(nil, errors.New("policy service down"))
+		auditRepo := mocks.NewAuditRecordRepository(t)
+		svc := userpat.NewService(log.NewNoop(), repo, defaultConfig, nil, nil, policySvc, nil, auditRepo)
+
+		_, err := svc.List(context.Background(), "user-1", "org-1", nil)
+		if err == nil || !strings.Contains(err.Error(), "enriching PAT scope") {
+			t.Fatalf("expected enriching error, got %v", err)
+		}
+	})
+
+	t.Run("should return enriched PAT list", func(t *testing.T) {
+		repo := mocks.NewRepository(t)
+		repo.EXPECT().List(mock.Anything, "user-1", "org-1", mock.Anything).
+			Return(models.PATList{
+				PATs: []models.PAT{
+					{ID: "pat-1", UserID: "user-1", OrgID: "org-1", Title: "token-1"},
+					{ID: "pat-2", UserID: "user-1", OrgID: "org-1", Title: "token-2"},
+				},
+			}, nil)
+		policySvc := mocks.NewPolicyService(t)
+		// enrichWithScope for pat-1
+		policySvc.EXPECT().List(mock.Anything, policy.Filter{
+			PrincipalID:   "pat-1",
+			PrincipalType: schema.PATPrincipal,
+		}).Return([]policy.Policy{
+			{ID: "pol-1", RoleID: "role-1", ResourceID: "org-1", ResourceType: schema.OrganizationNamespace, GrantRelation: "granted"},
+		}, nil)
+		// enrichWithScope for pat-2
+		policySvc.EXPECT().List(mock.Anything, policy.Filter{
+			PrincipalID:   "pat-2",
+			PrincipalType: schema.PATPrincipal,
+		}).Return([]policy.Policy{}, nil)
+		auditRepo := mocks.NewAuditRecordRepository(t)
+		svc := userpat.NewService(log.NewNoop(), repo, defaultConfig, nil, nil, policySvc, nil, auditRepo)
+
+		result, err := svc.List(context.Background(), "user-1", "org-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.PATs) != 2 {
+			t.Fatalf("expected 2 PATs, got %d", len(result.PATs))
+		}
+		if result.PATs[0].Title != "token-1" {
+			t.Fatalf("expected token-1, got %s", result.PATs[0].Title)
+		}
+		// pat-1 should have 1 scope from the policy
+		if len(result.PATs[0].Scopes) != 1 {
+			t.Fatalf("expected 1 scope for pat-1, got %d", len(result.PATs[0].Scopes))
+		}
+		// pat-2 should have 0 scopes
+		if len(result.PATs[1].Scopes) != 0 {
+			t.Fatalf("expected 0 scopes for pat-2, got %d", len(result.PATs[1].Scopes))
+		}
+	})
+}

--- a/internal/api/v1beta1connect/user_pat_test.go
+++ b/internal/api/v1beta1connect/user_pat_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 	"github.com/raystack/frontier/pkg/errors"
 	"github.com/raystack/frontier/pkg/metadata"
+	"github.com/raystack/frontier/pkg/utils"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1300,6 +1301,162 @@ func TestHandler_RegenerateCurrentUserPAT(t *testing.T) {
 				assert.NotNil(t, resp)
 				assert.Equal(t, testPATID, resp.Msg.GetPat().GetId())
 				assert.Equal(t, "fpt_newtoken123", resp.Msg.GetPat().GetToken())
+			}
+
+			mockPATSrv.AssertExpectations(t)
+			mockAuthnSrv.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHandler_SearchCurrentUserPATs(t *testing.T) {
+	testUserID := "8e256f86-31a3-11ec-8d3d-0242ac130003"
+	testOrgID := "9f256f86-31a3-11ec-8d3d-0242ac130003"
+	testTime := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	testCreatedAt := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		setup   func(ps *mocks.UserPATService, as *mocks.AuthnService)
+		request *connect.Request[frontierv1beta1.SearchCurrentUserPATsRequest]
+		want    *frontierv1beta1.SearchCurrentUserPATsResponse
+		wantErr error
+	}{
+		{
+			name: "should return unauthenticated error when GetLoggedInPrincipal fails",
+			setup: func(ps *mocks.UserPATService, as *mocks.AuthnService) {
+				as.EXPECT().GetPrincipal(mock.Anything).Return(authenticate.Principal{}, errors.ErrUnauthenticated)
+			},
+			request: connect.NewRequest(&frontierv1beta1.SearchCurrentUserPATsRequest{
+				OrgId: testOrgID,
+			}),
+			wantErr: connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated),
+		},
+		{
+			name: "should resolve PAT principal to user and list PATs",
+			setup: func(ps *mocks.UserPATService, as *mocks.AuthnService) {
+				as.EXPECT().GetPrincipal(mock.Anything).Return(authenticate.Principal{
+					ID:   "pat-1",
+					Type: schema.PATPrincipal,
+					User: &user.User{ID: testUserID},
+					PAT:  &models.PAT{ID: "pat-1", UserID: testUserID},
+				}, nil)
+				ps.EXPECT().List(mock.Anything, testUserID, testOrgID, mock.Anything).
+					Return(models.PATList{
+						PATs: []models.PAT{
+							{
+								ID: "pat-1", Title: "my-token", UserID: testUserID, OrgID: testOrgID,
+								ExpiresAt: testTime, CreatedAt: testCreatedAt, UpdatedAt: testCreatedAt,
+							},
+						},
+						Page: utils.Page{Offset: 0, Limit: 50, TotalCount: 1},
+					}, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.SearchCurrentUserPATsRequest{
+				OrgId: testOrgID,
+			}),
+			want: &frontierv1beta1.SearchCurrentUserPATsResponse{
+				Pats: []*frontierv1beta1.PAT{
+					{
+						Id: "pat-1", Title: "my-token", UserId: testUserID, OrgId: testOrgID,
+						Scopes:    []*frontierv1beta1.PATScope{},
+						ExpiresAt: timestamppb.New(testTime),
+						CreatedAt: timestamppb.New(testCreatedAt),
+						UpdatedAt: timestamppb.New(testCreatedAt),
+					},
+				},
+				Pagination: &frontierv1beta1.RQLQueryPaginationResponse{
+					Offset: 0, Limit: 50, TotalCount: 1,
+				},
+			},
+		},
+		{
+			name: "should return empty list when no PATs exist",
+			setup: func(ps *mocks.UserPATService, as *mocks.AuthnService) {
+				as.EXPECT().GetPrincipal(mock.Anything).Return(authenticate.Principal{
+					ID:   testUserID,
+					Type: schema.UserPrincipal,
+					User: &user.User{ID: testUserID},
+				}, nil)
+				ps.EXPECT().List(mock.Anything, testUserID, testOrgID, mock.Anything).
+					Return(models.PATList{
+						PATs: []models.PAT{},
+						Page: utils.Page{Offset: 0, Limit: 50, TotalCount: 0},
+					}, nil)
+			},
+			request: connect.NewRequest(&frontierv1beta1.SearchCurrentUserPATsRequest{
+				OrgId: testOrgID,
+			}),
+			want: &frontierv1beta1.SearchCurrentUserPATsResponse{
+				Pats: []*frontierv1beta1.PAT{},
+				Pagination: &frontierv1beta1.RQLQueryPaginationResponse{
+					Offset: 0, Limit: 50, TotalCount: 0,
+				},
+			},
+		},
+		{
+			name: "should return failed precondition when PAT is disabled",
+			setup: func(ps *mocks.UserPATService, as *mocks.AuthnService) {
+				as.EXPECT().GetPrincipal(mock.Anything).Return(authenticate.Principal{
+					ID:   testUserID,
+					Type: schema.UserPrincipal,
+					User: &user.User{ID: testUserID},
+				}, nil)
+				ps.EXPECT().List(mock.Anything, testUserID, testOrgID, mock.Anything).
+					Return(models.PATList{}, paterrors.ErrDisabled)
+			},
+			request: connect.NewRequest(&frontierv1beta1.SearchCurrentUserPATsRequest{
+				OrgId: testOrgID,
+			}),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, paterrors.ErrDisabled),
+		},
+		{
+			name: "should return internal error for unknown failure",
+			setup: func(ps *mocks.UserPATService, as *mocks.AuthnService) {
+				as.EXPECT().GetPrincipal(mock.Anything).Return(authenticate.Principal{
+					ID:   testUserID,
+					Type: schema.UserPrincipal,
+					User: &user.User{ID: testUserID},
+				}, nil)
+				ps.EXPECT().List(mock.Anything, testUserID, testOrgID, mock.Anything).
+					Return(models.PATList{}, errors.New("db error"))
+			},
+			request: connect.NewRequest(&frontierv1beta1.SearchCurrentUserPATsRequest{
+				OrgId: testOrgID,
+			}),
+			wantErr: connect.NewError(connect.CodeInternal, ErrInternalServerError),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPATSrv := new(mocks.UserPATService)
+			mockAuthnSrv := new(mocks.AuthnService)
+
+			if tt.setup != nil {
+				tt.setup(mockPATSrv, mockAuthnSrv)
+			}
+
+			handler := &ConnectHandler{
+				userPATService: mockPATSrv,
+				authnService:   mockAuthnSrv,
+			}
+
+			resp, err := handler.SearchCurrentUserPATs(context.Background(), tt.request)
+
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErr.Error(), err.Error())
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, len(tt.want.Pats), len(resp.Msg.Pats))
+				for i, pat := range resp.Msg.Pats {
+					assert.Equal(t, tt.want.Pats[i].Id, pat.Id)
+					assert.Equal(t, tt.want.Pats[i].Title, pat.Title)
+				}
+				assert.Equal(t, tt.want.Pagination.TotalCount, resp.Msg.Pagination.TotalCount)
 			}
 
 			mockPATSrv.AssertExpectations(t)

--- a/internal/api/v1beta1connect/user_pat_test.go
+++ b/internal/api/v1beta1connect/user_pat_test.go
@@ -1451,12 +1451,12 @@ func TestHandler_SearchCurrentUserPATs(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, resp)
-				assert.Equal(t, len(tt.want.Pats), len(resp.Msg.Pats))
-				for i, pat := range resp.Msg.Pats {
-					assert.Equal(t, tt.want.Pats[i].Id, pat.Id)
-					assert.Equal(t, tt.want.Pats[i].Title, pat.Title)
+				assert.Equal(t, len(tt.want.GetPats()), len(resp.Msg.GetPats()))
+				for i, pat := range resp.Msg.GetPats() {
+					assert.Equal(t, tt.want.GetPats()[i].GetId(), pat.GetId())
+					assert.Equal(t, tt.want.GetPats()[i].GetTitle(), pat.GetTitle())
 				}
-				assert.Equal(t, tt.want.Pagination.TotalCount, resp.Msg.Pagination.TotalCount)
+				assert.Equal(t, tt.want.GetPagination().GetTotalCount(), resp.Msg.GetPagination().GetTotalCount())
 			}
 
 			mockPATSrv.AssertExpectations(t)


### PR DESCRIPTION
## Summary
- Add tests for `SearchCurrentUserPATs` handler (5 cases)
- Add tests for `userpat.Service.List` method (4 cases)

## Handler tests (`TestHandler_SearchCurrentUserPATs`)
- Unauthenticated error when `GetLoggedInPrincipal` fails
- PAT principal resolves to user via `ResolveSubject()` and lists PATs correctly
- Returns empty list when no PATs exist
- Returns `FailedPrecondition` when PAT feature is disabled
- Returns `Internal` error for unknown service failures

## Service tests (`TestService_List`)
- Returns `ErrDisabled` when PAT feature is disabled
- Propagates repository error
- Returns wrapped error when `enrichWithScope` fails (policy service error)
- Happy path — returns enriched PAT list with scopes derived from policies

## Test plan
- [x] `go build ./...` passes
- [x] All existing tests pass
- [x] All 9 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)