### PR TITLE
refactor(organization): batch joinable orgs fetch, extract helper

### DIFF
--- a/core/organization/service.go
+++ b/core/organization/service.go
@@ -159,6 +159,10 @@ func (s Service) Get(ctx context.Context, idOrName string) (Organization, error)
 	return orgResp, nil
 }
 
+func (s Service) GetByIDs(ctx context.Context, ids []string) ([]Organization, error) {
+	return s.repository.GetByIDs(ctx, ids)
+}
+
 // GetRaw returns an organization(both enabled and disabled) by id or name
 func (s Service) GetRaw(ctx context.Context, idOrName string) (Organization, error) {
 	if utils.IsValidUUID(idOrName) {

--- a/internal/api/v1beta1connect/interfaces.go
+++ b/internal/api/v1beta1connect/interfaces.go
@@ -120,6 +120,7 @@ type ProductService interface {
 type OrganizationService interface {
 	Get(ctx context.Context, idOrSlug string) (organization.Organization, error)
 	GetRaw(ctx context.Context, idOrSlug string) (organization.Organization, error)
+	GetByIDs(ctx context.Context, ids []string) ([]organization.Organization, error)
 	Create(ctx context.Context, org organization.Organization) (organization.Organization, error)
 	AdminCreate(ctx context.Context, org organization.Organization, ownerEmail string) (organization.Organization, error)
 	List(ctx context.Context, f organization.Filter) ([]organization.Organization, error)

--- a/internal/api/v1beta1connect/mocks/organization_service.go
+++ b/internal/api/v1beta1connect/mocks/organization_service.go
@@ -288,6 +288,65 @@ func (_c *OrganizationService_Get_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// GetByIDs provides a mock function with given fields: ctx, ids
+func (_m *OrganizationService) GetByIDs(ctx context.Context, ids []string) ([]organization.Organization, error) {
+	ret := _m.Called(ctx, ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetByIDs")
+	}
+
+	var r0 []organization.Organization
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]organization.Organization, error)); ok {
+		return rf(ctx, ids)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []string) []organization.Organization); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]organization.Organization)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(ctx, ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// OrganizationService_GetByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetByIDs'
+type OrganizationService_GetByIDs_Call struct {
+	*mock.Call
+}
+
+// GetByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ids []string
+func (_e *OrganizationService_Expecter) GetByIDs(ctx interface{}, ids interface{}) *OrganizationService_GetByIDs_Call {
+	return &OrganizationService_GetByIDs_Call{Call: _e.mock.On("GetByIDs", ctx, ids)}
+}
+
+func (_c *OrganizationService_GetByIDs_Call) Run(run func(ctx context.Context, ids []string)) *OrganizationService_GetByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *OrganizationService_GetByIDs_Call) Return(_a0 []organization.Organization, _a1 error) *OrganizationService_GetByIDs_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *OrganizationService_GetByIDs_Call) RunAndReturn(run func(context.Context, []string) ([]organization.Organization, error)) *OrganizationService_GetByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRaw provides a mock function with given fields: ctx, idOrSlug
 func (_m *OrganizationService) GetRaw(ctx context.Context, idOrSlug string) (organization.Organization, error) {
 	ret := _m.Called(ctx, idOrSlug)

--- a/internal/api/v1beta1connect/user.go
+++ b/internal/api/v1beta1connect/user.go
@@ -3,12 +3,11 @@ package v1beta1connect
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/mail"
 	"strings"
 
 	"connectrpc.com/connect"
-
-	"log/slog"
 
 	"github.com/pkg/errors"
 	"github.com/raystack/frontier/core/audit"
@@ -765,29 +764,12 @@ func (h *ConnectHandler) ListOrganizationsByUser(ctx context.Context, request *c
 		}
 	}
 
-	joinableOrgIDs, err := h.domainService.ListJoinableOrgsByDomain(ctx, userData.Email)
+	joinableOrgs, err := h.joinableOrgsForEmail(
+		ctx, userData.Email, errorLogger, request, "ListOrganizationsByUser",
+		"user_id", userID,
+	)
 	if err != nil {
-		errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByUser", err,
-			"user_id", userID,
-			"user_email", userData.Email)
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
-	}
-
-	var joinableOrgs []*frontierv1beta1.Organization
-	for _, joinableOrg := range joinableOrgIDs {
-		org, err := h.orgService.Get(ctx, joinableOrg)
-		if err != nil {
-			errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByUser", err,
-				"user_id", userID,
-				"joinable_org_id", joinableOrg)
-			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
-		}
-		orgPB, err := transformOrgToPB(org)
-		if err != nil {
-			errorLogger.LogTransformError(ctx, request, "ListOrganizationsByUser", org.ID, err)
-			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
-		}
-		joinableOrgs = append(joinableOrgs, orgPB)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.ListOrganizationsByUserResponse{
@@ -828,30 +810,13 @@ func (h *ConnectHandler) ListOrganizationsByCurrentUser(ctx context.Context, req
 	var joinableOrgs []*frontierv1beta1.Organization
 	// Only regular users can join organizations by domain, service users cannot
 	if principal.Type == schema.UserPrincipal && principal.User != nil {
-		joinableOrgIDs, err := h.domainService.ListJoinableOrgsByDomain(ctx, principal.User.Email)
+		joinableOrgs, err = h.joinableOrgsForEmail(
+			ctx, principal.User.Email, errorLogger, request, "ListOrganizationsByCurrentUser",
+			"principal_id", principal.ID,
+			"principal_type", principal.Type,
+		)
 		if err != nil {
-			errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByCurrentUser", err,
-				"principal_id", principal.ID,
-				"principal_type", principal.Type,
-				"user_email", principal.User.Email)
 			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
-		}
-
-		for _, joinableOrg := range joinableOrgIDs {
-			org, err := h.orgService.Get(ctx, joinableOrg)
-			if err != nil {
-				errorLogger.LogUnexpectedError(ctx, request, "ListOrganizationsByCurrentUser", err,
-					"principal_id", principal.ID,
-					"principal_type", principal.Type,
-					"joinable_org_id", joinableOrg)
-				return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
-			}
-			orgPB, err := transformOrgToPB(org)
-			if err != nil {
-				errorLogger.LogTransformError(ctx, request, "ListOrganizationsByCurrentUser", org.ID, err)
-				return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
-			}
-			joinableOrgs = append(joinableOrgs, orgPB)
 		}
 	}
 
@@ -859,6 +824,44 @@ func (h *ConnectHandler) ListOrganizationsByCurrentUser(ctx context.Context, req
 		Organizations:     orgs,
 		JoinableViaDomain: joinableOrgs,
 	}), nil
+}
+
+// joinableOrgsForEmail returns the organizations a user with this email can join via a verified domain.
+func (h *ConnectHandler) joinableOrgsForEmail(
+	ctx context.Context,
+	email string,
+	errorLogger *ErrorLogger,
+	request connect.AnyRequest,
+	operation string,
+	extraCtx ...any,
+) ([]*frontierv1beta1.Organization, error) {
+	joinableOrgIDs, err := h.domainService.ListJoinableOrgsByDomain(ctx, email)
+	if err != nil {
+		args := append([]any{"user_email", email}, extraCtx...)
+		errorLogger.LogUnexpectedError(ctx, request, operation, err, args...)
+		return nil, err
+	}
+	if len(joinableOrgIDs) == 0 {
+		return nil, nil
+	}
+
+	orgs, err := h.orgService.GetByIDs(ctx, joinableOrgIDs)
+	if err != nil {
+		args := append([]any{"joinable_org_ids", joinableOrgIDs}, extraCtx...)
+		errorLogger.LogUnexpectedError(ctx, request, operation, err, args...)
+		return nil, err
+	}
+
+	pbOrgs := make([]*frontierv1beta1.Organization, 0, len(orgs))
+	for _, org := range orgs {
+		orgPB, err := transformOrgToPB(org)
+		if err != nil {
+			errorLogger.LogTransformError(ctx, request, operation, org.ID, err)
+			return nil, err
+		}
+		pbOrgs = append(pbOrgs, orgPB)
+	}
+	return pbOrgs, nil
 }
 
 func (h *ConnectHandler) ListProjectsByUser(ctx context.Context, request *connect.Request[frontierv1beta1.ListProjectsByUserRequest]) (*connect.Response[frontierv1beta1.ListProjectsByUserResponse], error) {

--- a/internal/api/v1beta1connect/user_test.go
+++ b/internal/api/v1beta1connect/user_test.go
@@ -1244,12 +1244,14 @@ func TestConnectHandler_ListOrganizationsByUser(t *testing.T) {
 
 				ds.EXPECT().ListJoinableOrgsByDomain(mock.Anything, "test@example.com").Return([]string{"org-2"}, nil)
 
-				os.EXPECT().Get(mock.Anything, "org-2").Return(organization.Organization{
-					ID:       "org-2",
-					Name:     "joinable-org",
-					Title:    "Joinable Organization",
-					State:    organization.Enabled,
-					Metadata: metadata.Metadata{},
+				os.EXPECT().GetByIDs(mock.Anything, []string{"org-2"}).Return([]organization.Organization{
+					{
+						ID:       "org-2",
+						Name:     "joinable-org",
+						Title:    "Joinable Organization",
+						State:    organization.Enabled,
+						Metadata: metadata.Metadata{},
+					},
 				}, nil)
 			},
 			req: &frontierv1beta1.ListOrganizationsByUserRequest{
@@ -1295,6 +1297,64 @@ func TestConnectHandler_ListOrganizationsByUser(t *testing.T) {
 				JoinableViaDomain: []*frontierv1beta1.Organization{},
 			},
 			err: connect.Code(0),
+		},
+		{
+			title: "should batch-fetch multiple joinable orgs in a single call",
+			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.DomainService) {
+				os.EXPECT().List(mock.Anything, principalFilter).
+					Return(nil, nil)
+
+				us.EXPECT().GetByID(mock.Anything, userID).Return(user.User{
+					ID:    userID,
+					Email: "test@example.com",
+					Name:  "Test User",
+				}, nil)
+
+				ds.EXPECT().ListJoinableOrgsByDomain(mock.Anything, "test@example.com").
+					Return([]string{"org-a", "org-b", "org-c"}, nil)
+
+				os.EXPECT().GetByIDs(mock.Anything, []string{"org-a", "org-b", "org-c"}).
+					Return([]organization.Organization{
+						{ID: "org-a", Name: "alpha", Title: "Alpha", State: organization.Enabled, Metadata: metadata.Metadata{}},
+						{ID: "org-b", Name: "bravo", Title: "Bravo", State: organization.Enabled, Metadata: metadata.Metadata{}},
+						{ID: "org-c", Name: "charlie", Title: "Charlie", State: organization.Enabled, Metadata: metadata.Metadata{}},
+					}, nil)
+			},
+			req: &frontierv1beta1.ListOrganizationsByUserRequest{
+				Id: userID,
+			},
+			want: &frontierv1beta1.ListOrganizationsByUserResponse{
+				Organizations: []*frontierv1beta1.Organization{},
+				JoinableViaDomain: []*frontierv1beta1.Organization{
+					{Id: "org-a", Name: "alpha", Title: "Alpha"},
+					{Id: "org-b", Name: "bravo", Title: "Bravo"},
+					{Id: "org-c", Name: "charlie", Title: "Charlie"},
+				},
+			},
+			err: connect.Code(0),
+		},
+		{
+			title: "should return internal error when joinable org batch fetch fails",
+			setup: func(os *mocks.OrganizationService, us *mocks.UserService, ds *mocks.DomainService) {
+				os.EXPECT().List(mock.Anything, principalFilter).
+					Return(nil, nil)
+
+				us.EXPECT().GetByID(mock.Anything, userID).Return(user.User{
+					ID:    userID,
+					Email: "test@example.com",
+				}, nil)
+
+				ds.EXPECT().ListJoinableOrgsByDomain(mock.Anything, "test@example.com").
+					Return([]string{"org-2"}, nil)
+
+				os.EXPECT().GetByIDs(mock.Anything, []string{"org-2"}).
+					Return(nil, errors.New("database error"))
+			},
+			req: &frontierv1beta1.ListOrganizationsByUserRequest{
+				Id: userID,
+			},
+			want: nil,
+			err:  connect.CodeInternal,
 		},
 		{
 			title: "should return not found error for invalid user ID",
@@ -1411,12 +1471,14 @@ func TestConnectHandler_ListOrganizationsByCurrentUser(t *testing.T) {
 
 				ds.EXPECT().ListJoinableOrgsByDomain(mock.Anything, "test@example.com").Return([]string{"org-2"}, nil)
 
-				os.EXPECT().Get(mock.Anything, "org-2").Return(organization.Organization{
-					ID:       "org-2",
-					Name:     "joinable-org",
-					Title:    "Joinable Organization",
-					State:    organization.Enabled,
-					Metadata: metadata.Metadata{},
+				os.EXPECT().GetByIDs(mock.Anything, []string{"org-2"}).Return([]organization.Organization{
+					{
+						ID:       "org-2",
+						Name:     "joinable-org",
+						Title:    "Joinable Organization",
+						State:    organization.Enabled,
+						Metadata: metadata.Metadata{},
+					},
 				}, nil)
 			},
 			req: &frontierv1beta1.ListOrganizationsByCurrentUserRequest{},
@@ -1482,6 +1544,35 @@ func TestConnectHandler_ListOrganizationsByCurrentUser(t *testing.T) {
 					},
 				},
 				JoinableViaDomain: []*frontierv1beta1.Organization{}, // Empty for service users
+			},
+			err: connect.Code(0),
+		},
+		{
+			title: "should batch-fetch multiple joinable orgs in a single call",
+			setup: func(os *mocks.OrganizationService, as *mocks.AuthnService, ds *mocks.DomainService) {
+				as.EXPECT().GetPrincipal(mock.Anything).Return(userPrincipal, nil)
+
+				os.EXPECT().List(mock.Anything, organization.Filter{Principal: &userPrincipal}).
+					Return(nil, nil)
+
+				ds.EXPECT().ListJoinableOrgsByDomain(mock.Anything, "test@example.com").
+					Return([]string{"org-a", "org-b", "org-c"}, nil)
+
+				os.EXPECT().GetByIDs(mock.Anything, []string{"org-a", "org-b", "org-c"}).
+					Return([]organization.Organization{
+						{ID: "org-a", Name: "alpha", Title: "Alpha", State: organization.Enabled, Metadata: metadata.Metadata{}},
+						{ID: "org-b", Name: "bravo", Title: "Bravo", State: organization.Enabled, Metadata: metadata.Metadata{}},
+						{ID: "org-c", Name: "charlie", Title: "Charlie", State: organization.Enabled, Metadata: metadata.Metadata{}},
+					}, nil)
+			},
+			req: &frontierv1beta1.ListOrganizationsByCurrentUserRequest{},
+			want: &frontierv1beta1.ListOrganizationsByCurrentUserResponse{
+				Organizations: []*frontierv1beta1.Organization{},
+				JoinableViaDomain: []*frontierv1beta1.Organization{
+					{Id: "org-a", Name: "alpha", Title: "Alpha"},
+					{Id: "org-b", Name: "bravo", Title: "Bravo"},
+					{Id: "org-c", Name: "charlie", Title: "Charlie"},
+				},
 			},
 			err: connect.Code(0),
 		},


### PR DESCRIPTION
## Summary
- `core/organization`: add `Service.GetByIDs` thin wrapper over the existing repository method.
- `internal/api/v1beta1connect`: expose `GetByIDs` on the `OrganizationService` interface; mocks regenerated.
- `ListOrganizationsByUser` and `ListOrganizationsByCurrentUser` now batch-fetch joinable orgs via one `GetByIDs` call instead of looping `orgService.Get(id)` per ID.
- Shared joinable-orgs lookup extracted into `joinableOrgsForEmail` helper; service-user skip stays in the current-user caller.
- Disabled / missing joinable orgs are silently excluded by the repository SQL filter; previously, a single disabled domain-trusted org failed the whole RPC with `CodeInternal`.
- Batch-error log field renamed from `joinable_org_id` (string, per failed iteration) to `joinable_org_ids` ([]string, full attempted set).

Addresses items 1 and 2 of #1637.

## Test plan
- [x] `go test ./internal/api/v1beta1connect/... ./core/organization/...`
- [x] `make lint`
- [x] Existing `TestConnectHandler_ListOrganizationsByUser` / `TestConnectHandler_ListOrganizationsByCurrentUser` updated to expect `GetByIDs`.
- [x] New tests added: multi-ID batch fetch (single mock call), batch error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)