### PR TITLE
fix(sdk): add icons to PAT details header action menu

### DIFF
--- a/web/sdk/react/views-new/pat/pat-details-view.tsx
+++ b/web/sdk/react/views-new/pat/pat-details-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { ReactNode, useCallback, useEffect, useMemo } from 'react';
-import { DotsHorizontalIcon } from '@radix-ui/react-icons';
+import {
+  DotsHorizontalIcon,
+  Pencil1Icon,
+  UpdateIcon
+} from '@radix-ui/react-icons';
 import {
   AlertDialog,
   Breadcrumb,
@@ -9,11 +13,13 @@ import {
   Dialog,
   Flex,
   IconButton,
+  Image,
   Menu,
   Skeleton,
   Text,
   toastManager
 } from '@raystack/apsara-v1';
+import deleteIcon from '../../assets/delete.svg';
 import { useQuery } from '@connectrpc/connect-query';
 import { create } from '@bufbuild/protobuf';
 import {
@@ -262,12 +268,14 @@ export function PATDetailsView({
           </Menu.Trigger>
           <Menu.Content align="start" className={styles.menuContent}>
             <Menu.Item
+              leadingIcon={<Pencil1Icon />}
               onClick={() => updatePATDialogHandle.open(null)}
               data-test-id="frontier-sdk-pat-update-menu-btn"
             >
               Update
             </Menu.Item>
             <Menu.Item
+              leadingIcon={<UpdateIcon />}
               onClick={() =>
                 regenerateDialogHandle.openWithPayload({
                   patId,
@@ -279,6 +287,14 @@ export function PATDetailsView({
               Regenerate
             </Menu.Item>
             <Menu.Item
+              leadingIcon={
+                <Image
+                  src={deleteIcon as unknown as string}
+                  alt="Revoke"
+                  width={16}
+                  height={16}
+                />
+              }
               onClick={() => revokePATDialogHandle.openWithPayload(patId)}
               style={{ color: 'var(--rs-color-foreground-danger-primary)' }}
               data-test-id="frontier-sdk-pat-revoke-menu-btn"


### PR DESCRIPTION
## Summary

- Added leading icons to the action menu items in the PAT details view header for visual consistency with team/project/service-account detail views.
- Update uses `Pencil1Icon`, Regenerate uses `UpdateIcon`, and Revoke uses the shared `delete.svg` asset — matching icon usage elsewhere in views-new.