### PR TITLE
refactor: remove unused serviceuser-user relation from SpiceDB schema

### DIFF
--- a/core/serviceuser/service.go
+++ b/core/serviceuser/service.go
@@ -107,26 +107,6 @@ func (s Service) Create(ctx context.Context, serviceUser ServiceUser) (ServiceUs
 		return ServiceUser{}, err
 	}
 
-	if len(serviceUser.CreatedByUser) > 0 {
-		// TODO: write authz tests that checks if the user who created the service user
-		// has the permission to interact with the service user
-		// attach user to service user who created it
-		_, err = s.relationService.Create(ctx, relation.Relation{
-			Object: relation.Object{
-				ID:        createdSU.ID,
-				Namespace: schema.ServiceUserPrincipal,
-			},
-			Subject: relation.Subject{
-				ID:        serviceUser.CreatedByUser,
-				Namespace: schema.UserPrincipal,
-			},
-			RelationName: schema.UserRelationName,
-		})
-		if err != nil {
-			return ServiceUser{}, err
-		}
-	}
-
 	return createdSU, nil
 }
 

--- a/core/serviceuser/serviceuser.go
+++ b/core/serviceuser/serviceuser.go
@@ -29,10 +29,6 @@ type ServiceUser struct {
 	State    string
 	Metadata metadata.Metadata
 
-	// CreatedByUser is a transient field that is used to track the user who created this service user
-	// this doesn't have any impact on the service user itself
-	CreatedByUser string
-
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/internal/bootstrap/schema/base_schema.zed
+++ b/internal/bootstrap/schema/base_schema.zed
@@ -2,9 +2,8 @@ definition app/user {}
 
 definition app/serviceuser {
 	relation org: app/organization
-	relation user: app/user
 
-    permission manage = org->serviceusermanage + user
+    permission manage = org->serviceusermanage
 }
 
 definition app/pat {

--- a/internal/bootstrap/testdata/compiled_schema.zed
+++ b/internal/bootstrap/testdata/compiled_schema.zed
@@ -182,9 +182,8 @@ definition app/rolebinding {
 }
 
 definition app/serviceuser {
-	permission manage = org->serviceusermanage + user
+	permission manage = org->serviceusermanage
 	relation org: app/organization
-	relation user: app/user
 }
 
 definition app/user {}


### PR DESCRIPTION
## Summary
- Remove the `user` relation from `app/serviceuser` SpiceDB schema — it was never written (handler never sets `CreatedByUser`)
- Simplify `manage` permission to just `org->serviceusermanage`
- Remove the `CreatedByUser` transient field from the service user struct and the conditional relation creation code

## Why this is safe to delete

1. **The relation was never written.** The `CreateServiceUser` handler (`serviceuser.go:145`) constructs the `ServiceUser` struct without setting `CreatedByUser`. The conditional block in `service.go:110` (`if len(serviceUser.CreatedByUser) > 0`) was therefore never entered — zero `serviceuser#user@<creator>` tuples exist in SpiceDB.

2. **The `manage` permission loses nothing.** Before: `permission manage = org->serviceusermanage + user`. Since `user` was never populated, the effective permission was already just `org->serviceusermanage`. This change makes the schema match reality.

3. **Creator attribution is already captured.** Two independent audit mechanisms record who created a service user:
   - **Repository-level audit record** (`serviceuser_repository.go:125`): `BuildAuditRecord` captures the authenticated actor (ID, type, name) from request context via `enrichActorFromContext`, stored in the `audit_records` table within the same transaction as the insert.
   - **Handler-level audit log** (`serviceuser.go:163`): `audit.GetAuditor(ctx, orgID).LogWithAttrs(ServiceUserCreatedEvent, ...)` emits a separate audit event with the acting user from context.

   Both paths derive the creator from the auth context — no struct field or SpiceDB relation needed.

## Context
Part of the membership package migration ([#1478](https://github.com/raystack/frontier/issues/1478)). This cleans up dead code before migrating service user org membership to the `core/membership` package.

## Test plan
- [x] Build passes
- [x] Service user handler tests pass
- [x] Verify no regressions in service user creation/deletion e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)