### PR TITLE
fix(admin): improve webhook form fields

### DIFF
--- a/web/sdk/admin/components/CustomField.tsx
+++ b/web/sdk/admin/components/CustomField.tsx
@@ -5,7 +5,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@radix-ui/react-form";
-import { Flex, Select, Switch, Text, Input } from "@raystack/apsara-v1";
+import { Flex, Select, Switch, Text, TextArea, Input } from "@raystack/apsara-v1";
 import React, { CSSProperties } from "react";
 
 import { Control, Controller, UseFormRegister } from "react-hook-form";
@@ -77,14 +77,14 @@ export const CustomFieldName = ({
                 switch (variant) {
                   case "textarea": {
                     return (
-                      <textarea
+                      <TextArea
                         {...field}
                         defaultValue={props?.defaultValue}
                         placeholder={
                           placeholder ||
                           `Enter your ${title?.toLowerCase() || name}`
                         }
-                        style={style}
+                        style={{ ...style, resize: "vertical" }}
                       />
                     );
                   }

--- a/web/sdk/admin/views/webhooks/webhooks/create/index.tsx
+++ b/web/sdk/admin/views/webhooks/webhooks/create/index.tsx
@@ -97,7 +97,7 @@ export default function CreateWebhooks({ open = false, onClose: onCloseProp }: C
                 name="url"
                 register={methods.register}
                 control={methods.control}
-                variant="textarea"
+                variant="input"
                 style={{ width: "100%" }}
               />
               <CustomFieldName

--- a/web/sdk/admin/views/webhooks/webhooks/update/index.tsx
+++ b/web/sdk/admin/views/webhooks/webhooks/update/index.tsx
@@ -130,7 +130,7 @@ export default function UpdateWebhooks({ open = false, webhookId: webhookIdProp,
                 defaultValue={webhook?.url}
                 register={methods.register}
                 control={methods.control}
-                variant="textarea"
+                variant="input"
                 style={{ width: "100%" }}
                 isLoading={isWebhookLoading}
               />


### PR DESCRIPTION
- Swap the raw \`<textarea>\` in \`CustomField\` for apsara \`TextArea\`, with horizontal resize locked.
- URL field in webhook create + update drawers now uses \`variant=\"input\"\` instead of \`variant=\"textarea\"\`.



