### PR TITLE
feat: SDK projects improvements

### DIFF
--- a/web/sdk/react/views-new/projects/components/delete-project-dialog.tsx
+++ b/web/sdk/react/views-new/projects/components/delete-project-dialog.tsx
@@ -19,6 +19,7 @@ import { handleConnectError } from '~/utils/error';
 
 export interface DeleteProjectPayload {
   projectId: string;
+  projectName: string;
 }
 
 type AlertDialogHandle = ReturnType<typeof AlertDialog.createHandle<DeleteProjectPayload>>;
@@ -68,8 +69,9 @@ export function DeleteProjectDialog({ handle, refetch }: DeleteProjectDialogProp
             </AlertDialog.Header>
             <AlertDialog.Body>
               <Text size="small" variant="secondary">
-                This action is irreversible and may result in the deletion of
-                all related files. Are you sure you want to proceed?
+                This action is irreversible and will delete all files
+                associated with &quot;{payload?.projectName}.&quot; Are you
+                sure you want to proceed?
               </Text>
             </AlertDialog.Body>
             <AlertDialog.Footer>

--- a/web/sdk/react/views-new/projects/project-details-view.tsx
+++ b/web/sdk/react/views-new/projects/project-details-view.tsx
@@ -528,7 +528,10 @@ function ProjectActionsMenu({
             <Menu.Item
               leadingIcon={<Image src={deleteIcon as unknown as string} alt="Delete" width={16} height={16} />}
               onClick={() =>
-                deleteProjectDialogHandle.openWithPayload({ projectId })
+                deleteProjectDialogHandle.openWithPayload({
+                  projectId,
+                  projectName: projectTitle
+                })
               }
               data-test-id="frontier-sdk-delete-project-details-btn"
               style={{ color: 'var(--rs-color-foreground-danger-primary)' }}

--- a/web/sdk/react/views-new/projects/projects-view.tsx
+++ b/web/sdk/react/views-new/projects/projects-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useMemo } from 'react';
-import { ExclamationTriangleIcon, Pencil1Icon } from '@radix-ui/react-icons';
+import {
+  ArchiveIcon,
+  ExclamationTriangleIcon,
+  Pencil1Icon
+} from '@radix-ui/react-icons';
 import {
   Button,
   Tooltip,
@@ -112,6 +116,43 @@ export function ProjectsView({
     [userAccessOnProject]
   );
 
+  if (!isLoading && (projects?.length ?? 0) === 0) {
+    return (
+      <ViewContainer>
+        <ViewHeader title={title} description={description ?? `Manage projects for this ${t.organization({ case: 'lower' })}`} />
+        <EmptyState
+          variant="empty2"
+          icon={<ArchiveIcon />}
+          heading={t.project()}
+          subHeading="A project is a structured initiative undertaken to achieve a specific outcome. It operates within a defined scope, objectives, and resources, following a process of planning, execution, monitoring, and completion."
+          secondaryAction={
+            <Tooltip>
+              <Tooltip.Trigger
+                disabled={canCreateProject}
+                render={<span />}
+              >
+                <Button
+                  variant="solid"
+                  color="accent"
+                  size="small"
+                  onClick={() => addProjectDialogHandle.open(null)}
+                  disabled={!canCreateProject}
+                  data-test-id="frontier-sdk-add-project-empty-state-button"
+                >
+                  Create new {t.project({ case: 'lower' })}
+                </Button>
+              </Tooltip.Trigger>
+              {!canCreateProject && (
+                <Tooltip.Content>{AuthTooltipMessage}</Tooltip.Content>
+              )}
+            </Tooltip>
+          }
+        />
+        <AddProjectDialog handle={addProjectDialogHandle} refetch={refetch} />
+      </ViewContainer>
+    );
+  }
+
   return (
     <ViewContainer>
       <ViewHeader title={title} description={description ?? `Manage projects for this ${t.organization({ case: 'lower' })}`} />
@@ -200,7 +241,8 @@ export function ProjectsView({
                   leadingIcon={<Image src={deleteIcon as unknown as string} alt="Delete" width={16} height={16} />}
                   onClick={() =>
                     deleteProjectDialogHandle.openWithPayload({
-                      projectId: payload.projectId
+                      projectId: payload.projectId,
+                      projectName: payload.title
                     })
                   }
                   data-test-id="delete-project-dropdown-item"


### PR DESCRIPTION
## Summary
- Add a dedicated empty-state view for the projects page (`empty2` variant) with project terminology, descriptive copy, and a permission-gated `Create new project` CTA
- Update the delete-project dialog copy to name the specific project being deleted (`…all files associated with "<projectName>."`)
- Thread `projectName` through the `DeleteProjectPayload` and both call sites (projects list and project details views)