### PR TITLE
fix(admin): prevent negative values in organization size input

### DIFF
--- a/web/sdk/admin/views/organizations/details/edit/organization.tsx
+++ b/web/sdk/admin/views/organizations/details/edit/organization.tsx
@@ -219,7 +219,7 @@ export function EditOrganizationPanel({ open = false, onClose }: { open?: boolea
                 label={`${t.organization({ case: "capital" })} size`}
                 error={errors.size?.message}
               >
-                <Input {...register("size")} type="number" />
+                <Input {...register("size")} type="number" min={0} />
               </Field>
               <Controller
                 name="type"

--- a/web/sdk/admin/views/organizations/list/create.tsx
+++ b/web/sdk/admin/views/organizations/list/create.tsx
@@ -194,7 +194,7 @@ export function CreateOrganizationPanel({
                 label={`${t.organization({ case: "capital" })} size`}
                 error={errors.size?.message}
               >
-                <Input {...register("size")} type="number" />
+                <Input {...register("size")} type="number" min={0} />
               </Field>
               <Controller
                 name="type"


### PR DESCRIPTION
## Summary
- Add `min={0}` to the organization size number input in both the edit and create org side panels so the browser blocks negative submissions natively.

## Test plan
- [ ] Organisations → {id} → Edit: try entering / pasting `-5` in size, click Save — browser blocks submission.
- [ ] Organisations → Add new: same check on the create panel.
