### PR TITLE
chore(client-demo): bump Apsara to v1.0.0-rc.6

### DIFF
--- a/web/apps/client-demo/package.json
+++ b/web/apps/client-demo/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
-    "@raystack/apsara": "1.0.0-rc.2",
+    "@raystack/apsara": "1.0.0-rc.6",
     "@raystack/frontier": "workspace:^",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/web/apps/client-demo/src/pages/Home.tsx
+++ b/web/apps/client-demo/src/pages/Home.tsx
@@ -301,12 +301,12 @@ export default function Home() {
       >
         <Navbar>
           <Navbar.Start>
-            <Text size="large" weight="bold">
+            <Text size="large" weight="medium">
               {t.appName()}
             </Text>
           </Navbar.Start>
           <Navbar.End>
-            <Flex align="center" gap="small">
+            <Flex align="center" gap={3}>
               {showSearch ? (
                 <DataTable.Search
                   autoFocus

--- a/web/apps/client-demo/src/pages/Settings.tsx
+++ b/web/apps/client-demo/src/pages/Settings.tsx
@@ -45,7 +45,7 @@ export default function Settings() {
       <Sidebar defaultOpen>
         <Sidebar.Header>
           <Flex align="center" gap={3}>
-            <Text size={4} weight="medium" data-collapse-hidden>
+            <Text size="regular" weight="medium" data-collapse-hidden>
               Settings
             </Text>
           </Flex>
@@ -58,7 +58,7 @@ export default function Settings() {
               return (
                 <Sidebar.Item
                   key={item.path}
-                  as={<Link to={fullPath} />}
+                  render={<Link to={fullPath} />}
                   active={isActive}
                   data-test-id={`[settings-nav-${item.path}]`}
                 >

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.2(react@19.2.4)
       '@raystack/apsara':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 1.0.0-rc.6
+        version: 1.0.0-rc.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@raystack/frontier':
         specifier: workspace:^
         version: link:../../sdk
@@ -2219,17 +2219,6 @@ packages:
       '@types/react': ^18 || ^19
       react: ^18 || ^19
       react-dom: ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@raystack/apsara@1.0.0-rc.2':
-    resolution: {integrity: sha512-uhnN4PX7xSfL/huupfXpe2tJjykON2rPECdtKGFPE8JWGTFNMou9dJyXrj0NOYu0guRmQchBp7+uLjoKUojxoA==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      '@types/react': ^19
-      react: ^19
-      react-dom: ^19
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -9527,28 +9516,6 @@ snapshots:
       react-day-picker: 9.14.0(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
       sonner: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 19.2.14
-    transitivePeerDependencies:
-      - '@types/react-dom'
-
-  '@raystack/apsara@1.0.0-rc.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@base-ui/utils': 0.2.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-icons': 1.3.2(react@19.2.4)
-      '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/react-table': 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/react-virtual': 3.13.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/table-core': 8.21.3
-      class-variance-authority: 0.7.1
-      cmdk: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      color: 5.0.3
-      dayjs: 1.11.19
-      prism-react-renderer: 2.4.1(react@19.2.4)
-      react: 19.2.4
-      react-day-picker: 9.14.0(react@19.2.4)
-      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Bump `@raystack/apsara` in `apps/client-demo` from `1.0.0-rc.2` → `1.0.0-rc.6`.
- Fix 4 type errors surfaced by the bump per the v1 migration guide:
  - `<Text weight="bold">` → `weight="medium"`
  - `<Flex gap="small">` → `gap={3}`
  - `<Text size={4}>` → `size="regular"`
  - `<Sidebar.Item as={<Link/>}>` → `render={<Link/>}`

## Test plan
- [ ] `pnpm exec tsc --noEmit` in `apps/client-demo` — pre-existing 3 baseline errors only (in `api/frontier.ts` and `config/frontier.ts`, unrelated to apsara)
- [ ] `pnpm vite build` succeeds
- [ ] Visual: sign-in, sign-up, magic-link verify, updates, settings pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)