### PR TITLE
fix: handle in/notin operators in token search filters

### DIFF
--- a/internal/store/postgres/org_tokens_repository.go
+++ b/internal/store/postgres/org_tokens_repository.go
@@ -167,22 +167,14 @@ func (r OrgTokensRepository) addFilter(query *goqu.SelectDataset, filter rql.Fil
 	case "like", "notlike":
 		value := "%" + filter.Value.(string) + "%"
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: value}}), nil
-	case "in":
+	case "in", "notin":
 		values := make([]string, 0)
 		for _, v := range strings.Split(filter.Value.(string), ",") {
 			if trimmed := strings.TrimSpace(v); trimmed != "" {
 				values = append(values, trimmed)
 			}
 		}
-		return query.Where(goqu.Cast(goqu.I(field), "TEXT").In(values)), nil
-	case "notin":
-		values := make([]string, 0)
-		for _, v := range strings.Split(filter.Value.(string), ",") {
-			if trimmed := strings.TrimSpace(v); trimmed != "" {
-				values = append(values, trimmed)
-			}
-		}
-		return query.Where(goqu.Cast(goqu.I(field), "TEXT").NotIn(values)), nil
+		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: values}}), nil
 	default:
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: filter.Value}}), nil
 	}

--- a/internal/store/postgres/org_tokens_repository.go
+++ b/internal/store/postgres/org_tokens_repository.go
@@ -168,9 +168,21 @@ func (r OrgTokensRepository) addFilter(query *goqu.SelectDataset, filter rql.Fil
 		value := "%" + filter.Value.(string) + "%"
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: value}}), nil
 	case "in":
-		return query.Where(goqu.Cast(goqu.I(field), "TEXT").In(strings.Split(filter.Value.(string), ","))), nil
+		values := make([]string, 0)
+		for _, v := range strings.Split(filter.Value.(string), ",") {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				values = append(values, trimmed)
+			}
+		}
+		return query.Where(goqu.Cast(goqu.I(field), "TEXT").In(values)), nil
 	case "notin":
-		return query.Where(goqu.Cast(goqu.I(field), "TEXT").NotIn(strings.Split(filter.Value.(string), ","))), nil
+		values := make([]string, 0)
+		for _, v := range strings.Split(filter.Value.(string), ",") {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				values = append(values, trimmed)
+			}
+		}
+		return query.Where(goqu.Cast(goqu.I(field), "TEXT").NotIn(values)), nil
 	default:
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: filter.Value}}), nil
 	}

--- a/internal/store/postgres/org_tokens_repository.go
+++ b/internal/store/postgres/org_tokens_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/jmoiron/sqlx"
@@ -166,6 +167,10 @@ func (r OrgTokensRepository) addFilter(query *goqu.SelectDataset, filter rql.Fil
 	case "like", "notlike":
 		value := "%" + filter.Value.(string) + "%"
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: value}}), nil
+	case "in":
+		return query.Where(goqu.Cast(goqu.I(field), "TEXT").In(strings.Split(filter.Value.(string), ","))), nil
+	case "notin":
+		return query.Where(goqu.Cast(goqu.I(field), "TEXT").NotIn(strings.Split(filter.Value.(string), ","))), nil
 	default:
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: filter.Value}}), nil
 	}

--- a/internal/store/postgres/org_tokens_repository.go
+++ b/internal/store/postgres/org_tokens_repository.go
@@ -168,13 +168,19 @@ func (r OrgTokensRepository) addFilter(query *goqu.SelectDataset, filter rql.Fil
 		value := "%" + filter.Value.(string) + "%"
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: value}}), nil
 	case "in", "notin":
+		// in/notin only applies to string-type RQL fields (source, type, etc.)
+		// numeric fields like amount are rejected by rql.ValidateQuery before reaching here
 		values := make([]string, 0)
 		for _, v := range strings.Split(filter.Value.(string), ",") {
 			if trimmed := strings.TrimSpace(v); trimmed != "" {
 				values = append(values, trimmed)
 			}
 		}
-		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: values}}), nil
+		col := goqu.Cast(goqu.I(field), "TEXT")
+		if filter.Operator == "in" {
+			return query.Where(col.In(values)), nil
+		}
+		return query.Where(col.NotIn(values)), nil
 	default:
 		return query.Where(goqu.Ex{field: goqu.Op{filter.Operator: filter.Value}}), nil
 	}


### PR DESCRIPTION
## Summary
- Add explicit `in`/`notin` operator handling in `OrgTokensRepository.addFilter`
- The `in` operator requires splitting comma-separated string values into a slice for goqu's `In()` method
- Without this, `goqu.Op{"in": "system.buy"}` generates invalid SQL — it passes a raw string instead of a list to `IN ()`
- Same pattern as `OrgBillingRepository.addRQLFiltersInQuery` which already handles this correctly

## Root cause
The DataTable multiselect filter sends `operator: "in"` with `stringValue: "system.buy"` (comma-separated for multiple values). The `addFilter` default case passes this directly to goqu as `goqu.Op{"in": filter.Value}`, but goqu's `in` needs a slice, not a string. The fix splits the value by commas before passing to `In()`/`NotIn()`.

## Test plan
- [ ] Open tokens page → Filter → Event → select "Recharge" → verify filtered results appear
- [ ] Select multiple event types → verify comma-separated values filter correctly
- [ ] Use "is not" operator → verify `notin` works