### PR TITLE
fix(authz): symmetric SpiceDB cleanup on policy delete

### DIFF
--- a/core/policy/service.go
+++ b/core/policy/service.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/raystack/frontier/pkg/utils"
@@ -78,12 +79,7 @@ func (s Service) Create(ctx context.Context, policy Policy) (Policy, error) {
 }
 
 func (s Service) Delete(ctx context.Context, id string) error {
-	if err := s.relationService.Delete(ctx, relation.Relation{
-		Object: relation.Object{
-			ID:        id,
-			Namespace: schema.RoleBindingNamespace,
-		},
-	}); err != nil {
+	if err := s.deleteRoleBindingRelations(ctx, id); err != nil {
 		return err
 	}
 	return s.repository.Delete(ctx, id)
@@ -93,12 +89,31 @@ func (s Service) DeleteWithMinRoleGuard(ctx context.Context, id string, guardRol
 	if err := s.repository.DeleteWithMinRoleGuard(ctx, id, guardRoleID); err != nil {
 		return err
 	}
-	return s.relationService.Delete(ctx, relation.Relation{
+	return s.deleteRoleBindingRelations(ctx, id)
+}
+
+// deleteRoleBindingRelations removes all SpiceDB tuples written by AssignRole:
+// the rolebinding-as-Object tuples (role_bearer, role) and the resource-grant
+// tuple where the rolebinding is the Subject. The Subject-side delete tolerates
+// ErrNotExist because resource-delete sweeps may have already removed it.
+func (s Service) deleteRoleBindingRelations(ctx context.Context, id string) error {
+	if err := s.relationService.Delete(ctx, relation.Relation{
 		Object: relation.Object{
 			ID:        id,
 			Namespace: schema.RoleBindingNamespace,
 		},
-	})
+	}); err != nil {
+		return err
+	}
+	if err := s.relationService.Delete(ctx, relation.Relation{
+		Subject: relation.Subject{
+			ID:        id,
+			Namespace: schema.RoleBindingNamespace,
+		},
+	}); err != nil && !errors.Is(err, relation.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 // AssignRole Note: ideally this should be in a single transaction

--- a/core/policy/service_test.go
+++ b/core/policy/service_test.go
@@ -30,7 +30,7 @@ func TestService_Delete(t *testing.T) {
 		setup   func() *policy.Service
 	}{
 		{
-			name:    "delete policy from relation before repository",
+			name:    "delete both rolebinding-as-object and rolebinding-as-subject tuples before repository",
 			id:      "test-id",
 			wantErr: false,
 			setup: func() *policy.Service {
@@ -41,6 +41,34 @@ func TestService_Delete(t *testing.T) {
 						Namespace: schema.RoleBindingNamespace,
 					},
 				}).Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Subject: relation.Subject{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(nil)
+				repo.On("Delete", ctx, "test-id").Return(nil)
+				return policy.NewService(repo, relationService, roleService)
+			},
+		},
+		{
+			name:    "tolerate ErrNotExist on resource-grant tuple delete",
+			id:      "test-id",
+			wantErr: false,
+			setup: func() *policy.Service {
+				repo, roleService, relationService := mockService(t)
+				relationService.On("Delete", ctx, relation.Relation{
+					Object: relation.Object{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Subject: relation.Subject{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(relation.ErrNotExist)
 				repo.On("Delete", ctx, "test-id").Return(nil)
 				return policy.NewService(repo, relationService, roleService)
 			},
@@ -60,12 +88,110 @@ func TestService_Delete(t *testing.T) {
 				return policy.NewService(repo, relationService, roleService)
 			},
 		},
+		{
+			name:    "resource-grant tuple delete failure (non-ErrNotExist) blocks repository delete",
+			id:      "test-id",
+			wantErr: true,
+			setup: func() *policy.Service {
+				repo, roleService, relationService := mockService(t)
+				relationService.On("Delete", ctx, relation.Relation{
+					Object: relation.Object{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Subject: relation.Subject{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(errors.New("spicedb unavailable"))
+				return policy.NewService(repo, relationService, roleService)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup()
 			if err := s.Delete(ctx, tt.id); (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestService_DeleteWithMinRoleGuard(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name    string
+		id      string
+		guardID string
+		wantErr bool
+		setup   func() *policy.Service
+	}{
+		{
+			name:    "delete both rolebinding-as-object and rolebinding-as-subject tuples after repository",
+			id:      "test-id",
+			guardID: "guard-role-id",
+			wantErr: false,
+			setup: func() *policy.Service {
+				repo, roleService, relationService := mockService(t)
+				repo.On("DeleteWithMinRoleGuard", ctx, "test-id", "guard-role-id").Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Object: relation.Object{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Subject: relation.Subject{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(nil)
+				return policy.NewService(repo, relationService, roleService)
+			},
+		},
+		{
+			name:    "tolerate ErrNotExist on resource-grant tuple delete",
+			id:      "test-id",
+			guardID: "guard-role-id",
+			wantErr: false,
+			setup: func() *policy.Service {
+				repo, roleService, relationService := mockService(t)
+				repo.On("DeleteWithMinRoleGuard", ctx, "test-id", "guard-role-id").Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Object: relation.Object{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(nil)
+				relationService.On("Delete", ctx, relation.Relation{
+					Subject: relation.Subject{
+						ID:        "test-id",
+						Namespace: schema.RoleBindingNamespace,
+					},
+				}).Return(relation.ErrNotExist)
+				return policy.NewService(repo, relationService, roleService)
+			},
+		},
+		{
+			name:    "repository guard failure skips relation deletes",
+			id:      "test-id",
+			guardID: "guard-role-id",
+			wantErr: true,
+			setup: func() *policy.Service {
+				repo, roleService, relationService := mockService(t)
+				repo.On("DeleteWithMinRoleGuard", ctx, "test-id", "guard-role-id").Return(errors.New("guard violated"))
+				return policy.NewService(repo, relationService, roleService)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup()
+			if err := s.DeleteWithMinRoleGuard(ctx, tt.id, tt.guardID); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteWithMinRoleGuard() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`policy.AssignRole` writes three SpiceDB tuples per policy:

```
T1: rolebinding:<polID>#role_bearer          @ <principal>
T2: rolebinding:<polID>#role                 @ role:<roleID>
T3: <resource>#<grant_relation>              @ rolebinding:<polID>
```

`policy.Delete` (and `DeleteWithMinRoleGuard`) only swept by Object on the rolebinding, catching T1+T2. T3 has the rolebinding as **Subject**, so it leaked on every per-member removal, ownership swap, and cross-resource principal cleanup.

Full-resource teardown (`group.DeleteModel`, `project.DeleteModel`) papered over it with a wildcard sweep on the resource — but only for T3 tied to the deleted resource. Per-member removals leaked forever.

## Fix

Both delete paths now route through a `deleteRoleBindingRelations` helper that issues two `relationService.Delete` calls: one by Object (T1, T2), one by Subject (T3). The Subject-side delete tolerates `relation.ErrNotExist` so resource-level sweeps that already removed T3 don't fail the policy delete.

## Test plan

- [x] `core/policy` unit tests cover happy path, `ErrNotExist` tolerance, non-`ErrNotExist` failure semantics for both `Delete` and `DeleteWithMinRoleGuard`.
- [x] Caller-side tests pass: `organization`, `group`, `project`, `membership`, `userpat`, `deleter`, `v1beta1connect` policy handler.

## Follow-ups

- Remove the now-redundant T3 sweeps in `group.DeleteModel` and `project.DeleteModel`.
- #1625 — derive `grant_relation` from `principal_type` inside `policy.Service.Create` so the A2 invariant is structural.

Closes #1617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)