### PR TITLE
fix(api): return CodeFailedPrecondition for disabled org in AuthToken

### DIFF
--- a/internal/api/v1beta1connect/authenticate.go
+++ b/internal/api/v1beta1connect/authenticate.go
@@ -191,9 +191,12 @@ func (h *ConnectHandler) AuthToken(ctx context.Context, request *connect.Request
 		orgId := principal.ServiceUser.OrgID
 		_, err := h.orgService.Get(ctx, orgId)
 		if err != nil {
-			errorLogger.LogUnexpectedError(ctx, request, "AuthToken", err,
+			errorLogger.LogServiceError(ctx, request, "AuthToken.orgService.Get", err,
 				"org_id", orgId,
 				"service_user_id", principal.ServiceUser.ID)
+			if errors.Is(err, organization.ErrDisabled) {
+				return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
+			}
 			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}

--- a/internal/api/v1beta1connect/authenticate_test.go
+++ b/internal/api/v1beta1connect/authenticate_test.go
@@ -116,8 +116,13 @@ func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
 				assert.Error(t, err)
 				if tt.expectedErr != nil {
 					connectErr := err.(*connect.Error)
-					assert.Equal(t, connect.CodeInternal, connectErr.Code())
-					assert.Equal(t, "internal server error", connectErr.Message())
+					if tt.expectedErr == organization.ErrDisabled {
+						assert.Equal(t, connect.CodeFailedPrecondition, connectErr.Code())
+						assert.Contains(t, connectErr.Message(), "org is disabled")
+					} else {
+						assert.Equal(t, connect.CodeInternal, connectErr.Code())
+						assert.Equal(t, "internal server error", connectErr.Message())
+					}
 				}
 				assert.Nil(t, resp)
 			} else {

--- a/internal/api/v1beta1connect/domain.go
+++ b/internal/api/v1beta1connect/domain.go
@@ -20,7 +20,7 @@ func (h *ConnectHandler) CreateOrganizationDomain(ctx context.Context, request *
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -57,7 +57,7 @@ func (h *ConnectHandler) DeleteOrganizationDomain(ctx context.Context, request *
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -89,7 +89,7 @@ func (h *ConnectHandler) GetOrganizationDomain(ctx context.Context, request *con
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -135,7 +135,7 @@ func (h *ConnectHandler) JoinOrganization(ctx context.Context, request *connect.
 		case errors.Is(err, user.ErrDisabled):
 			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		case errors.Is(err, membership.ErrInvalidOrgRole):
@@ -160,7 +160,7 @@ func (h *ConnectHandler) VerifyOrganizationDomain(ctx context.Context, request *
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -197,7 +197,7 @@ func (h *ConnectHandler) ListOrganizationDomains(ctx context.Context, request *c
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:

--- a/internal/api/v1beta1connect/domain_test.go
+++ b/internal/api/v1beta1connect/domain_test.go
@@ -91,7 +91,7 @@ func TestHandler_CreateOrganizationDomain(t *testing.T) {
 				Domain: "raystack.org",
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if org does not exist",
@@ -203,7 +203,7 @@ func TestHandler_DeleteOrganizationDomain(t *testing.T) {
 				Id:    testDomainID1,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if org does not exist",
@@ -306,7 +306,7 @@ func TestHandler_GetOrganizationDomain(t *testing.T) {
 				Id:    testDomainID1,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if org does not exist",
@@ -397,7 +397,7 @@ func TestHandler_JoinOrganization(t *testing.T) {
 				OrgId: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if org does not exist",
@@ -497,7 +497,7 @@ func TestHandler_ListOrganizationDomains(t *testing.T) {
 				OrgId: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if org does not exist",
@@ -587,7 +587,7 @@ func TestHandler_VerifyOrganizationDomain(t *testing.T) {
 				Id:    testDomainID1,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if org does not exist",

--- a/internal/api/v1beta1connect/group.go
+++ b/internal/api/v1beta1connect/group.go
@@ -55,7 +55,7 @@ func (h *ConnectHandler) ListOrganizationGroups(ctx context.Context, request *co
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -145,7 +145,7 @@ func (h *ConnectHandler) CreateGroup(ctx context.Context, request *connect.Reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -208,7 +208,7 @@ func (h *ConnectHandler) GetGroup(ctx context.Context, request *connect.Request[
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -275,7 +275,7 @@ func (h *ConnectHandler) UpdateGroup(ctx context.Context, request *connect.Reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -331,7 +331,7 @@ func (h *ConnectHandler) ListGroupUsers(ctx context.Context, request *connect.Re
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -399,7 +399,7 @@ func (h *ConnectHandler) RemoveGroupUser(ctx context.Context, request *connect.R
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -446,7 +446,7 @@ func (h *ConnectHandler) SetGroupMemberRole(ctx context.Context, request *connec
 	if _, err := h.orgService.Get(ctx, orgID); err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -495,7 +495,7 @@ func (h *ConnectHandler) EnableGroup(ctx context.Context, request *connect.Reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -524,7 +524,7 @@ func (h *ConnectHandler) DisableGroup(ctx context.Context, request *connect.Requ
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:
@@ -553,7 +553,7 @@ func (h *ConnectHandler) DeleteGroup(ctx context.Context, request *connect.Reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrOrgNotFound)
 		default:

--- a/internal/api/v1beta1connect/group_test.go
+++ b/internal/api/v1beta1connect/group_test.go
@@ -272,7 +272,7 @@ func TestConnectHandler_CreateGroup(t *testing.T) {
 			}),
 			want:        nil,
 			wantErr:     true,
-			wantErrCode: connect.CodeNotFound,
+			wantErrCode: connect.CodeFailedPrecondition,
 			wantErrMsg:  ErrOrgDisabled,
 		},
 		{
@@ -488,7 +488,7 @@ func TestConnectHandler_GetGroup(t *testing.T) {
 			}),
 			want:        nil,
 			wantErr:     true,
-			wantErrCode: connect.CodeNotFound,
+			wantErrCode: connect.CodeFailedPrecondition,
 			wantErrMsg:  ErrOrgDisabled,
 		},
 		{
@@ -664,7 +664,7 @@ func TestConnectHandler_UpdateGroup(t *testing.T) {
 			}),
 			want:        nil,
 			wantErr:     true,
-			wantErrCode: connect.CodeNotFound,
+			wantErrCode: connect.CodeFailedPrecondition,
 			wantErrMsg:  ErrOrgDisabled,
 		},
 		{
@@ -930,7 +930,7 @@ func TestConnectHandler_ListOrganizationGroups(t *testing.T) {
 			}),
 			want:        nil,
 			wantErr:     true,
-			wantErrCode: connect.CodeNotFound,
+			wantErrCode: connect.CodeFailedPrecondition,
 			wantErrMsg:  ErrOrgDisabled,
 		},
 		{
@@ -1046,7 +1046,7 @@ func TestConnectHandler_ListGroupUsers(t *testing.T) {
 				OrgId: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return internal server error if error in listing group users",
@@ -1270,7 +1270,7 @@ func TestConnectHandler_RemoveGroupUser(t *testing.T) {
 				UserId: randomID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found if group does not exist",
@@ -1455,7 +1455,7 @@ func TestConnectHandler_EnableGroup(t *testing.T) {
 				OrgId: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return error if group does not exist",
@@ -1540,7 +1540,7 @@ func TestConnectHandler_DisableGroup(t *testing.T) {
 				OrgId: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return error if group does not exist",
@@ -1625,7 +1625,7 @@ func TestConnectHandler_DeleteGroup(t *testing.T) {
 				OrgId: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return error if group does not exist",
@@ -1715,7 +1715,7 @@ func TestConnectHandler_SetGroupMemberRole(t *testing.T) {
 				os.EXPECT().Get(mock.Anything, testOrgID).Return(organization.Organization{}, organization.ErrDisabled)
 			},
 			request: baseRequest(),
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found if group does not exist",

--- a/internal/api/v1beta1connect/invitations.go
+++ b/internal/api/v1beta1connect/invitations.go
@@ -22,7 +22,7 @@ func (h *ConnectHandler) ListOrganizationInvitations(ctx context.Context, reques
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -143,7 +143,7 @@ func (h *ConnectHandler) CreateOrganizationInvitation(ctx context.Context, reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -203,7 +203,7 @@ func (h *ConnectHandler) GetOrganizationInvitation(ctx context.Context, request 
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -255,7 +255,7 @@ func (h *ConnectHandler) AcceptOrganizationInvitation(ctx context.Context, reque
 		case errors.Is(err, user.ErrDisabled):
 			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		case errors.Is(err, membership.ErrInvalidOrgRole):
@@ -280,7 +280,7 @@ func (h *ConnectHandler) DeleteOrganizationInvitation(ctx context.Context, reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:

--- a/internal/api/v1beta1connect/organization.go
+++ b/internal/api/v1beta1connect/organization.go
@@ -285,7 +285,7 @@ func (h *ConnectHandler) ListOrganizationProjects(ctx context.Context, request *
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -327,7 +327,7 @@ func (h *ConnectHandler) ListOrganizationAdmins(ctx context.Context, request *co
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -384,7 +384,7 @@ func (h *ConnectHandler) ListOrganizationUsers(ctx context.Context, request *con
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:
@@ -463,7 +463,7 @@ func (h *ConnectHandler) RemoveOrganizationMember(ctx context.Context, request *
 	if err := h.membershipService.RemoveOrganizationMember(ctx, orgID, principalID, principalType); err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		case errors.Is(err, membership.ErrInvalidPrincipalType):
@@ -499,7 +499,7 @@ func (h *ConnectHandler) SetOrganizationMemberRole(ctx context.Context, request 
 
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		case errors.Is(err, user.ErrNotExist):
@@ -611,7 +611,7 @@ func (h *ConnectHandler) ListOrganizationServiceUsers(ctx context.Context, reque
 	if err != nil {
 		switch {
 		case errors.Is(err, organization.ErrDisabled):
-			return nil, connect.NewError(connect.CodeNotFound, ErrOrgDisabled)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled)
 		case errors.Is(err, organization.ErrNotExist):
 			return nil, connect.NewError(connect.CodeNotFound, ErrNotFound)
 		default:

--- a/internal/api/v1beta1connect/organization_test.go
+++ b/internal/api/v1beta1connect/organization_test.go
@@ -563,7 +563,7 @@ func TestHandler_ListOrganizationProjects(t *testing.T) {
 				Id: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return internal error if org service return some error",
@@ -751,7 +751,7 @@ func TestHandler_ListOrganizationAdmins(t *testing.T) {
 				Id: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return internal error if org service return some error",
@@ -871,7 +871,7 @@ func TestHandler_ListOrganizationUsers(t *testing.T) {
 				Id: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return internal error if membership service returns an error",
@@ -989,7 +989,7 @@ func TestHandler_RemoveOrganizationMember(t *testing.T) {
 				PrincipalType: schema.UserPrincipal,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return failed precondition if not a member",
@@ -1190,7 +1190,7 @@ func TestHandler_ListOrganizationServiceUsers(t *testing.T) {
 				Id: testOrgID,
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return internal error if service user service returns error",
@@ -1294,7 +1294,7 @@ func TestHandler_SetOrganizationMemberRole(t *testing.T) {
 				RoleId: "9f256f86-31a3-11ec-8d3d-0242ac130005",
 			}),
 			want:    nil,
-			wantErr: connect.NewError(connect.CodeNotFound, ErrOrgDisabled),
+			wantErr: connect.NewError(connect.CodeFailedPrecondition, ErrOrgDisabled),
 		},
 		{
 			name: "should return not found error if user does not exist",


### PR DESCRIPTION
## Summary
- `AuthToken` returned `CodeInternal` for `organization.ErrDisabled`, treating a domain condition as an infrastructure error
- Changed to `CodeFailedPrecondition` + `ErrOrgDisabled`, matching `serviceuser.go:158` and gRPC API guidelines (caller can retry after org is re-enabled)
- Also switched from `LogUnexpectedError` to `LogServiceError` since this is an expected domain error, not unexpected
- Replaced raw `err` with `ErrInternalServerError` for the remaining catch-all

## Test plan
- [x] Unit tests pass (assertion updated to expect `CodeFailedPrecondition`)
- [x] `golangci-lint` clean