### PR TITLE
 fix: enable goqu prepared statements globally

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,10 @@
 <!-- Describe how you tested these changes -->
 - [ ] Manual testing completed
 - [ ] Build and type checking passes
+
+## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
+- [ ] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
+- [ ] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
+- [ ] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
+- [ ] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,8 @@ output:
 linters:
   default: none
   enable:
+    - forbidigo
+    - gosec
     - govet
     - importas
     - ineffassign
@@ -20,6 +22,21 @@ linters:
   settings:
     revive:
       severity: warning
+    gosec:
+      # Only run SQL-injection rules. Revisit if specific risks emerge.
+      includes:
+        - G201  # SQL query construction using format string (fmt.Sprintf)
+        - G202  # SQL query construction using string concatenation
+    forbidigo:
+      # SQL safety.
+      analyze-types: false
+      forbid:
+        - pattern: 'goqu\.L\("[^"'']*''[^'']*\?[^'']*'''
+          msg: "Don't put ? inside a single-quoted string in goqu.L — breaks prepared mode. Use make_interval(secs => ?)-style functions instead."
+        - pattern: '\w+,\s*_,\s*err\s*[:=]+[^=]*\.ToSQL\(\)'
+          msg: "Don't discard params from ToSQL(); capture and pass via …Context(ctx, …, query, params...)."
+        - pattern: 'goqu\.From\('
+          msg: "Use dialect.From(...) not goqu.From(...). The latter uses goqu's default dialect (? placeholders) which PostgreSQL rejects in prepared mode."
   exclusions:
     generated: lax
     presets:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -30,6 +31,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	"github.com/doug-martin/goqu/v9"
 	"github.com/jackc/pgx/v4"
 	"github.com/stripe/stripe-go/v79"
 
@@ -104,8 +106,6 @@ import (
 	"github.com/raystack/frontier/internal/store/postgres"
 	"github.com/raystack/frontier/internal/store/spicedb"
 	"github.com/raystack/frontier/pkg/db"
-
-	"log/slog"
 
 	"github.com/pkg/profile"
 )
@@ -694,6 +694,10 @@ func getStripeClient(logger *slog.Logger, cfg *config.Frontier) *client.API {
 }
 
 func setupDB(cfg db.Config, logger *slog.Logger) (dbc *db.Client, err error) {
+	// Force every goqu dataset to use prepared statements ($N placeholders +
+	// separate args) instead of inlining values into the SQL string.
+	goqu.SetDefaultPrepared(true)
+
 	// prefer use pgx instead of lib/pq for postgres to catch pg error
 	if cfg.Driver == "postgres" {
 		cfg.Driver = "pgx"

--- a/internal/store/postgres/audit_record_repository.go
+++ b/internal/store/postgres/audit_record_repository.go
@@ -318,7 +318,10 @@ func (r AuditRecordRepository) executeCursorQuery(ctx context.Context, selectQue
 				return fmt.Errorf("failed to generate cursor name: %w", err)
 			}
 
-			// Declare cursor with the SELECT query
+			// Declare cursor with the SELECT query.
+			// #nosec G201 -- cursorName is server-generated (generateCursorName: crypto/rand
+			// hex); `query` is built by goqu with parameter binding (params... are forwarded).
+			// Postgres has no parameter binding for cursor names.
 			declareSQL := fmt.Sprintf("DECLARE %s CURSOR FOR %s", cursorName, query)
 			_, err = tx.ExecContext(ctx, declareSQL, params...)
 			if err != nil {
@@ -406,7 +409,10 @@ func (r AuditRecordRepository) streamCursorToCSV(ctx context.Context, tx *sql.Tx
 
 	rowCount := 0
 	for {
-		// Fetch batch from cursor
+		// Fetch batch from cursor.
+		// #nosec G201 -- cursorName is server-generated (generateCursorName: crypto/rand
+		// hex); BATCH_SIZE is a compile-time const. Postgres has no parameter binding for
+		// cursor names or FETCH counts.
 		fetchSQL := fmt.Sprintf("FETCH %d FROM %s", BATCH_SIZE, cursorName)
 		rows, err := tx.QueryContext(ctx, fetchSQL)
 		if err != nil {

--- a/internal/store/postgres/billing_invoice_repository.go
+++ b/internal/store/postgres/billing_invoice_repository.go
@@ -232,7 +232,7 @@ func (r BillingInvoiceRepository) List(ctx context.Context, flt invoice.Filter) 
 
 		// always make this call after all the filters have been applied
 		totalCountStmt := stmt.Select(goqu.COUNT("*"))
-		totalCountQuery, _, err := totalCountStmt.ToSQL()
+		totalCountQuery, totalCountParams, err := totalCountStmt.ToSQL()
 
 		if err != nil {
 			return []invoice.Invoice{}, fmt.Errorf("%w: %w", queryErr, err)
@@ -240,7 +240,7 @@ func (r BillingInvoiceRepository) List(ctx context.Context, flt invoice.Filter) 
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "Count", func(ctx context.Context) error {
-			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery)
+			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery, totalCountParams...)
 		}); err != nil {
 			return nil, fmt.Errorf("%w: %w", dbErr, err)
 		}

--- a/internal/store/postgres/billing_invoice_repository_test.go
+++ b/internal/store/postgres/billing_invoice_repository_test.go
@@ -1,10 +1,14 @@
 package postgres
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/doug-martin/goqu/v9"
+	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/salt/rql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBillingInvoiceRepository_prepareDataQuery(t *testing.T) {
@@ -174,4 +178,106 @@ func TestBillingInvoiceRepository_prepareDataQuery(t *testing.T) {
 			assert.Equal(t, tt.wantParams, gotParams)
 		})
 	}
+}
+
+// Prepared-mode regression guards. Each test mirrors the goqu chain at its named site.
+
+// Mirror of relation_repository.go::GetByFields query construction.
+func TestRelationRepository_GetByFields_PreparedSQLForwardsParams(t *testing.T) {
+	rel := relation.Relation{
+		Object:       relation.Object{ID: "obj-1", Namespace: "ns-obj"},
+		Subject:      relation.Subject{ID: "sub-1", Namespace: "ns-sub"},
+		RelationName: "owner",
+	}
+
+	stmt := dialect.Select(&relationCols{}).From(TABLE_RELATIONS).Prepared(true)
+	if rel.Object.ID != "" {
+		stmt = stmt.Where(goqu.Ex{"object_id": rel.Object.ID})
+	}
+	if rel.Object.Namespace != "" {
+		stmt = stmt.Where(goqu.Ex{"object_namespace_name": rel.Object.Namespace})
+	}
+	if rel.Subject.ID != "" {
+		stmt = stmt.Where(goqu.Ex{"subject_id": rel.Subject.ID})
+	}
+	if rel.Subject.Namespace != "" {
+		stmt = stmt.Where(goqu.Ex{"subject_namespace_name": rel.Subject.Namespace})
+	}
+	if rel.RelationName != "" {
+		stmt = stmt.Where(goqu.Ex{"relation_name": rel.RelationName})
+	}
+
+	sql, params, err := stmt.ToSQL()
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(sql, "$1"), "SQL must use $N placeholders, got: %s", sql)
+	assert.Equal(t, []interface{}{"obj-1", "ns-obj", "sub-1", "ns-sub", "owner"}, params)
+}
+
+// Mirror of relation_repository.go::ListByFields query construction.
+func TestRelationRepository_ListByFields_PreparedSQLForwardsParams(t *testing.T) {
+	rel := relation.Relation{
+		Subject:      relation.Subject{ID: "sub-1", SubRelationName: "member"},
+		RelationName: "team",
+		Object:       relation.Object{ID: "obj-1"},
+	}
+	like := "%:" + rel.Subject.SubRelationName
+
+	var exprs []goqu.Expression
+	if len(rel.Subject.ID) != 0 {
+		exprs = append(exprs, goqu.Ex{"subject_id": rel.Subject.ID})
+	}
+	if len(rel.RelationName) != 0 {
+		exprs = append(exprs, goqu.Ex{"relation_name": goqu.Op{"like": like}})
+	}
+	if len(rel.Object.ID) != 0 {
+		exprs = append(exprs, goqu.Ex{"object_id": rel.Object.ID})
+	}
+
+	sql, params, err := dialect.Select(&relationCols{}).From(TABLE_RELATIONS).Prepared(true).Where(exprs...).ToSQL()
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(sql, "$1"), "SQL must use $N placeholders, got: %s", sql)
+	assert.Equal(t, []interface{}{"sub-1", "%:member", "obj-1"}, params)
+}
+
+// Mirror of organization_repository.go::List totalCount path.
+func TestOrganizationRepository_ListTotalCount_PreparedSQLForwardsParams(t *testing.T) {
+	stmt := dialect.From(TABLE_ORGANIZATIONS).Prepared(true).Where(goqu.Ex{"state": "enabled"})
+	stmt = stmt.Where(goqu.Ex{"id": goqu.Op{"in": []string{"o-1", "o-2"}}})
+
+	totalCountStmt := stmt.Select(goqu.COUNT("*"))
+	sql, params, err := totalCountStmt.ToSQL()
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(sql, "$1"), "SQL must use $N placeholders, got: %s", sql)
+	assert.Equal(t, []interface{}{"enabled", "o-1", "o-2"}, params)
+}
+
+// Mirror of project_repository.go::List totalCount path.
+func TestProjectRepository_ListTotalCount_PreparedSQLForwardsParams(t *testing.T) {
+	stmt := dialect.From(TABLE_PROJECTS).Prepared(true).Where(goqu.Ex{"org_id": "org-1"})
+	stmt = stmt.Where(goqu.Ex{"id": goqu.Op{"in": []string{"p-1", "p-2"}}})
+	stmt = stmt.Where(goqu.Ex{"state": "enabled"})
+
+	totalCountStmt := stmt.Select(goqu.COUNT("*"))
+	sql, params, err := totalCountStmt.ToSQL()
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(sql, "$1"), "SQL must use $N placeholders, got: %s", sql)
+	assert.Equal(t, []interface{}{"org-1", "p-1", "p-2", "enabled"}, params)
+}
+
+// Mirror of billing_invoice_repository.go::List totalCount path.
+func TestBillingInvoiceRepository_ListTotalCount_PreparedSQLForwardsParams(t *testing.T) {
+	stmt := dialect.Select().From(TABLE_BILLING_INVOICES).Prepared(true).Where(goqu.Ex{"customer_id": "cust-1"})
+	stmt = stmt.Where(goqu.Ex{"amount": goqu.Op{"gt": 0}})
+	stmt = stmt.Where(goqu.Ex{"state": "paid"})
+
+	totalCountStmt := stmt.Select(goqu.COUNT("*"))
+	sql, params, err := totalCountStmt.ToSQL()
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(sql, "$1"), "SQL must use $N placeholders, got: %s", sql)
+	assert.Equal(t, []interface{}{"cust-1", int64(0), "paid"}, params)
 }

--- a/internal/store/postgres/org_users_repository_test.go
+++ b/internal/store/postgres/org_users_repository_test.go
@@ -109,10 +109,11 @@ func TestOrgUsersRepository_PrepareDataQuery(t *testing.T) {
 
 func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 	tests := []struct {
-		name    string
-		filter  rql.Filter
-		wantSQL string
-		wantErr bool
+		name     string
+		filter   rql.Filter
+		wantSQL  string
+		wantArgs []interface{}
+		wantErr  bool
 	}{
 		{
 			name: "eq operator",
@@ -121,7 +122,8 @@ func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 				Operator: "eq",
 				Value:    "test@example.com",
 			},
-			wantSQL: `("users"."email" = 'test@example.com')`,
+			wantSQL:  `("users"."email" = $1)`,
+			wantArgs: []interface{}{"test@example.com"},
 		},
 		{
 			name: "like operator",
@@ -130,7 +132,8 @@ func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 				Operator: "like",
 				Value:    "john",
 			},
-			wantSQL: `(CAST("users"."name" AS TEXT) ILIKE '%john%')`,
+			wantSQL:  `(CAST("users"."name" AS TEXT) ILIKE $1)`,
+			wantArgs: []interface{}{"%john%"},
 		},
 		{
 			name: "notlike operator",
@@ -139,7 +142,8 @@ func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 				Operator: "notlike",
 				Value:    "john",
 			},
-			wantSQL: `(CAST("users"."name" AS TEXT) NOT ILIKE '%john%')`,
+			wantSQL:  `(CAST("users"."name" AS TEXT) NOT ILIKE $1)`,
+			wantArgs: []interface{}{"%john%"},
 		},
 		{
 			name: "in operator",
@@ -148,7 +152,8 @@ func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 				Operator: "in",
 				Value:    "active,inactive",
 			},
-			wantSQL: `("users"."state" IN ('active', 'inactive'))`,
+			wantSQL:  `("users"."state" IN ($1, $2))`,
+			wantArgs: []interface{}{"active", "inactive"},
 		},
 		{
 			name: "empty operator",
@@ -156,7 +161,8 @@ func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 				Name:     "title",
 				Operator: "empty",
 			},
-			wantSQL: `(("users"."title" IS NULL) OR ("users"."title" = ''))`,
+			wantSQL:  `(("users"."title" IS NULL) OR ("users"."title" = $1))`,
+			wantArgs: []interface{}{""},
 		},
 		{
 			name: "invalid operator",
@@ -180,22 +186,24 @@ func TestOrgUsersRepository_BuildNonRoleFilterCondition(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			sql, _, err := dialect.From("dummy").Where(got).ToSQL()
+			sql, args, err := dialect.From("dummy").Prepared(true).Where(got).ToSQL()
 			assert.NoError(t, err)
 			// Remove the "SELECT * FROM "dummy" WHERE" part from the generated SQL
 			actualSQL := strings.TrimPrefix(sql, `SELECT * FROM "dummy" WHERE `)
 			assert.Equal(t, tt.wantSQL, actualSQL)
+			assert.Equal(t, tt.wantArgs, args)
 		})
 	}
 }
 
 func TestOrgUsersRepository_BuildRoleFilterCondition(t *testing.T) {
 	tests := []struct {
-		name    string
-		orgID   string
-		filter  rql.Filter
-		wantSQL string
-		wantErr bool
+		name     string
+		orgID    string
+		filter   rql.Filter
+		wantSQL  string
+		wantArgs []interface{}
+		wantErr  bool
 	}{
 		{
 			name:  "eq operator",
@@ -205,7 +213,8 @@ func TestOrgUsersRepository_BuildRoleFilterCondition(t *testing.T) {
 				Operator: "eq",
 				Value:    "admin",
 			},
-			wantSQL: `EXISTS (SELECT 1 FROM "policies" INNER JOIN "roles" ON ("roles"."id" = "policies"."role_id") WHERE (("policies"."principal_id" = "users"."id") AND ("policies"."resource_id" = 'org123') AND ("policies"."resource_type" = 'app/organization') AND ("roles"."name" = 'admin')) LIMIT 1)`,
+			wantSQL:  `EXISTS (SELECT 1 FROM "policies" INNER JOIN "roles" ON ("roles"."id" = "policies"."role_id") WHERE (("policies"."principal_id" = "users"."id") AND ("policies"."resource_id" = $1) AND ("policies"."resource_type" = $2) AND ("roles"."name" = $3)) LIMIT $4)`,
+			wantArgs: []interface{}{"org123", "app/organization", "admin", int64(1)},
 		},
 		{
 			name:  "neq operator",
@@ -215,7 +224,8 @@ func TestOrgUsersRepository_BuildRoleFilterCondition(t *testing.T) {
 				Operator: "neq",
 				Value:    "admin",
 			},
-			wantSQL: `(NOT EXISTS (SELECT 1 FROM "policies" INNER JOIN "roles" ON ("roles"."id" = "policies"."role_id") WHERE (("policies"."principal_id" = "users"."id") AND ("policies"."resource_id" = 'org123') AND ("policies"."resource_type" = 'app/organization') AND ("roles"."name" = 'admin')) LIMIT 1) AND EXISTS (SELECT 1 FROM "policies" INNER JOIN "roles" ON ("roles"."id" = "policies"."role_id") WHERE (("policies"."principal_id" = "users"."id") AND ("policies"."resource_id" = 'org123') AND ("policies"."resource_type" = 'app/organization')) LIMIT 1))`,
+			wantSQL:  `(NOT EXISTS (SELECT 1 FROM "policies" INNER JOIN "roles" ON ("roles"."id" = "policies"."role_id") WHERE (("policies"."principal_id" = "users"."id") AND ("policies"."resource_id" = $1) AND ("policies"."resource_type" = $2) AND ("roles"."name" = $3)) LIMIT $4) AND EXISTS (SELECT 1 FROM "policies" INNER JOIN "roles" ON ("roles"."id" = "policies"."role_id") WHERE (("policies"."principal_id" = "users"."id") AND ("policies"."resource_id" = $5) AND ("policies"."resource_type" = $6)) LIMIT $7))`,
+			wantArgs: []interface{}{"org123", "app/organization", "admin", int64(1), "org123", "app/organization", int64(1)},
 		},
 		{
 			name:  "invalid operator",
@@ -240,11 +250,12 @@ func TestOrgUsersRepository_BuildRoleFilterCondition(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			sql, _, err := dialect.From("dummy").Where(goqu.And(got...)).ToSQL()
+			sql, args, err := dialect.From("dummy").Prepared(true).Where(goqu.And(got...)).ToSQL()
 			assert.NoError(t, err)
 			// Remove the "SELECT * FROM "dummy" WHERE" part from the generated SQL
 			actualSQL := strings.TrimPrefix(sql, `SELECT * FROM "dummy" WHERE `)
 			assert.Equal(t, tt.wantSQL, actualSQL)
+			assert.Equal(t, tt.wantArgs, args)
 		})
 	}
 }

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -236,14 +236,14 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 		limit := flt.Pagination.PageSize
 
 		totalCountStmt := stmt.Select(goqu.COUNT("*"))
-		totalCountQuery, _, err := totalCountStmt.ToSQL()
+		totalCountQuery, totalCountParams, err := totalCountStmt.ToSQL()
 		if err != nil {
 			return []organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
 		}
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_ORGANIZATIONS, "Count", func(ctx context.Context) error {
-			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery)
+			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery, totalCountParams...)
 		}); err != nil {
 			return nil, fmt.Errorf("%w: %w", dbErr, err)
 		}

--- a/internal/store/postgres/policy_repository.go
+++ b/internal/store/postgres/policy_repository.go
@@ -367,7 +367,7 @@ func (r PolicyRepository) GroupMemberCount(ctx context.Context, groupIDs []strin
 	if len(groupIDs) == 0 {
 		return nil, policy.ErrInvalidID
 	}
-	stmt := goqu.From("policies").
+	stmt := dialect.From("policies").
 		Select(goqu.I("resource_id").As("id"), goqu.COUNT(goqu.DISTINCT(goqu.I("principal_id"))).As("count")).
 		Where(goqu.Ex{
 			"resource_type": schema.GroupNamespace,
@@ -404,7 +404,7 @@ func (r PolicyRepository) ProjectMemberCount(ctx context.Context, projectIDs []s
 	if len(projectIDs) == 0 {
 		return nil, policy.ErrInvalidID
 	}
-	stmt := goqu.From("policies").
+	stmt := dialect.From("policies").
 		Select(goqu.I("resource_id").As("id"), goqu.COUNT(goqu.DISTINCT(goqu.I("principal_id"))).As("count")).
 		Where(goqu.Ex{
 			"resource_type": schema.ProjectNamespace,
@@ -440,7 +440,7 @@ func (r PolicyRepository) OrgMemberCount(ctx context.Context, id string) (policy
 	if len(id) == 0 {
 		return policy.MemberCount{}, policy.ErrInvalidID
 	}
-	stmt := goqu.From("policies").
+	stmt := dialect.From("policies").
 		Select(goqu.I("resource_id").As("id"), goqu.COUNT(goqu.DISTINCT(goqu.I("principal_id"))).As("count")).
 		Where(goqu.Ex{
 			"resource_type": schema.OrganizationNamespace,

--- a/internal/store/postgres/project_repository.go
+++ b/internal/store/postgres/project_repository.go
@@ -180,7 +180,7 @@ func (r ProjectRepository) List(ctx context.Context, flt project.Filter) ([]proj
 
 		// always make this call after all the filters have been applied
 		totalCountStmt := stmt.Select(goqu.COUNT("*"))
-		totalCountQuery, _, err := totalCountStmt.ToSQL()
+		totalCountQuery, totalCountParams, err := totalCountStmt.ToSQL()
 
 		if err != nil {
 			return []project.Project{}, fmt.Errorf("%w: %w", queryErr, err)
@@ -188,7 +188,7 @@ func (r ProjectRepository) List(ctx context.Context, flt project.Filter) ([]proj
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_PROJECTS, "Count", func(ctx context.Context) error {
-			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery)
+			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery, totalCountParams...)
 		}); err != nil {
 			return nil, fmt.Errorf("%w: %w", dbErr, err)
 		}

--- a/internal/store/postgres/relation_repository.go
+++ b/internal/store/postgres/relation_repository.go
@@ -193,12 +193,12 @@ func (r RelationRepository) GetByFields(ctx context.Context, rel relation.Relati
 		})
 	}
 
-	query, _, err := stmt.ToSQL()
+	query, params, err := stmt.ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", queryErr, err)
 	}
 	if err = r.dbc.WithTimeout(ctx, TABLE_RELATIONS, "GetByFields", func(ctx context.Context) error {
-		return r.dbc.SelectContext(ctx, &fetchedRelations, query)
+		return r.dbc.SelectContext(ctx, &fetchedRelations, query, params...)
 	}); err != nil {
 		err = checkPostgresError(err)
 		switch {
@@ -230,12 +230,12 @@ func (r RelationRepository) ListByFields(ctx context.Context, rel relation.Relat
 	if len(rel.Object.ID) != 0 {
 		exprs = append(exprs, goqu.Ex{"object_id": rel.Object.ID})
 	}
-	query, _, err := dialect.Select(&relationCols{}).From(TABLE_RELATIONS).Where(exprs...).ToSQL()
+	query, params, err := dialect.Select(&relationCols{}).From(TABLE_RELATIONS).Where(exprs...).ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", queryErr, err)
 	}
 	if err = r.dbc.WithTimeout(ctx, TABLE_RELATIONS, "GetByFields", func(ctx context.Context) error {
-		return r.dbc.SelectContext(ctx, &fetchedRelation, query)
+		return r.dbc.SelectContext(ctx, &fetchedRelation, query, params...)
 	}); err != nil {
 		err = checkPostgresError(err)
 		switch {

--- a/internal/store/postgres/role_repository.go
+++ b/internal/store/postgres/role_repository.go
@@ -122,22 +122,22 @@ func (r RoleRepository) Upsert(ctx context.Context, rl role.Role) (role.Role, er
 		return role.Role{}, fmt.Errorf("%w: %s", parseErr, err)
 	}
 
-	query, _, err := dialect.Insert(TABLE_ROLES).Rows(
+	query, params, err := dialect.Insert(TABLE_ROLES).Rows(
 		goqu.Record{
-			"id":          goqu.L("$1"),
-			"org_id":      goqu.L("$2"),
-			"name":        goqu.L("$3"),
-			"title":       goqu.L("$4"),
-			"permissions": goqu.L("$5"),
-			"state":       goqu.L("$6"),
-			"metadata":    goqu.L("$7"),
-			"scopes":      goqu.L("$8"),
+			"id":          rl.ID,
+			"org_id":      rl.OrgID,
+			"name":        rl.Name,
+			"title":       rl.Title,
+			"permissions": marshaledPermissions,
+			"state":       rl.State,
+			"metadata":    marshaledMetadata,
+			"scopes":      pq.Array(rl.Scopes),
 		}).OnConflict(goqu.DoUpdate("org_id, name", goqu.Record{
-		"title":       goqu.L("$4"),
-		"permissions": goqu.L("$5"),
-		"state":       goqu.L("$6"),
-		"metadata":    goqu.L("$7"),
-		"scopes":      goqu.L("$8"),
+		"title":       rl.Title,
+		"permissions": marshaledPermissions,
+		"state":       rl.State,
+		"metadata":    marshaledMetadata,
+		"scopes":      pq.Array(rl.Scopes),
 	})).Returning(&Role{}).ToSQL()
 	if err != nil {
 		return role.Role{}, fmt.Errorf("%w: %s", queryErr, err)
@@ -145,8 +145,7 @@ func (r RoleRepository) Upsert(ctx context.Context, rl role.Role) (role.Role, er
 
 	var roleDB Role
 	if err = r.dbc.WithTimeout(ctx, TABLE_ROLES, "Upsert", func(ctx context.Context) error {
-		return r.dbc.QueryRowxContext(ctx, query, rl.ID, rl.OrgID, rl.Name, rl.Title, marshaledPermissions,
-			rl.State, marshaledMetadata, pq.Array(rl.Scopes)).StructScan(&roleDB)
+		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&roleDB)
 	}); err != nil {
 		err = checkPostgresError(err)
 		switch {
@@ -221,17 +220,17 @@ func (r RoleRepository) Update(ctx context.Context, rl role.Role) (role.Role, er
 		return role.Role{}, fmt.Errorf("%w: %s", parseErr, err)
 	}
 
-	query, _, err := dialect.Update(TABLE_ROLES).Set(
+	query, params, err := dialect.Update(TABLE_ROLES).Set(
 		goqu.Record{
-			"name":        goqu.L("$2"),
-			"permissions": goqu.L("$3"),
-			"title":       goqu.L("$4"),
-			"state":       goqu.L("$5"),
-			"metadata":    goqu.L("$6"),
-			"scopes":      goqu.L("$7"),
+			"name":        rl.Name,
+			"permissions": marshaledPermissions,
+			"title":       rl.Title,
+			"state":       rl.State,
+			"metadata":    marshaledMetadata,
+			"scopes":      pq.Array(rl.Scopes),
 			"updated_at":  goqu.L("now()"),
 		}).Where(
-		goqu.Ex{"id": goqu.L("$1")},
+		goqu.Ex{"id": rl.ID},
 	).Returning(&Role{}).ToSQL()
 	if err != nil {
 		return role.Role{}, fmt.Errorf("%w: %s", queryErr, err)
@@ -239,8 +238,7 @@ func (r RoleRepository) Update(ctx context.Context, rl role.Role) (role.Role, er
 
 	var roleDB Role
 	if err = r.dbc.WithTimeout(ctx, TABLE_ROLES, "Update", func(ctx context.Context) error {
-		return r.dbc.QueryRowxContext(ctx, query, rl.ID, rl.Name, marshaledPermissions, rl.Title, rl.State,
-			marshaledMetadata, pq.Array(rl.Scopes)).StructScan(&roleDB)
+		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&roleDB)
 	}); err != nil {
 		err = checkPostgresError(err)
 		switch {

--- a/internal/store/postgres/session_repository.go
+++ b/internal/store/postgres/session_repository.go
@@ -6,9 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
-
 	"log/slog"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	frontiersession "github.com/raystack/frontier/core/authenticate/session"
@@ -209,7 +208,7 @@ func (s *SessionRepository) DeleteExpiredSessions(ctx context.Context) error {
 func (s *SessionRepository) UpdateValidity(ctx context.Context, id uuid.UUID, validity time.Duration) error {
 	query, params, err := dialect.Update(TABLE_SESSIONS).Set(
 		goqu.Record{
-			"expires_at": goqu.L("expires_at + INTERVAL '? hours'", validity.Hours()),
+			"expires_at": goqu.L("expires_at + make_interval(secs => ?)", validity.Seconds()),
 		}).Where(goqu.Ex{
 		"id": id,
 	}).ToSQL()


### PR DESCRIPTION

  ## Summary

  Forces every goqu dataset to use prepared statements ($N placeholders + separate args) instead of inlining values into the SQL string, by setting
  `goqu.SetDefaultPrepared(true)` globally in `cmd/serve.go::setupDB`. SQL injection becomes structurally impossible at the goqu layer rather than relying on per-site
  discipline.

  Flipping the flag surfaced several latent bugs that worked silently under value-interpolation but broke under prepared mode. They're fixed in the same PR so the flip is safe
  to ship.

  ## Changes
  - Enable `goqu.SetDefaultPrepared(true)` in `cmd/serve.go::setupDB`.
  - 5 params-discard fixes (`query, _, err := stmt.ToSQL()` followed by an exec without forwarding `params...`):
    - `relation_repository.GetByFields` / `ListByFields`
    - `organization_repository.List` totalCount
    - `project_repository.List` totalCount
    - `billing_invoice_repository.List` totalCount
  - `session_repository.UpdateValidity` — `INTERVAL '? hours'` (goqu substitutes `?` regardless of quote context, breaking under prepared mode) → `make_interval(secs => ?)`.
  - `role_repository.Upsert` / `Update` — drop the manual `goqu.L("$N")` placeholder workaround; pass real values through `goqu.Record{}`. Wire size grows by ~5 params on
  `Upsert`; database state is byte-for-byte identical.
  - `policy_repository.GroupMemberCount` / `ProjectMemberCount` / `OrgMemberCount` — `goqu.From("policies")` → `dialect.From("policies")`. The package-level `goqu.From` uses
  goqu's default dialect (`?` placeholders), which PostgreSQL rejects in prepared mode.
  - `audit_record_repository.go` — added `// #nosec G201` annotations with justifications on the two `fmt.Sprintf` calls building `DECLARE … CURSOR FOR …` and `FETCH … FROM …`
  (Postgres has no parameter binding for cursor identifiers; `cursorName` is server-generated via `crypto/rand`).
  - `.golangci.yml`:
    - Enable `gosec` with G201/G202 only.
    - Enable `forbidigo` with three narrow patterns: `?` inside a single-quoted goqu.L, params-discard from `ToSQL()`, and `goqu.From(` (use `dialect.From` instead).
  - `.github/pull_request_template.md` — added a 4-item SQL Safety checklist.

  ## Technical Details

  Three bug shapes lint catches:
  - `?` inside single-quoted goqu.L — goqu's literal templater walks char-by-char, substituting `?` regardless of quote context. Prepared mode emits `INTERVAL '$1 hours'`
  literal + a bound arg, so Postgres rejects with `bind message supplies 1 parameters, but prepared statement requires 0`.
  - Discarding `params` from `ToSQL()` — works in interpolated mode (params is `[]`); under prepared mode the SQL has `$N` placeholders without values bound.
  - `goqu.From(...)` — uses goqu's default dialect (`?` placeholders). PostgreSQL parses `?` as a syntax error.

  `role_repository`'s old `goqu.L("$1")…goqu.L("$8")` was a workaround for goqu not reusing parameter positions across `INSERT VALUES` and `ON CONFLICT DO UPDATE`. With
  prepared mode on, goqu emits fresh placeholders ($9..$13 for the UPDATE clause) and the values get sent twice on the wire — strings/json/UUIDs, negligible.

  ## Test Plan
  - [x] Manual testing completed (org/project/role lifecycle in `make compose-up-dev`)
  - [x] Build and type checking passes (`make build`, `golangci-lint run ./...` — 0 issues)
  - [x] `make test` passes
  - [x] `go test -v ./test/e2e/...` regression suite passes (`TestProjectAPI/7,8`, `TestCheckoutAPI/2`, `TestCheckFeatureEntitlementAPI/2` were failing pre-fix — all routed
  through `policy_repository.*MemberCount`)

  ## SQL Safety
  - [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
  - [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
  - [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
  - [x] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.

