### PR TITLE
fix(sdk): forward existing project name in edit-project update

### DIFF
--- a/web/sdk/react/views-new/projects/components/edit-project-dialog.tsx
+++ b/web/sdk/react/views-new/projects/components/edit-project-dialog.tsx
@@ -34,6 +34,7 @@ type FormData = yup.InferType<typeof editProjectSchema>;
 
 export interface EditProjectPayload {
   projectId: string;
+  name: string;
   title: string;
 }
 
@@ -108,6 +109,7 @@ function EditProjectForm({ payload, handle, refetch }: EditProjectFormProps) {
         create(UpdateProjectRequestSchema, {
           id: payload.projectId,
           body: {
+            name: payload.name,
             title: data.title
           }
         })

--- a/web/sdk/react/views-new/projects/components/project-columns.tsx
+++ b/web/sdk/react/views-new/projects/components/project-columns.tsx
@@ -13,6 +13,7 @@ import { MembersCell } from './members-cell';
 
 export interface ProjectMenuPayload {
   projectId: string;
+  name: string;
   title: string;
   canUpdate: boolean;
   canDelete: boolean;
@@ -88,6 +89,7 @@ export const getColumns = ({
               handle={menuHandle}
               payload={{
                 projectId: project.id || '',
+                name: project.name || '',
                 title: project.title || '',
                 canUpdate,
                 canDelete

--- a/web/sdk/react/views-new/projects/project-details-view.tsx
+++ b/web/sdk/react/views-new/projects/project-details-view.tsx
@@ -319,6 +319,7 @@ export function ProjectDetailsView({
   }, [onDeleteSuccess]);
 
   const projectTitle = project?.title || '';
+  const projectName = project?.name || '';
 
   return (
     <ViewContainer>
@@ -349,6 +350,7 @@ export function ProjectDetailsView({
         {!isLoading && (canUpdateProject || canDeleteProject) && (
           <ProjectActionsMenu
             projectId={projectId}
+            projectName={projectName}
             projectTitle={projectTitle}
             canUpdate={canUpdateProject}
             canDelete={canDeleteProject}
@@ -480,6 +482,7 @@ export function ProjectDetailsView({
 
 interface ProjectActionsMenuProps {
   projectId: string;
+  projectName: string;
   projectTitle: string;
   canUpdate: boolean;
   canDelete: boolean;
@@ -489,6 +492,7 @@ const projectActionsMenuHandle = Menu.createHandle();
 
 function ProjectActionsMenu({
   projectId,
+  projectName,
   projectTitle,
   canUpdate,
   canDelete
@@ -515,6 +519,7 @@ function ProjectActionsMenu({
               onClick={() =>
                 editProjectDialogHandle.openWithPayload({
                   projectId,
+                  name: projectName,
                   title: projectTitle
                 })
               }

--- a/web/sdk/react/views-new/projects/projects-view.tsx
+++ b/web/sdk/react/views-new/projects/projects-view.tsx
@@ -229,6 +229,7 @@ export function ProjectsView({
                   onClick={() =>
                     editProjectDialogHandle.openWithPayload({
                       projectId: payload.projectId,
+                      name: payload.name,
                       title: payload.title
                     })
                   }


### PR DESCRIPTION
## Summary
- Edit-project dialog was sending only `title` in `UpdateProjectRequestBody`, but the proto requires `name` (validated against `^[A-Za-z0-9-_]+$`) so the server rejected the update.
- Threaded the existing project `name` through `ProjectMenuPayload`, the details-view actions menu, and `EditProjectPayload` so it's forwarded unchanged in the update body.
- `name` stays non-editable in the UI — matches the convention used by `project-general.tsx`, `rename-project.tsx`, and the team-edit dialog.