### PR TITLE
feat: migrate UI from RemoveOrganizationUser to RemoveOrganizationMember

### DIFF
--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "0.56.6",
     "@raystack/frontier": "workspace:^",
-    "@raystack/proton": "0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd",
+    "@raystack/proton": "0.1.0-432d98ce56451cd9461a755d8db4842ec4354669",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:../../sdk
       '@raystack/proton':
-        specifier: 0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd
-        version: 0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-432d98ce56451cd9461a755d8db4842ec4354669
+        version: 0.1.0-432d98ce56451cd9461a755d8db4842ec4354669(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.2.4)
@@ -228,8 +228,8 @@ importers:
         specifier: npm:@raystack/apsara@1.0.0-rc.2
         version: '@raystack/apsara@1.0.0-rc.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       '@raystack/proton':
-        specifier: 0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd
-        version: 0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-432d98ce56451cd9461a755d8db4842ec4354669
+        version: 0.1.0-432d98ce56451cd9461a755d8db4842ec4354669(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -2234,8 +2234,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd':
-    resolution: {integrity: sha512-GTKX7uUhiCIxs/tzVVjwCHxFCC4TEgibpUaAPvaDEvUH9MVmnSsP11h14ATHb0c8G/FTwZYyGnEw8wU/agrq5A==}
+  '@raystack/proton@0.1.0-432d98ce56451cd9461a755d8db4842ec4354669':
+    resolution: {integrity: sha512-IDGmiUDxE/8joCGSUfgUSflUoqnM2GUyIgrwmqkSFseyXC463O5lpWPW8XRwh5KF392BbwokdtznMOymjTUaTw==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -9542,7 +9542,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
-  '@raystack/proton@0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-432d98ce56451cd9461a755d8db4842ec4354669(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/sdk/admin/views/organizations/details/members/remove-member.tsx
+++ b/web/sdk/admin/views/organizations/details/members/remove-member.tsx
@@ -1,7 +1,7 @@
 import type { SearchOrganizationUsersResponse_OrganizationUser } from "@raystack/proton/frontier";
 import {
   FrontierServiceQueries,
-  RemoveOrganizationUserRequestSchema,
+  RemoveOrganizationMemberRequestSchema,
 } from "@raystack/proton/frontier";
 import { create } from "@bufbuild/protobuf";
 import { useMutation } from "@connectrpc/connect-query";
@@ -23,17 +23,18 @@ export const RemoveMember = ({
   onClose,
 }: RemoveMemberProps) => {
   const t = useTerminology();
-  const { mutateAsync: removeOrganizationUser, isPending } = useMutation(
-    FrontierServiceQueries.removeOrganizationUser,
+  const { mutateAsync: removeOrganizationMember, isPending } = useMutation(
+    FrontierServiceQueries.removeOrganizationMember,
   );
 
   async function onSubmit() {
     try {
       if (!user) return;
-      await removeOrganizationUser(
-        create(RemoveOrganizationUserRequestSchema, {
-          id: organizationId,
-          userId: user?.id || "",
+      await removeOrganizationMember(
+        create(RemoveOrganizationMemberRequestSchema, {
+          orgId: organizationId,
+          principalId: user?.id || "",
+          principalType: "app/user",
         }),
       );
       if (onRemove) {

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -102,7 +102,7 @@
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
     "@raystack/apsara-v1": "npm:@raystack/apsara@1.0.0-rc.2",
-    "@raystack/proton": "0.1.0-a34fad75e08453004b9a8c0931e4ca9b087de8cd",
+    "@raystack/proton": "0.1.0-432d98ce56451cd9461a755d8db4842ec4354669",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",

--- a/web/sdk/react/views-new/members/components/remove-member-dialog.tsx
+++ b/web/sdk/react/views-new/members/components/remove-member-dialog.tsx
@@ -6,7 +6,7 @@ import { useMutation } from '@connectrpc/connect-query';
 import {
   FrontierServiceQueries,
   DeleteOrganizationInvitationRequestSchema,
-  RemoveOrganizationUserRequestSchema
+  RemoveOrganizationMemberRequestSchema
 } from '@raystack/proton/frontier';
 import {
   Button,
@@ -43,17 +43,17 @@ export function RemoveMemberDialog({ handle, refetch }: RemoveMemberDialogProps)
     {
       onSuccess: () => {
         handle.close();
-        toastManager.add({ title: 'Member deleted', type: 'success' });
+        toastManager.add({ title: 'Invitation deleted', type: 'success' });
       }
     }
   );
 
-  const { mutateAsync: removeUser } = useMutation(
-    FrontierServiceQueries.removeOrganizationUser,
+  const { mutateAsync: removeMember } = useMutation(
+    FrontierServiceQueries.removeOrganizationMember,
     {
       onSuccess: () => {
         handle.close();
-        toastManager.add({ title: 'Member deleted', type: 'success' });
+        toastManager.add({ title: 'User removed', type: 'success' });
       }
     }
   );
@@ -68,16 +68,18 @@ export function RemoveMemberDialog({ handle, refetch }: RemoveMemberDialogProps)
         });
         await deleteInvitation(req);
       } else {
-        const req = create(RemoveOrganizationUserRequestSchema, {
-          id: organizationId,
-          userId: memberId
+        const req = create(RemoveOrganizationMemberRequestSchema, {
+          orgId: organizationId,
+          principalId: memberId,
+          principalType: 'app/user'
         });
-        await removeUser(req);
+        await removeMember(req);
       }
     } catch (error) {
       handleConnectError(error, {
         NotFound: (err) => toastManager.add({ title: 'Not found', description: err.message, type: 'error' }),
         PermissionDenied: () => toastManager.add({ title: "You don't have permission to perform this action", type: 'error' }),
+        FailedPrecondition: (err) => toastManager.add({ title: 'Cannot remove user', description: err.message, type: 'error' }),
         Default: (err) => toastManager.add({ title: 'Something went wrong', description: err.message, type: 'error' }),
       });
     } finally {

--- a/web/sdk/react/views/members/remove-member-dialog.tsx
+++ b/web/sdk/react/views/members/remove-member-dialog.tsx
@@ -7,7 +7,7 @@ import { useMutation } from '@connectrpc/connect-query';
 import {
   FrontierServiceQueries,
   DeleteOrganizationInvitationRequestSchema,
-  RemoveOrganizationUserRequestSchema
+  RemoveOrganizationMemberRequestSchema
 } from '@raystack/proton/frontier';
 import { create } from '@bufbuild/protobuf';
 
@@ -34,7 +34,7 @@ export const RemoveMemberDialog = ({
     {
       onSuccess: () => {
         onOpenChange(false);
-        toast.success('Member deleted');
+        toast.success('Invitation deleted');
       },
       onError: (error: any) => {
         toast.error('Something went wrong', {
@@ -44,12 +44,12 @@ export const RemoveMemberDialog = ({
     }
   );
 
-  const { mutateAsync: removeUser } = useMutation(
-    FrontierServiceQueries.removeOrganizationUser,
+  const { mutateAsync: removeMember } = useMutation(
+    FrontierServiceQueries.removeOrganizationMember,
     {
       onSuccess: () => {
         onOpenChange(false);
-        toast.success('Member deleted');
+        toast.success('User removed');
       },
       onError: (error: any) => {
         toast.error('Something went wrong', {
@@ -69,11 +69,12 @@ export const RemoveMemberDialog = ({
         });
         await deleteInvitation(req);
       } else {
-        const req = create(RemoveOrganizationUserRequestSchema, {
-          id: organizationId,
-          userId: memberId
+        const req = create(RemoveOrganizationMemberRequestSchema, {
+          orgId: organizationId,
+          principalId: memberId,
+          principalType: 'app/user'
         });
-        await removeUser(req);
+        await removeMember(req);
       }
     } catch (error: any) {
       toast.error('Something went wrong', {

--- a/web/sdk/utils/error.ts
+++ b/web/sdk/utils/error.ts
@@ -6,6 +6,7 @@ type ErrorHandlerMap = {
   AlreadyExists?: ErrorHandler;
   InvalidArgument?: ErrorHandler;
   PermissionDenied?: ErrorHandler;
+  FailedPrecondition?: ErrorHandler;
   NotFound?: ErrorHandler;
   Default?: ErrorHandler;
 };
@@ -49,6 +50,11 @@ export function handleConnectError(
     case Code.NotFound:
       handlers?.NotFound
         ? handlers.NotFound(connectError)
+        : defaultHandler(connectError);
+      break;
+    case Code.FailedPrecondition:
+      handlers?.FailedPrecondition
+        ? handlers.FailedPrecondition(connectError)
         : defaultHandler(connectError);
       break;
     default:


### PR DESCRIPTION
## Summary
- Migrate all UI components from `RemoveOrganizationUser` RPC to `RemoveOrganizationMember`
- Update request schema to use `orgId`, `principalId`, `principalType` fields (hardcoded to `app/user` for now)
- Add `FailedPrecondition` handler to `handleConnectError` utility for `ErrNotMember` and `ErrLastOwnerRole`
- Fix toast messages to say "user" instead of "member" since `principalType` is `app/user`

## Files changed
- `web/sdk/admin/views/.../remove-member.tsx` — schema + mutation renamed
- `web/sdk/react/views/members/remove-member-dialog.tsx` — schema + mutation renamed, toast messages updated
- `web/sdk/react/views-new/members/components/remove-member-dialog.tsx` — schema + mutation renamed, toast messages updated, `FailedPrecondition` error handling added
- `web/sdk/utils/error.ts` — added `FailedPrecondition` to `ErrorHandlerMap` and switch cases

## Note
Depends on `@raystack/proton` being published with the `RemoveOrganizationMember` RPC. Until the proton package is updated, the imports will not resolve.