### PR TITLE
chore(sdk): use Apsara coin icons in org tokens side panel

### DIFF
--- a/web/sdk/admin/views/organizations/details/side-panel/tokens-details-section.tsx
+++ b/web/sdk/admin/views/organizations/details/side-panel/tokens-details-section.tsx
@@ -1,6 +1,6 @@
 import { List, Text, Flex } from "@raystack/apsara";
+import { CoinIcon, CoinColoredIcon } from "@raystack/apsara/icons";
 import styles from "./side-panel.module.css";
-import { MixIcon } from "@radix-ui/react-icons";
 import { useContext, useEffect } from "react";
 import Skeleton from "react-loading-skeleton";
 import { OrganizationContext } from "../contexts/organization-context";
@@ -52,7 +52,7 @@ export const TokensDetailsSection = () => {
             <Skeleton />
           ) : (
             <Flex gap={3}>
-              <MixIcon />
+              <CoinColoredIcon />
               <Text>{tokenBalance}</Text>
             </Flex>
           )}
@@ -67,7 +67,7 @@ export const TokensDetailsSection = () => {
             <Skeleton />
           ) : (
             <Flex gap={3}>
-              <MixIcon style={{ color: "var(--rs-color-foreground-base-tertiary)" }} />
+              <CoinIcon style={{ color: "var(--rs-color-foreground-base-tertiary)" }} />
               <Text>{tokensUsed}</Text>
             </Flex>
           )}


### PR DESCRIPTION
Replace `MixIcon` with `CoinColoredIcon` (Available tokens) and `CoinIcon` (Used till date) in the organization details side panel.

<img width="387" height="276" alt="Screenshot 2026-05-12 at 11 50 43 AM" src="https://github.com/user-attachments/assets/c54d0d36-33f6-4ac4-93da-07664d2cf900" />
