### PR TITLE
fix(admin): surface API error message in assign role toast

### DIFF
--- a/web/sdk/admin/components/AssignRole.tsx
+++ b/web/sdk/admin/components/AssignRole.tsx
@@ -16,6 +16,7 @@ import {
   SetOrganizationMemberRoleRequestSchema,
 } from "@raystack/proton/frontier";
 import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
 import { useMutation } from "@connectrpc/connect-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -81,7 +82,11 @@ export const AssignRole = ({
         type: "success",
       });
     } catch (error) {
-      toastManager.add({ title: "Failed to assign role", type: "error" });
+      toastManager.add({
+        title: "Failed to assign role",
+        description: error instanceof ConnectError ? error.rawMessage : undefined,
+        type: "error",
+      });
       console.error(error);
     }
   };

--- a/web/sdk/admin/views/organizations/details/projects/members/assign-role.tsx
+++ b/web/sdk/admin/views/organizations/details/projects/members/assign-role.tsx
@@ -17,6 +17,7 @@ import {
   SetProjectMemberRoleRequestSchema,
 } from "@raystack/proton/frontier";
 import { create } from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
 import { useMutation } from "@connectrpc/connect-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -84,7 +85,11 @@ export const AssignRole = ({
 
       toastManager.add({ title: "Role assigned successfully", type: "success" });
     } catch (error) {
-      toastManager.add({ title: "Failed to assign role", type: "error" });
+      toastManager.add({
+        title: "Failed to assign role",
+        description: error instanceof ConnectError ? error.rawMessage : undefined,
+        type: "error",
+      });
       console.error(error);
     }
   };


### PR DESCRIPTION
The Assign Role dialog catch blocks were swallowing the server's error and showing only a generic \"Failed to assign role\" toast. The actual reason (e.g. \`last member cannot change role\`) was never visible to the user.

Forwards \`ConnectError.rawMessage\` into the toast \`description\` field for both the org-level and project-level Assign Role dialogs. Falls back to no description for non-\`ConnectError\` errors → toast behavior is unchanged for those.

Affected paths:
- `web/sdk/admin/components/AssignRole.tsx`
paths: 
  1. `/workspaces/{orgId}/members` → row action menu on a member → "Assign role…"
  2. `/users/{userId} `→ side panel → membership row → role dropdown → "Assign role…"


- web/sdk/admin/views/organizations/details/projects/members/assign-role.tsx
Paths: 

  1.   `/workspaces/{orgId}/projects` → click a project row (opens the Project Members dialog) → row action menu on a member → "Assign role…"
