### PR TITLE
fix(admin): stop leaking entire process.env into client bundle

### DIFF
--- a/web/apps/admin/vite.config.ts
+++ b/web/apps/admin/vite.config.ts
@@ -42,11 +42,6 @@ export default defineConfig(() => {
     },
     server: {
       proxy: {
-        "/frontier-api": {
-          target: process.env.FRONTIER_API_URL,
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/frontier-api/, ""),
-        },
         "/frontier-connect": {
           target: process.env.FRONTIER_CONNECTRPC_URL,
           changeOrigin: true,
@@ -67,9 +62,6 @@ export default defineConfig(() => {
     define: {
       "process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL": JSON.stringify(
         process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL || ""
-      ),
-      "process.env.FRONTIER_API_URL": JSON.stringify(
-        process.env.FRONTIER_API_URL || ""
       ),
       "process.env.FRONTIER_CONNECTRPC_URL": JSON.stringify(
         process.env.FRONTIER_CONNECTRPC_URL || ""

--- a/web/apps/admin/vite.config.ts
+++ b/web/apps/admin/vite.config.ts
@@ -68,6 +68,12 @@ export default defineConfig(() => {
       "process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL": JSON.stringify(
         process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL || ""
       ),
+      "process.env.FRONTIER_API_URL": JSON.stringify(
+        process.env.FRONTIER_API_URL || ""
+      ),
+      "process.env.FRONTIER_CONNECTRPC_URL": JSON.stringify(
+        process.env.FRONTIER_CONNECTRPC_URL || ""
+      ),
     },
   };
 });

--- a/web/apps/admin/vite.config.ts
+++ b/web/apps/admin/vite.config.ts
@@ -65,7 +65,9 @@ export default defineConfig(() => {
       dedupe: ["react", "react-dom", "@tanstack/react-query", "@connectrpc/connect-query"],
     },
     define: {
-      "process.env": process.env,
+      "process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL": JSON.stringify(
+        process.env.NEXT_PUBLIC_FRONTIER_CONNECT_URL || ""
+      ),
     },
   };
 });


### PR DESCRIPTION
## Summary
- The admin vite config had `"process.env": process.env` in the `define` block, which injects **every environment variable** from the build machine into the production JS bundle
- Verified by setting a canary env var (`SECURITY_TEST_SECRET`), building, and finding it in the output JS alongside `VAULT_ADDR`, `GOPRIVATE`, `SHELL`, `TMPDIR`, etc.
- Replaced with an explicit allowlist containing only `NEXT_PUBLIC_FRONTIER_CONNECT_URL` (the single env var the app actually uses)

## Test plan
- [x] Build admin app with `SECURITY_TEST_SECRET=canary` — canary NOT present in output bundle
- [x] `frontier-connect` fallback URL still present in bundle
- [x] No other env vars leaked (`VAULT_ADDR`, `GOPRIVATE`, `SHELL` etc. all absent)