### PR TITLE
refactor(sdk): migrate service account project access to membership API

### DIFF
--- a/web/sdk/react/views-new/service-accounts/components/add-service-account-dialog.tsx
+++ b/web/sdk/react/views-new/service-accounts/components/add-service-account-dialog.tsx
@@ -16,14 +16,13 @@ import {
 import {
   FrontierServiceQueries,
   CreateServiceUserRequestSchema,
-  CreatePolicyForProjectRequestSchema,
+  SetProjectMemberRoleRequestSchema,
   CreateServiceUserTokenRequestSchema,
   ListOrganizationServiceUsersRequestSchema,
   ListOrganizationProjectsRequestSchema,
   ListServiceUserTokensRequestSchema,
   ListServiceUserTokensResponseSchema,
-  ServiceUserRequestBodySchema,
-  CreatePolicyForProjectBodySchema
+  ServiceUserRequestBodySchema
 } from '@raystack/proton/frontier';
 import {
   Button,
@@ -112,8 +111,8 @@ export function AddServiceAccountDialog({
     FrontierServiceQueries.createServiceUser
   );
 
-  const { mutateAsync: createPolicyForProject } = useMutation(
-    FrontierServiceQueries.createPolicyForProject
+  const { mutateAsync: setProjectMemberRole } = useMutation(
+    FrontierServiceQueries.setProjectMemberRole
   );
 
   const { mutateAsync: createServiceUserToken } = useMutation(
@@ -137,17 +136,14 @@ export function AddServiceAccountDialog({
         const serviceUserId = serviceUserResponse.serviceuser?.id;
         if (!serviceUserId) return;
 
-        const principal = `${PERMISSIONS.ServiceUserPrincipal}:${serviceUserId}`;
-
         await Promise.all(
           data.project_ids.map(projectId =>
-            createPolicyForProject(
-              create(CreatePolicyForProjectRequestSchema, {
+            setProjectMemberRole(
+              create(SetProjectMemberRoleRequestSchema, {
                 projectId,
-                body: create(CreatePolicyForProjectBodySchema, {
-                  roleId: PERMISSIONS.RoleProjectOwner,
-                  principal
-                })
+                principalId: serviceUserId,
+                principalType: PERMISSIONS.ServiceUserPrincipal,
+                roleId: PERMISSIONS.RoleProjectOwner
               })
             )
           )
@@ -204,7 +200,7 @@ export function AddServiceAccountDialog({
     [
       orgId,
       createServiceUser,
-      createPolicyForProject,
+      setProjectMemberRole,
       createServiceUserToken,
       queryClient,
       transport,

--- a/web/sdk/react/views-new/service-accounts/components/add-service-account-dialog.tsx
+++ b/web/sdk/react/views-new/service-accounts/components/add-service-account-dialog.tsx
@@ -108,7 +108,7 @@ export function AddServiceAccountDialog({
     return orderBy(list, ['title'], ['asc']);
   }, [projectsData]);
 
-  const { data: rolesData } = useQuery(
+  const { data: rolesData, isLoading: isRolesLoading } = useQuery(
     FrontierServiceQueries.listRoles,
     create(ListRolesRequestSchema, {
       state: 'enabled',
@@ -242,7 +242,7 @@ export function AddServiceAccountDialog({
                 interactions on behalf of the{' '}
                 {t.organization({ case: 'lower' })}.
               </Text>
-              {isProjectsLoading ? (
+              {isProjectsLoading || isRolesLoading ? (
                 <Flex direction="column" gap={5}>
                   <Skeleton height="60px" />
                   <Skeleton height="60px" />
@@ -302,7 +302,7 @@ export function AddServiceAccountDialog({
                 type="submit"
                 data-test-id="frontier-sdk-add-service-account-btn"
                 loading={isSubmitting}
-                disabled={isSubmitting || isProjectsLoading || !isDirty || !ownerRoleId}
+                disabled={isSubmitting || isProjectsLoading || isRolesLoading || !isDirty || !ownerRoleId}
                 loaderText="Creating..."
               >
                 Create

--- a/web/sdk/react/views-new/service-accounts/components/add-service-account-dialog.tsx
+++ b/web/sdk/react/views-new/service-accounts/components/add-service-account-dialog.tsx
@@ -20,6 +20,7 @@ import {
   CreateServiceUserTokenRequestSchema,
   ListOrganizationServiceUsersRequestSchema,
   ListOrganizationProjectsRequestSchema,
+  ListRolesRequestSchema,
   ListServiceUserTokensRequestSchema,
   ListServiceUserTokensResponseSchema,
   ServiceUserRequestBodySchema
@@ -107,6 +108,22 @@ export function AddServiceAccountDialog({
     return orderBy(list, ['title'], ['asc']);
   }, [projectsData]);
 
+  const { data: rolesData } = useQuery(
+    FrontierServiceQueries.listRoles,
+    create(ListRolesRequestSchema, {
+      state: 'enabled',
+      scopes: [PERMISSIONS.ProjectNamespace]
+    }),
+    { enabled: Boolean(orgId) }
+  );
+
+  const ownerRoleId = useMemo(
+    () =>
+      rolesData?.roles?.find(r => r.name === PERMISSIONS.RoleProjectOwner)
+        ?.id ?? '',
+    [rolesData]
+  );
+
   const { mutateAsync: createServiceUser } = useMutation(
     FrontierServiceQueries.createServiceUser
   );
@@ -121,7 +138,7 @@ export function AddServiceAccountDialog({
 
   const onSubmit = useCallback(
     async (data: FormData) => {
-      if (!orgId) return;
+      if (!orgId || !ownerRoleId) return;
 
       try {
         const serviceUserResponse = await createServiceUser(
@@ -143,7 +160,7 @@ export function AddServiceAccountDialog({
                 projectId,
                 principalId: serviceUserId,
                 principalType: PERMISSIONS.ServiceUserPrincipal,
-                roleId: PERMISSIONS.RoleProjectOwner
+                roleId: ownerRoleId
               })
             )
           )
@@ -199,6 +216,7 @@ export function AddServiceAccountDialog({
     },
     [
       orgId,
+      ownerRoleId,
       createServiceUser,
       setProjectMemberRole,
       createServiceUserToken,
@@ -284,7 +302,7 @@ export function AddServiceAccountDialog({
                 type="submit"
                 data-test-id="frontier-sdk-add-service-account-btn"
                 loading={isSubmitting}
-                disabled={isSubmitting || isProjectsLoading || !isDirty}
+                disabled={isSubmitting || isProjectsLoading || !isDirty || !ownerRoleId}
                 loaderText="Creating..."
               >
                 Create

--- a/web/sdk/react/views-new/service-accounts/components/manage-project-access-dialog.tsx
+++ b/web/sdk/react/views-new/service-accounts/components/manage-project-access-dialog.tsx
@@ -18,12 +18,9 @@ import {
   FrontierServiceQueries,
   ListServiceUserProjectsRequestSchema,
   ListOrganizationProjectsRequestSchema,
-  CreatePolicyForProjectRequestSchema,
-  CreatePolicyForProjectBodySchema,
-  ListPoliciesRequestSchema,
-  DeletePolicyRequestSchema,
-  type Project,
-  type Policy
+  SetProjectMemberRoleRequestSchema,
+  RemoveProjectMemberRequestSchema,
+  type Project
 } from '@raystack/proton/frontier';
 import { orderBy } from 'lodash';
 import { useFrontier } from '../../../contexts/FrontierContext';
@@ -176,16 +173,12 @@ export function ManageProjectAccessDialog({
     setAccessMap(permMap);
   }, [addedProjects]);
 
-  const { mutateAsync: createPolicyForProject } = useMutation(
-    FrontierServiceQueries.createPolicyForProject
+  const { mutateAsync: setProjectMemberRole } = useMutation(
+    FrontierServiceQueries.setProjectMemberRole
   );
 
-  const { mutateAsync: listPolicies } = useMutation(
-    FrontierServiceQueries.listPolicies
-  );
-
-  const { mutateAsync: deletePolicy } = useMutation(
-    FrontierServiceQueries.deletePolicy
+  const { mutateAsync: removeProjectMember } = useMutation(
+    FrontierServiceQueries.removeProjectMember
   );
 
   const onCheckChange = useCallback(
@@ -203,14 +196,12 @@ export function ManageProjectAccessDialog({
         if (value) {
           const roleId =
             accessMap[projectId]?.roleId || PERMISSIONS.RoleProjectViewer;
-          const principal = `${PERMISSIONS.ServiceUserPrincipal}:${serviceUserId}`;
-          await createPolicyForProject(
-            create(CreatePolicyForProjectRequestSchema, {
+          await setProjectMemberRole(
+            create(SetProjectMemberRoleRequestSchema, {
               projectId,
-              body: create(CreatePolicyForProjectBodySchema, {
-                roleId,
-                principal
-              })
+              principalId: serviceUserId,
+              principalType: PERMISSIONS.ServiceUserPrincipal,
+              roleId
             })
           );
           setAccessMap(prev => ({
@@ -218,20 +209,12 @@ export function ManageProjectAccessDialog({
             [projectId]: { value: true, isLoading: false, roleId }
           }));
         } else {
-          const policiesResp = await listPolicies(
-            create(ListPoliciesRequestSchema, {
+          await removeProjectMember(
+            create(RemoveProjectMemberRequestSchema, {
               projectId,
-              userId: serviceUserId,
-              orgId: '',
-              roleId: '',
-              groupId: ''
+              principalId: serviceUserId,
+              principalType: PERMISSIONS.ServiceUserPrincipal
             })
-          );
-          const policies = policiesResp?.policies || [];
-          await Promise.all(
-            policies.map((p: Policy) =>
-              deletePolicy(create(DeletePolicyRequestSchema, { id: p.id }))
-            )
           );
           setAccessMap(prev => ({
             ...prev,
@@ -257,9 +240,8 @@ export function ManageProjectAccessDialog({
     [
       serviceUserId,
       accessMap,
-      createPolicyForProject,
-      listPolicies,
-      deletePolicy
+      setProjectMemberRole,
+      removeProjectMember
     ]
   );
 
@@ -280,30 +262,12 @@ export function ManageProjectAccessDialog({
           [projectId]: { ...prev[projectId], isLoading: true, roleId }
         }));
 
-        const policiesResp = await listPolicies(
-          create(ListPoliciesRequestSchema, {
+        await setProjectMemberRole(
+          create(SetProjectMemberRoleRequestSchema, {
             projectId,
-            userId: serviceUserId,
-            orgId: '',
-            roleId: '',
-            groupId: ''
-          })
-        );
-        const policies = policiesResp?.policies || [];
-        await Promise.all(
-          policies.map((p: Policy) =>
-            deletePolicy(create(DeletePolicyRequestSchema, { id: p.id }))
-          )
-        );
-
-        const principal = `${PERMISSIONS.ServiceUserPrincipal}:${serviceUserId}`;
-        await createPolicyForProject(
-          create(CreatePolicyForProjectRequestSchema, {
-            projectId,
-            body: create(CreatePolicyForProjectBodySchema, {
-              roleId,
-              principal
-            })
+            principalId: serviceUserId,
+            principalType: PERMISSIONS.ServiceUserPrincipal,
+            roleId
           })
         );
 
@@ -326,9 +290,7 @@ export function ManageProjectAccessDialog({
     [
       serviceUserId,
       accessMap,
-      createPolicyForProject,
-      listPolicies,
-      deletePolicy
+      setProjectMemberRole
     ]
   );
 

--- a/web/sdk/react/views-new/service-accounts/components/manage-project-access-dialog.tsx
+++ b/web/sdk/react/views-new/service-accounts/components/manage-project-access-dialog.tsx
@@ -18,6 +18,7 @@ import {
   FrontierServiceQueries,
   ListServiceUserProjectsRequestSchema,
   ListOrganizationProjectsRequestSchema,
+  ListRolesRequestSchema,
   SetProjectMemberRoleRequestSchema,
   RemoveProjectMemberRequestSchema,
   type Project
@@ -161,6 +162,23 @@ export function ManageProjectAccessDialog({
     [addedProjectsData]
   );
 
+  const { data: rolesData } = useQuery(
+    FrontierServiceQueries.listRoles,
+    create(ListRolesRequestSchema, {
+      state: 'enabled',
+      scopes: [PERMISSIONS.ProjectNamespace]
+    }),
+    { enabled: Boolean(orgId) && isOpen }
+  );
+
+  const roleNameToId = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const r of rolesData?.roles ?? []) {
+      if (r.name && r.id) map[r.name] = r.id;
+    }
+    return map;
+  }, [rolesData]);
+
   useEffect(() => {
     const permMap = addedProjects.reduce((acc, proj) => {
       acc[proj?.id || ''] = {
@@ -194,19 +212,20 @@ export function ManageProjectAccessDialog({
         }));
 
         if (value) {
-          const roleId =
+          const roleName =
             accessMap[projectId]?.roleId || PERMISSIONS.RoleProjectViewer;
+          const resolvedRoleId = roleNameToId[roleName] || '';
           await setProjectMemberRole(
             create(SetProjectMemberRoleRequestSchema, {
               projectId,
               principalId: serviceUserId,
               principalType: PERMISSIONS.ServiceUserPrincipal,
-              roleId
+              roleId: resolvedRoleId
             })
           );
           setAccessMap(prev => ({
             ...prev,
-            [projectId]: { value: true, isLoading: false, roleId }
+            [projectId]: { value: true, isLoading: false, roleId: roleName }
           }));
         } else {
           await removeProjectMember(
@@ -240,6 +259,7 @@ export function ManageProjectAccessDialog({
     [
       serviceUserId,
       accessMap,
+      roleNameToId,
       setProjectMemberRole,
       removeProjectMember
     ]
@@ -262,12 +282,13 @@ export function ManageProjectAccessDialog({
           [projectId]: { ...prev[projectId], isLoading: true, roleId }
         }));
 
+        const resolvedRoleId = roleNameToId[roleId] || '';
         await setProjectMemberRole(
           create(SetProjectMemberRoleRequestSchema, {
             projectId,
             principalId: serviceUserId,
             principalType: PERMISSIONS.ServiceUserPrincipal,
-            roleId
+            roleId: resolvedRoleId
           })
         );
 
@@ -290,6 +311,7 @@ export function ManageProjectAccessDialog({
     [
       serviceUserId,
       accessMap,
+      roleNameToId,
       setProjectMemberRole
     ]
   );

--- a/web/sdk/react/views-new/service-accounts/components/manage-project-access-dialog.tsx
+++ b/web/sdk/react/views-new/service-accounts/components/manage-project-access-dialog.tsx
@@ -162,7 +162,7 @@ export function ManageProjectAccessDialog({
     [addedProjectsData]
   );
 
-  const { data: rolesData } = useQuery(
+  const { data: rolesData, isLoading: isRolesLoading } = useQuery(
     FrontierServiceQueries.listRoles,
     create(ListRolesRequestSchema, {
       state: 'enabled',
@@ -326,7 +326,7 @@ export function ManageProjectAccessDialog({
     [accessMap, onCheckChange, onRoleChange]
   );
 
-  const isLoading = isProjectsLoading || isAddedProjectsLoading;
+  const isLoading = isProjectsLoading || isAddedProjectsLoading || isRolesLoading;
 
   return (
     <Dialog handle={handle} onOpenChange={handleOpenChange}>


### PR DESCRIPTION
## Summary
- Replace raw `CreatePolicyForProject` / `DeletePolicy` / `ListPolicies` calls with `SetProjectMemberRole` and `RemoveProjectMember` in the `views-new` service accounts dialogs
- Role changes are now atomic (single `SetProjectMemberRole` call instead of non-atomic delete+create cycle)
- Aligns service account project access management with how user/group project access is handled everywhere else in the SDK

## Test plan
- [x] Create a new service account with projects selected — project access granted
- [x] Assign service account to a project — access granted
- [x] Change role on an assigned project — role updated atomically
- [x] Remove service account from a project — access removed
- [x] Delete service account token — works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)