### PR TITLE
fix(api): replace raw error responses with generic ErrInternalServerError

### DIFF
--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -296,6 +296,7 @@ func (h *ConnectHandler) getLoggedInSessionID(ctx context.Context) (uuid.UUID, e
 }
 
 func (h *ConnectHandler) GetLoggedInPrincipal(ctx context.Context, via ...authenticate.ClientAssertion) (authenticate.Principal, error) {
+	errorLogger := NewErrorLogger()
 	principal, err := h.authnService.GetPrincipal(ctx, via...)
 	if err != nil {
 		switch {
@@ -309,7 +310,6 @@ func (h *ConnectHandler) GetLoggedInPrincipal(ctx context.Context, via ...authen
 			errors.Is(err, patErrors.ErrDisabled):
 			return principal, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 		default:
-			errorLogger := NewErrorLogger()
 			errorLogger.LogUnexpectedError(ctx, nil, "GetLoggedInPrincipal", err)
 			return principal, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}

--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -310,7 +309,8 @@ func (h *ConnectHandler) GetLoggedInPrincipal(ctx context.Context, via ...authen
 			errors.Is(err, patErrors.ErrDisabled):
 			return principal, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 		default:
-			slog.ErrorContext(ctx, "unexpected error in GetLoggedInPrincipal", "error", err)
+			errorLogger := NewErrorLogger()
+			errorLogger.LogUnexpectedError(ctx, nil, "GetLoggedInPrincipal", err)
 			return principal, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}

--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -21,9 +21,7 @@ import (
 	"github.com/raystack/frontier/pkg/server/consts"
 	sessionutils "github.com/raystack/frontier/pkg/session"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -44,7 +42,7 @@ func (h *ConnectHandler) Authenticate(ctx context.Context, request *connect.Requ
 		return resp, nil
 	} else if err != nil && !errors.Is(err, frontiersession.ErrNoSession) {
 		errorLogger.LogUnexpectedError(ctx, request, "Authenticate", err)
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
 	if (request.Msg.GetStrategyName() == authenticate.MailLinkAuthMethod.String() || request.Msg.GetStrategyName() == authenticate.MailOTPAuthMethod.String()) && !isValidEmail(request.Msg.GetEmail()) {

--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -309,6 +310,7 @@ func (h *ConnectHandler) GetLoggedInPrincipal(ctx context.Context, via ...authen
 			errors.Is(err, patErrors.ErrDisabled):
 			return principal, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 		default:
+			slog.ErrorContext(ctx, "unexpected error in GetLoggedInPrincipal", "error", err)
 			return principal, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}

--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -62,7 +62,7 @@ func (h *ConnectHandler) Authenticate(ctx context.Context, request *connect.Requ
 		errorLogger.LogUnexpectedError(ctx, request, "Authenticate", err,
 			"strategy", request.Msg.GetStrategyName(),
 			"email", request.Msg.GetEmail())
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
 	// set location header for redirect to start auth?
@@ -80,14 +80,14 @@ func (h *ConnectHandler) Authenticate(ctx context.Context, request *connect.Requ
 		if err = userCredentils.UnmarshalJSON(response.StateConfig["options"].([]byte)); err != nil {
 			errorLogger.LogUnexpectedError(ctx, request, "Authenticate", err,
 				"strategy", authenticate.PassKeyAuthMethod.String())
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 		typeValue, ok := response.Flow.Metadata["passkey_type"].(string)
 		if !ok {
 			err = fmt.Errorf("passkey_type metadata is not a string")
 			errorLogger.LogUnexpectedError(ctx, request, "Authenticate", err,
 				"strategy", authenticate.PassKeyAuthMethod.String())
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 		stringValue := &structpb.Value{
 			Kind: &structpb.Value_StringValue{
@@ -128,7 +128,7 @@ func (h *ConnectHandler) AuthCallback(ctx context.Context, request *connect.Requ
 		errorLogger.LogUnexpectedError(ctx, request, "AuthCallback", err,
 			"strategy", request.Msg.GetStrategyName(),
 			"state", request.Msg.GetState())
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
 	// Extract session metadata from request headers
@@ -139,7 +139,7 @@ func (h *ConnectHandler) AuthCallback(ctx context.Context, request *connect.Requ
 	if err != nil {
 		errorLogger.LogUnexpectedError(ctx, request, "AuthCallback", err,
 			"user_id", response.User.ID)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	// create response and set headers
 	resp := connect.NewResponse(&frontierv1beta1.AuthCallbackResponse{})
@@ -186,7 +186,7 @@ func (h *ConnectHandler) AuthToken(ctx context.Context, request *connect.Request
 	if err != nil {
 		errorLogger.LogUnexpectedError(ctx, request, "AuthToken", err,
 			"grant_type", request.Msg.GetGrantType())
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
 	if principal.Type == schema.ServiceUserPrincipal {
@@ -196,7 +196,7 @@ func (h *ConnectHandler) AuthToken(ctx context.Context, request *connect.Request
 			errorLogger.LogUnexpectedError(ctx, request, "AuthToken", err,
 				"org_id", orgId,
 				"service_user_id", principal.ServiceUser.ID)
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 
@@ -205,7 +205,7 @@ func (h *ConnectHandler) AuthToken(ctx context.Context, request *connect.Request
 		errorLogger.LogUnexpectedError(ctx, request, "AuthToken", err,
 			"principal_id", principal.ID,
 			"principal_type", principal.Type)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
 	resp := connect.NewResponse(&frontierv1beta1.AuthTokenResponse{
@@ -276,7 +276,7 @@ func (h *ConnectHandler) AuthLogout(ctx context.Context, request *connect.Reques
 		if err = h.sessionService.Delete(ctx, sessionID); err != nil {
 			errorLogger.LogUnexpectedError(ctx, request, "AuthLogout", err,
 				"session_id", sessionID.String())
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 
@@ -309,7 +309,7 @@ func (h *ConnectHandler) GetLoggedInPrincipal(ctx context.Context, via ...authen
 			errors.Is(err, patErrors.ErrDisabled):
 			return principal, connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
 		default:
-			return principal, connect.NewError(connect.CodeInternal, err)
+			return principal, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 	return principal, nil

--- a/internal/api/v1beta1connect/authenticate_test.go
+++ b/internal/api/v1beta1connect/authenticate_test.go
@@ -115,14 +115,9 @@ func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.expectedErr != nil {
-					if tt.expectedErr == organization.ErrDisabled {
-						connectErr := err.(*connect.Error)
-						assert.Equal(t, connect.CodeInternal, connectErr.Code())
-						assert.Contains(t, connectErr.Message(), "org is disabled")
-					} else {
-						connectErr := err.(*connect.Error)
-						assert.Equal(t, connect.CodeInternal, connectErr.Code())
-					}
+					connectErr := err.(*connect.Error)
+					assert.Equal(t, connect.CodeInternal, connectErr.Code())
+					assert.Equal(t, "internal server error", connectErr.Message())
 				}
 				assert.Nil(t, resp)
 			} else {

--- a/internal/api/v1beta1connect/authorize.go
+++ b/internal/api/v1beta1connect/authorize.go
@@ -115,7 +115,7 @@ func (h *ConnectHandler) IsSuperUser(ctx context.Context, request connect.AnyReq
 			errorLogger.LogUnexpectedError(ctx, request, "IsSuperUser", err,
 				"user_id", currentUser.ID,
 				"permission", schema.PlatformSudoPermission)
-			return connect.NewError(connect.CodeInternal, err)
+			return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		} else if ok {
 			return nil
 		}
@@ -124,7 +124,7 @@ func (h *ConnectHandler) IsSuperUser(ctx context.Context, request connect.AnyReq
 			errorLogger.LogUnexpectedError(ctx, request, "IsSuperUser", err,
 				"service_user_id", currentUser.ID,
 				"permission", schema.PlatformSudoPermission)
-			return connect.NewError(connect.CodeInternal, err)
+			return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		} else if ok {
 			return nil
 		}

--- a/internal/api/v1beta1connect/kyc.go
+++ b/internal/api/v1beta1connect/kyc.go
@@ -33,7 +33,7 @@ func (h *ConnectHandler) SetOrganizationKyc(ctx context.Context, request *connec
 				"org_id", request.Msg.GetOrgId(),
 				"status", request.Msg.GetStatus(),
 				"link", request.Msg.GetLink())
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 
@@ -63,7 +63,7 @@ func (h *ConnectHandler) GetOrganizationKyc(ctx context.Context, request *connec
 		default:
 			errorLogger.LogServiceError(ctx, request, "GetOrganizationKyc.GetKyc", err,
 				"org_id", request.Msg.GetOrgId())
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 	return connect.NewResponse(&frontierv1beta1.GetOrganizationKycResponse{OrganizationKyc: transformOrgKycToPB(orgKyc)}), nil
@@ -79,7 +79,7 @@ func (h *ConnectHandler) ListOrganizationsKyc(ctx context.Context, request *conn
 			return nil, connect.NewError(connect.CodeNotFound, kyc.ErrNotExist)
 		default:
 			errorLogger.LogServiceError(ctx, request, "ListOrganizationsKyc.ListKycs", err)
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 	resp := make([]*frontierv1beta1.OrganizationKyc, len(orgKycs))

--- a/internal/api/v1beta1connect/kyc_test.go
+++ b/internal/api/v1beta1connect/kyc_test.go
@@ -86,7 +86,7 @@ func TestSetOrganizationKyc(t *testing.T) {
 			}),
 			mockError:     errors.New("internal error"),
 			expectError:   true,
-			expectedError: connect.NewError(connect.CodeInternal, errors.New("internal error")),
+			expectedError: connect.NewError(connect.CodeInternal, errors.New("internal server error")),
 		},
 	}
 
@@ -241,7 +241,7 @@ func TestListOrganizationsKyc(t *testing.T) {
 			mockService:   mocks.NewKycService(t),
 			mockResponse:  nil,
 			mockError:     errors.New("internal error"),
-			expectError:   connect.NewError(connect.CodeInternal, errors.New("internal error")),
+			expectError:   connect.NewError(connect.CodeInternal, errors.New("internal server error")),
 			expectNilResp: true,
 		},
 	}

--- a/internal/api/v1beta1connect/organization.go
+++ b/internal/api/v1beta1connect/organization.go
@@ -41,14 +41,14 @@ func (h *ConnectHandler) GetOrganization(ctx context.Context, request *connect.R
 		default:
 			errorLogger.LogServiceError(ctx, request, "GetOrganization.GetRaw", err,
 				"org_id", request.Msg.GetId())
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 
 	orgPB, err := transformOrgToPB(fetchedOrg)
 	if err != nil {
 		errorLogger.LogTransformError(ctx, request, "GetOrganization", fetchedOrg.ID, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.GetOrganizationResponse{

--- a/internal/api/v1beta1connect/role.go
+++ b/internal/api/v1beta1connect/role.go
@@ -239,7 +239,7 @@ func (h *ConnectHandler) CreateOrganizationRole(ctx context.Context, request *co
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "CreateOrganizationRole.GetOrganization", err,
 			"org_id", request.Msg.GetOrgId())
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	metaDataMap[orgNameMetadataKey] = org.Title
 
@@ -341,7 +341,7 @@ func (h *ConnectHandler) UpdateOrganizationRole(ctx context.Context, request *co
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "UpdateOrganizationRole.GetOrganization", err,
 			"org_id", request.Msg.GetOrgId())
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	metaDataMap[orgNameMetadataKey] = org.Title
 

--- a/internal/api/v1beta1connect/serviceuser.go
+++ b/internal/api/v1beta1connect/serviceuser.go
@@ -104,14 +104,14 @@ func (h *ConnectHandler) GetServiceUser(ctx context.Context, request *connect.Re
 		default:
 			errorLogger.LogUnexpectedError(ctx, request, "GetServiceUser", err,
 				"service_user_id", serviceUserID)
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}
 
 	svUserPb, err := transformServiceUserToPB(svUser)
 	if err != nil {
 		errorLogger.LogTransformError(ctx, request, "GetServiceUser", svUser.ID, err)
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	return connect.NewResponse(&frontierv1beta1.GetServiceUserResponse{
 		Serviceuser: svUserPb,


### PR DESCRIPTION
## Summary
- 21 call sites across 6 handler files were returning raw internal errors to clients via `connect.NewError(connect.CodeInternal, err)`, leaking DB table names, OIDC config, SMTP details, SpiceDB addresses, and file paths
- Replaced all with `connect.NewError(connect.CodeInternal, ErrInternalServerError)` which returns a generic `"internal server error"` message
- All call sites already had `errorLogger.LogUnexpectedError` / `errorLogger.LogServiceError` calls logging the real error server-side before returning

## Files changed
- `authenticate.go` — 10 fixes (unauthenticated endpoints, highest risk)
- `authorize.go` — 2 fixes
- `kyc.go` — 3 fixes
- `organization.go` — 2 fixes
- `role.go` — 2 fixes
- `serviceuser.go` — 2 fixes

## Test plan
- [x] `go build` and `go vet` pass
- [x] Zero remaining `connect.NewError(connect.CodeInternal, err)` in handler files
- [ ] Verify error responses return generic message, not raw error details