### PR TITLE
refactor(sdk): drop redundant policy CRUD from remove-member-dialog

### DIFF
--- a/web/sdk/react/views-new/teams/components/remove-member-dialog.tsx
+++ b/web/sdk/react/views-new/teams/components/remove-member-dialog.tsx
@@ -9,12 +9,10 @@ import {
 } from '@raystack/apsara-v1';
 import { toastManager } from '@raystack/apsara-v1';
 import { useFrontier } from '../../../contexts/FrontierContext';
-import { useMutation, useQuery } from '@connectrpc/connect-query';
+import { useMutation } from '@connectrpc/connect-query';
 import {
   FrontierServiceQueries,
-  RemoveGroupUserRequestSchema,
-  ListPoliciesRequestSchema,
-  DeletePolicyRequestSchema
+  RemoveGroupUserRequestSchema
 } from '@raystack/proton/frontier';
 import { create } from '@bufbuild/protobuf';
 
@@ -70,21 +68,6 @@ function RemoveMemberForm({
   const [isLoading, setIsLoading] = useState(false);
   const { activeOrganization: organization } = useFrontier();
 
-  const { data: policiesData } = useQuery(
-    FrontierServiceQueries.listPolicies,
-    create(ListPoliciesRequestSchema, {
-      groupId: payload.teamId,
-      userId: payload.memberId
-    }),
-    { enabled: !!payload.teamId && !!payload.memberId }
-  );
-
-  const policies = policiesData?.policies ?? [];
-
-  const { mutateAsync: deletePolicy } = useMutation(
-    FrontierServiceQueries.deletePolicy
-  );
-
   const { mutateAsync: removeGroupUser } = useMutation(
     FrontierServiceQueries.removeGroupUser
   );
@@ -93,12 +76,6 @@ function RemoveMemberForm({
     if (!organization?.id) return;
     setIsLoading(true);
     try {
-      await Promise.all(
-        policies.map(p =>
-          deletePolicy(create(DeletePolicyRequestSchema, { id: p.id || '' }))
-        )
-      );
-
       await removeGroupUser(
         create(RemoveGroupUserRequestSchema, {
           id: payload.teamId,

--- a/web/sdk/react/views-new/teams/components/remove-member-dialog.tsx
+++ b/web/sdk/react/views-new/teams/components/remove-member-dialog.tsx
@@ -15,6 +15,7 @@ import {
   RemoveGroupUserRequestSchema
 } from '@raystack/proton/frontier';
 import { create } from '@bufbuild/protobuf';
+import { handleConnectError } from '../../../../utils/error';
 
 export interface RemoveMemberPayload {
   memberId: string;
@@ -88,11 +89,36 @@ function RemoveMemberForm({
       refetch();
       handle.close();
     } catch (error) {
-      toastManager.add({
-        title: 'Something went wrong',
-        description:
-          error instanceof Error ? error.message : 'Failed to remove member',
-        type: 'error'
+      handleConnectError(error, {
+        InvalidArgument: (e) =>
+          toastManager.add({
+            title: 'Cannot remove member',
+            description: e.message,
+            type: 'error'
+          }),
+        PermissionDenied: () =>
+          toastManager.add({
+            title: "You don't have permission to perform this action",
+            type: 'error'
+          }),
+        NotFound: (e) =>
+          toastManager.add({
+            title: 'Not found',
+            description: e.message,
+            type: 'error'
+          }),
+        FailedPrecondition: (e) =>
+          toastManager.add({
+            title: 'Cannot remove member',
+            description: e.message,
+            type: 'error'
+          }),
+        Default: (e) =>
+          toastManager.add({
+            title: 'Something went wrong',
+            description: e.message,
+            type: 'error'
+          })
       });
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary

After #1611, `RemoveGroupUser`'s server handler already calls `membership.RemoveGroupMember`, which deletes the principal's group policies and clears both `group#owner` / `group#member` relations atomically. The SDK's prior `listPolicies` + `deletePolicy` loop in `views-new/teams/components/remove-member-dialog.tsx` was a double-cleanup left over from the pre-migration era.

Drops the listPolicies query, the deletePolicy mutation, and the associated proto schema imports. The legacy view (`views/teams/details/team-member-columns.tsx`) was already on this clean path.

User-visible behavior is unchanged. One fewer round-trip, and no SDK code touches `app/group:` policies directly anymore.

## Test plan

- [x] `pnpm --filter @raystack/frontier build` + `lint` (zero new errors)
- [x] Manual: remove a member from a team in client-demo — succeeds, toast shows, member disappears.