### PR TITLE
fix: webhook secret rotation rejects valid events

### DIFF
--- a/core/event/service.go
+++ b/core/event/service.go
@@ -210,7 +210,7 @@ func (p *Service) BillingWebhook(ctx context.Context, payload ProviderWebhookEve
 		}
 		break
 	}
-	if len(parseErrs) > 0 {
+	if len(parseErrs) == len(p.billingConf.StripeWebhookSecrets) {
 		return fmt.Errorf("failed to construct event: %w", errors.Join(parseErrs...))
 	}
 	ctx = context.WithoutCancel(ctx)


### PR DESCRIPTION
## Summary
- Fix bug in `BillingWebhook` where valid Stripe webhook events are rejected during secret rotation
- When multiple `StripeWebhookSecrets` are configured, if the first secret fails verification but a later one succeeds, the condition `len(parseErrs) > 0` incorrectly returns an error
- Changed to `len(parseErrs) == len(secrets)` so it only fails when **all** secrets are exhausted

## Test plan
- [ ] Existing `core/event` tests pass
- [ ] Configure two webhook secrets (old + new), send event signed with the second secret, verify it is accepted
- [ ] Verify events signed with an invalid secret are still rejected