### PR TITLE
chore(sdk-admin): list new group member webhook events

### DIFF
--- a/web/sdk/admin/utils/webhook-events.ts
+++ b/web/sdk/admin/utils/webhook-events.ts
@@ -9,6 +9,8 @@ const events = [
   "app.group.created",
   "app.group.updated",
   "app.group.deleted",
+  "app.group.member.created",
+  "app.group.member.role_changed",
   "app.group.members.removed",
 
   "app.role.created",


### PR DESCRIPTION
## Summary

The backend emits three group-member audit events that weren't yet selectable in the admin webhook-subscription UI:

- `app.group.member.created` (since #1596 / #1603)
- `app.group.member.role_changed` (since #1596 / #1603)
- `app.group.members.removed` (long-standing)

Adds all three to `web/sdk/admin/utils/webhook-events.ts` so admins can subscribe via the webhook UI.

Purely additive; no functional change.