### PR TITLE
fix(sdk): add filter config to old tokens view

### DIFF
--- a/web/sdk/react/views/tokens/transactions/columns.tsx
+++ b/web/sdk/react/views/tokens/transactions/columns.tsx
@@ -19,12 +19,17 @@ import dayjs from 'dayjs';
 interface getColumnsOptions {
   dateFormat: string;
 }
-const TxnEventSourceMap = {
+const TxnEventSourceMap: Record<string, string> = {
   'system.starter': 'Starter tokens',
   'system.buy': 'Recharge',
   'system.awarded': 'Complimentary tokens',
-  'system.revert': 'Refund'
+  'system.revert': 'Refund',
+  'system.overdraft': 'Overdraft'
 };
+
+const eventFilterOptions = Object.entries(TxnEventSourceMap).map(
+  ([value, label]) => ({ value, label })
+);
 
 export const getColumns = ({
   dateFormat
@@ -32,6 +37,8 @@ export const getColumns = ({
   {
     header: 'Date',
     accessorKey: 'createdAt',
+    enableColumnFilter: true,
+    filterType: 'date',
     cell: ({ getValue }) => {
       const value = getValue() as TimeStamp;
       const date = isNullTimestamp(value)
@@ -59,6 +66,9 @@ export const getColumns = ({
   {
     header: 'Event',
     accessorKey: 'source',
+    enableColumnFilter: true,
+    filterType: 'multiselect',
+    filterOptions: eventFilterOptions,
     classNames: {
       cell: tokenStyles.txnTableEventColumn
     },

--- a/web/sdk/react/views/tokens/transactions/index.tsx
+++ b/web/sdk/react/views/tokens/transactions/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   EmptyState,
   Text,
   Flex,
@@ -6,6 +7,7 @@ import {
   DataTableSort
 } from '@raystack/apsara';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
+import { FilterIcon } from '@raystack/apsara/icons';
 import type { BillingTransaction } from '~/src';
 import { getColumns } from './columns';
 import { useFrontier } from '~/react/contexts/FrontierContext';
@@ -40,6 +42,18 @@ export function TransactionsTable({
         <Text size="small" weight="medium">
           Token transactions
         </Text>
+        <DataTable.Filters
+          trigger={
+            <Button
+              variant="outline"
+              color="neutral"
+              size="small"
+              leadingIcon={<FilterIcon />}
+            >
+              Filter
+            </Button>
+          }
+        />
         <DataTable.Content
           emptyState={noDataChildren}
           classNames={{ header: tokenStyles.txnTableHeader }}


### PR DESCRIPTION
## Summary
- Add `enableColumnFilter`, `filterType`, and `filterOptions` to the old tokens view columns (used by `OrganizationProfile`)
- Add `DataTable.Filters` trigger button to the transactions table
- Add missing `system.overdraft` event source to `TxnEventSourceMap`
- Fixes: token transaction filters on hue.pixxel.dev were showing 0 results because the Event column had no filter configuration — the DataTable auto-generated filter options from raw `source` values but couldn't match them during client-side filtering

**Related:** The billing page "Upgrade" button not working on hue.pixxel.dev is a studio-side issue — `BillingView` accepts `onNavigateToPlans` but the studio app wasn't passing it. Fixed in pixxelhq/studio#2665.

## Test plan
- [ ] Open tokens page in OrganizationProfile → verify Filter button appears
- [ ] Click Filter → Event → select "Recharge" → verify table shows only recharge transactions
- [ ] Click Filter → Date → verify date range filter works
- [ ] Clear filters → verify all transactions show again