### PR TITLE
fix(sdk): remove orgId from project update requests

### DIFF
--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "0.56.6",
     "@raystack/frontier": "workspace:^",
-    "@raystack/proton": "0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3",
+    "@raystack/proton": "0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "0.56.6",
     "@raystack/frontier": "workspace:^",
-    "@raystack/proton": "0.1.0-fe747c0278b08e54b16540b091d980d1b166f948",
+    "@raystack/proton": "0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "0.56.6",
     "@raystack/frontier": "workspace:^",
-    "@raystack/proton": "0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3",
+    "@raystack/proton": "0.1.0-fe747c0278b08e54b16540b091d980d1b166f948",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:../../sdk
       '@raystack/proton':
-        specifier: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3
-        version: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948
+        version: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.2.4)
@@ -228,8 +228,8 @@ importers:
         specifier: npm:@raystack/apsara@1.0.0-rc.6
         version: '@raystack/apsara@1.0.0-rc.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       '@raystack/proton':
-        specifier: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3
-        version: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948
+        version: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -2234,8 +2234,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3':
-    resolution: {integrity: sha512-M3xF5gUqiPnam9Wb7qEsEECTqKYF0yZQJihkmNvHBs5fMA+b5A/lyUujwCTYYFJwk10V8Trr1t4v9uQ19gCoww==}
+  '@raystack/proton@0.1.0-fe747c0278b08e54b16540b091d980d1b166f948':
+    resolution: {integrity: sha512-57ayc3m2zwECG/pjIhYaOuAznJbWp0UelMGRGcrbFCfjOZJt2rE1gs7nmhRap14jmQs5Zo0lizzhgSdmaWG/fQ==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -9540,7 +9540,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@raystack/proton@0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-fe747c0278b08e54b16540b091d980d1b166f948(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:../../sdk
       '@raystack/proton':
-        specifier: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948
-        version: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3
+        version: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.2.4)
@@ -228,8 +228,8 @@ importers:
         specifier: npm:@raystack/apsara@1.0.0-rc.6
         version: '@raystack/apsara@1.0.0-rc.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       '@raystack/proton':
-        specifier: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948
-        version: 0.1.0-fe747c0278b08e54b16540b091d980d1b166f948(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3
+        version: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -2234,8 +2234,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-fe747c0278b08e54b16540b091d980d1b166f948':
-    resolution: {integrity: sha512-57ayc3m2zwECG/pjIhYaOuAznJbWp0UelMGRGcrbFCfjOZJt2rE1gs7nmhRap14jmQs5Zo0lizzhgSdmaWG/fQ==}
+  '@raystack/proton@0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3':
+    resolution: {integrity: sha512-M3xF5gUqiPnam9Wb7qEsEECTqKYF0yZQJihkmNvHBs5fMA+b5A/lyUujwCTYYFJwk10V8Trr1t4v9uQ19gCoww==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -9540,7 +9540,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@raystack/proton@0.1.0-fe747c0278b08e54b16540b091d980d1b166f948(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:../../sdk
       '@raystack/proton':
-        specifier: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3
-        version: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e
+        version: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.2.4)
@@ -228,8 +228,8 @@ importers:
         specifier: npm:@raystack/apsara@1.0.0-rc.6
         version: '@raystack/apsara@1.0.0-rc.6(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       '@raystack/proton':
-        specifier: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3
-        version: 0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e
+        version: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -2234,8 +2234,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3':
-    resolution: {integrity: sha512-M3xF5gUqiPnam9Wb7qEsEECTqKYF0yZQJihkmNvHBs5fMA+b5A/lyUujwCTYYFJwk10V8Trr1t4v9uQ19gCoww==}
+  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e':
+    resolution: {integrity: sha512-82QvGoJjcp5zGt/QIkdSJEn2iX8vn/g2H4jm8O3QH3YIZuZp0bXFXo+ddD5S49tSUtWiegi7qWJargHgBceLPg==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -9540,7 +9540,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@raystack/proton@0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/sdk/admin/views/organizations/details/projects/rename-project.tsx
+++ b/web/sdk/admin/views/organizations/details/projects/rename-project.tsx
@@ -15,7 +15,6 @@ import { useTerminology } from "../../../../hooks/useTerminology";
 const projectRenameSchema = z.object({
   title: z.string(),
   name: z.string(),
-  orgId: z.string(),
 });
 
 type ProjectRenameSchema = z.infer<typeof projectRenameSchema>;
@@ -46,7 +45,6 @@ export function RenameProjectDialog({
     defaultValues: {
       title: project?.title,
       name: project?.name,
-      orgId: project?.organizationId,
     },
     resolver: zodResolver(projectRenameSchema),
   });

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -108,7 +108,7 @@
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
     "@raystack/apsara-v1": "npm:@raystack/apsara@1.0.0-rc.6",
-    "@raystack/proton": "0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3",
+    "@raystack/proton": "0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -108,7 +108,7 @@
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
     "@raystack/apsara-v1": "npm:@raystack/apsara@1.0.0-rc.6",
-    "@raystack/proton": "0.1.0-fe747c0278b08e54b16540b091d980d1b166f948",
+    "@raystack/proton": "0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -108,7 +108,7 @@
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
     "@raystack/apsara-v1": "npm:@raystack/apsara@1.0.0-rc.6",
-    "@raystack/proton": "0.1.0-7523cfd3a676d3fb72d63c8c4f0476738a2217b3",
+    "@raystack/proton": "0.1.0-fe747c0278b08e54b16540b091d980d1b166f948",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",

--- a/web/sdk/react/views-new/projects/components/edit-project-dialog.tsx
+++ b/web/sdk/react/views-new/projects/components/edit-project-dialog.tsx
@@ -14,7 +14,6 @@ import { toastManager } from '@raystack/apsara-v1';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
-import { useFrontier } from '../../../contexts/FrontierContext';
 import { useMutation } from '@connectrpc/connect-query';
 import {
   FrontierServiceQueries,
@@ -88,7 +87,6 @@ function EditProjectForm({ payload, handle, refetch }: EditProjectFormProps) {
     }
   });
 
-  const { activeOrganization: organization } = useFrontier();
   const privacy = watch('privacy');
 
   const { mutateAsync: updateProject } = useMutation(
@@ -103,15 +101,14 @@ function EditProjectForm({ payload, handle, refetch }: EditProjectFormProps) {
   }, [payload.projectId, payload.title, reset]);
 
   async function onSubmit(data: FormData) {
-    if (!organization?.id || !payload.projectId) return;
+    if (!payload.projectId) return;
 
     try {
       await updateProject(
         create(UpdateProjectRequestSchema, {
           id: payload.projectId,
           body: {
-            title: data.title,
-            orgId: organization.id
+            title: data.title
           }
         })
       );

--- a/web/sdk/react/views-new/projects/project-details-view.tsx
+++ b/web/sdk/react/views-new/projects/project-details-view.tsx
@@ -125,8 +125,7 @@ export function ProjectDetailsView({
   } = useQuery(
     FrontierServiceQueries.listProjectUsers,
     create(ListProjectUsersRequestSchema, {
-      id: projectId || '',
-      withRoles: true
+      id: projectId || ''
     }),
     { enabled: !!organization?.id && !!projectId }
   );
@@ -153,8 +152,7 @@ export function ProjectDetailsView({
   } = useQuery(
     FrontierServiceQueries.listProjectGroups,
     create(ListProjectGroupsRequestSchema, {
-      id: projectId || '',
-      withRoles: true
+      id: projectId || ''
     }),
     { enabled: !!organization?.id && !!projectId }
   );

--- a/web/sdk/react/views-new/teams/team-details-view.tsx
+++ b/web/sdk/react/views-new/teams/team-details-view.tsx
@@ -121,8 +121,7 @@ export function TeamDetailsView({
     FrontierServiceQueries.listGroupUsers,
     create(ListGroupUsersRequestSchema, {
       id: teamId || '',
-      orgId: organization?.id || '',
-      withRoles: true
+      orgId: organization?.id || ''
     }),
     { enabled: !!organization?.id && !!teamId }
   );


### PR DESCRIPTION
## Summary
- Remove `orgId` field from project update request bodies in the frontend SDK
- Applies to both the client-side edit project dialog (`views-new`) and the admin rename project dialog
- Backend already enforces org immutability on UpdateProject (f4d3398f), so sending `orgId` is unnecessary

## Test plan
- [ ] Login to client-demo, edit a project name — verify update succeeds without errors
- [ ] Login to admin UI, rename a project — verify rename succeeds without errors
- [ ] Verify network tab shows no `orgId` in the UpdateProject request body