### PR TITLE
fix(api): wrap raw errors in connect codes and add missing error logs

### DIFF
--- a/internal/api/v1beta1connect/audit_record.go
+++ b/internal/api/v1beta1connect/audit_record.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"slices"
 
 	"connectrpc.com/connect"
@@ -196,7 +197,7 @@ func (h *ConnectHandler) ExportAuditRecords(ctx context.Context, request *connec
 		}
 	}
 	// Stream the data using io.Reader
-	return streamReaderInChunks(reader, contentType, stream)
+	return streamReaderInChunks(ctx, reader, contentType, stream)
 }
 
 func TransformAuditRecordToPB(record auditrecord.AuditRecord) (*frontierv1beta1.CreateAuditRecordResponse, error) {
@@ -264,7 +265,7 @@ func TransformAuditRecordToPB(record auditrecord.AuditRecord) (*frontierv1beta1.
 }
 
 // streamReaderInChunks reads from io.Reader and streams data in HTTP-friendly chunks
-func streamReaderInChunks(reader io.Reader, contentType string, stream *connect.ServerStream[httpbody.HttpBody]) error {
+func streamReaderInChunks(ctx context.Context, reader io.Reader, contentType string, stream *connect.ServerStream[httpbody.HttpBody]) error {
 	buffer := make([]byte, HttpChunkSize)
 
 	for {
@@ -273,6 +274,7 @@ func streamReaderInChunks(reader io.Reader, contentType string, stream *connect.
 			break
 		}
 		if err != nil {
+			slog.ErrorContext(ctx, "failed to read chunk for streaming", "error", err)
 			return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 		if n > 0 {
@@ -281,6 +283,7 @@ func streamReaderInChunks(reader io.Reader, contentType string, stream *connect.
 				Data:        buffer[:n],
 			}
 			if sendErr := stream.Send(msg); sendErr != nil {
+				slog.ErrorContext(ctx, "failed to send chunk in stream", "error", sendErr)
 				return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 			}
 		}

--- a/internal/api/v1beta1connect/authorize.go
+++ b/internal/api/v1beta1connect/authorize.go
@@ -3,6 +3,7 @@ package v1beta1connect
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/billing/checkout"
@@ -49,7 +50,7 @@ func (h *ConnectHandler) IsAuthorized(ctx context.Context, object relation.Objec
 			"permission", permission,
 			"subject_namespace", currentUser.Type,
 			"subject_id", currentUser.ID)
-		return handleAuthErr(err)
+		return handleAuthErr(ctx, err)
 	}
 	if result {
 		return nil
@@ -74,7 +75,7 @@ func (h *ConnectHandler) IsAuthorized(ctx context.Context, object relation.Objec
 				"subject_namespace", currentUser.Type,
 				"subject_id", str.GenerateUserSlug(currentUser.User.Email),
 				"user_email", currentUser.User.Email)
-			return handleAuthErr(checkErr)
+			return handleAuthErr(ctx, checkErr)
 		}
 		if result2 {
 			return nil
@@ -84,7 +85,7 @@ func (h *ConnectHandler) IsAuthorized(ctx context.Context, object relation.Objec
 	return connect.NewError(connect.CodePermissionDenied, ErrUnauthorized)
 }
 
-func handleAuthErr(err error) error {
+func handleAuthErr(ctx context.Context, err error) error {
 	switch {
 	case errors.Is(err, user.ErrInvalidEmail) || errors.Is(err, errors.ErrUnauthenticated):
 		return connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
@@ -93,6 +94,7 @@ func handleAuthErr(err error) error {
 		errors.Is(err, resource.ErrNotExist):
 		return connect.NewError(connect.CodeNotFound, ErrNotFound)
 	default:
+		slog.ErrorContext(ctx, "unhandled auth error", "error", err)
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 }

--- a/internal/api/v1beta1connect/organization_billing.go
+++ b/internal/api/v1beta1connect/organization_billing.go
@@ -69,7 +69,7 @@ func (h *ConnectHandler) ExportOrganizations(ctx context.Context, request *conne
 		errorLogger.LogServiceError(ctx, request, "ExportOrganizations.Export", err)
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return streamBytesInChunks(orgBillingDataBytes, contentType, stream)
+	return streamBytesInChunks(ctx, orgBillingDataBytes, contentType, stream)
 }
 
 func transformProtoToRQL(q *frontierv1beta1.RQLRequest) (*rql.Query, error) {

--- a/internal/api/v1beta1connect/organization_projects.go
+++ b/internal/api/v1beta1connect/organization_projects.go
@@ -92,5 +92,5 @@ func (h *ConnectHandler) ExportOrganizationProjects(ctx context.Context, request
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
-	return streamBytesInChunks(orgProjectsDataBytes, contentType, stream)
+	return streamBytesInChunks(ctx, orgProjectsDataBytes, contentType, stream)
 }

--- a/internal/api/v1beta1connect/organization_tokens.go
+++ b/internal/api/v1beta1connect/organization_tokens.go
@@ -80,5 +80,5 @@ func (h *ConnectHandler) ExportOrganizationTokens(ctx context.Context, request *
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
-	return streamBytesInChunks(orgTokensDataBytes, contentType, stream)
+	return streamBytesInChunks(ctx, orgTokensDataBytes, contentType, stream)
 }

--- a/internal/api/v1beta1connect/organization_users.go
+++ b/internal/api/v1beta1connect/organization_users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/aggregates/orgusers"
@@ -96,10 +97,10 @@ func (h *ConnectHandler) ExportOrganizationUsers(ctx context.Context, request *c
 			"org_id", request.Msg.GetId())
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return streamBytesInChunks(orgUsersDataBytes, contentType, stream)
+	return streamBytesInChunks(ctx, orgUsersDataBytes, contentType, stream)
 }
 
-func streamBytesInChunks(data []byte, contentType string, stream *connect.ServerStream[httpbody.HttpBody]) error {
+func streamBytesInChunks(ctx context.Context, data []byte, contentType string, stream *connect.ServerStream[httpbody.HttpBody]) error {
 	chunkSize := 1024 * 200 // 200KB
 	for i := 0; i < len(data); i += chunkSize {
 		end := min(i+chunkSize, len(data))
@@ -111,6 +112,7 @@ func streamBytesInChunks(data []byte, contentType string, stream *connect.Server
 		}
 
 		if err := stream.Send(msg); err != nil {
+			slog.ErrorContext(ctx, "failed to send chunk in stream", "error", err)
 			return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 	}

--- a/internal/api/v1beta1connect/permission_check.go
+++ b/internal/api/v1beta1connect/permission_check.go
@@ -27,9 +27,13 @@ func logAuditForCheck(ctx context.Context, result bool, objectID string, objectN
 	})
 }
 
-func (h *ConnectHandler) getPermissionName(ctx context.Context, ns, name string) (string, error) {
+func (h *ConnectHandler) getPermissionName(ctx context.Context, ns, name string,
+	errorLogger *ErrorLogger, request connect.AnyRequest, operation string,
+) (string, error) {
 	resolved, ok, err := h.resolvePermissionName(ctx, ns, name)
 	if err != nil {
+		errorLogger.LogServiceError(ctx, request, operation+".getPermissionName", err,
+			"namespace", ns, "permission_name", name)
 		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	if !ok {
@@ -73,7 +77,8 @@ func (h *ConnectHandler) CheckFederatedResourcePermission(ctx context.Context, r
 		return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
 	}
 
-	permissionName, err := h.getPermissionName(ctx, objectNamespace, req.Msg.GetPermission())
+	permissionName, err := h.getPermissionName(ctx, objectNamespace, req.Msg.GetPermission(),
+		errorLogger, req, "CheckFederatedResourcePermission")
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +100,7 @@ func (h *ConnectHandler) CheckFederatedResourcePermission(ctx context.Context, r
 			"subject_id", principalID,
 			"subject_namespace", principalNamespace,
 			"permission", permissionName)
-		return nil, handleAuthErr(err)
+		return nil, handleAuthErr(ctx, err)
 	}
 
 	logAuditForCheck(ctx, result, objectID, objectNamespace)
@@ -105,7 +110,9 @@ func (h *ConnectHandler) CheckFederatedResourcePermission(ctx context.Context, r
 	return connect.NewResponse(&frontierv1beta1.CheckFederatedResourcePermissionResponse{Status: true}), nil
 }
 
-func (h *ConnectHandler) fetchAccessPairsOnResource(ctx context.Context, objectNamespace string, ids, permissions []string) ([]relation.CheckPair, error) {
+func (h *ConnectHandler) fetchAccessPairsOnResource(ctx context.Context, objectNamespace string, ids, permissions []string,
+	errorLogger *ErrorLogger, request connect.AnyRequest, operation string,
+) ([]relation.CheckPair, error) {
 	// Resolve each requested permission once, dropping unknown names and
 	// duplicate inputs. Unknown names produce an empty result rather than
 	// 4xx/5xx — see the contract on resolvePermissionName.
@@ -114,6 +121,8 @@ func (h *ConnectHandler) fetchAccessPairsOnResource(ctx context.Context, objectN
 	for _, p := range permissions {
 		resolved, ok, err := h.resolvePermissionName(ctx, objectNamespace, p)
 		if err != nil {
+			errorLogger.LogServiceError(ctx, request, operation+".resolvePermissionName", err,
+				"namespace", objectNamespace, "permission", p)
 			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 		}
 		if !ok {
@@ -143,6 +152,9 @@ func (h *ConnectHandler) fetchAccessPairsOnResource(ctx context.Context, objectN
 	}
 	checkPairs, err := h.resourceService.BatchCheck(ctx, checks)
 	if err != nil {
+		errorLogger.LogServiceError(ctx, request, operation+".BatchCheck", err,
+			"namespace", objectNamespace, "id_count", len(ids),
+			"permission_count", len(resolvedPerms))
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	// remove all the failed checks
@@ -163,7 +175,8 @@ func (h *ConnectHandler) CheckResourcePermission(ctx context.Context, req *conne
 		return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
 	}
 
-	permissionName, err := h.getPermissionName(ctx, objectNamespace, req.Msg.GetPermission())
+	permissionName, err := h.getPermissionName(ctx, objectNamespace, req.Msg.GetPermission(),
+		errorLogger, req, "CheckResourcePermission")
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +192,7 @@ func (h *ConnectHandler) CheckResourcePermission(ctx context.Context, req *conne
 			"object_id", objectID,
 			"object_namespace", objectNamespace,
 			"permission", permissionName)
-		return nil, handleAuthErr(err)
+		return nil, handleAuthErr(ctx, err)
 	}
 
 	logAuditForCheck(ctx, result, objectID, objectNamespace)
@@ -199,7 +212,8 @@ func (h *ConnectHandler) BatchCheckPermission(ctx context.Context, req *connect.
 			return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
 		}
 
-		permissionName, err := h.getPermissionName(ctx, objectNamespace, body.GetPermission())
+		permissionName, err := h.getPermissionName(ctx, objectNamespace, body.GetPermission(),
+			errorLogger, req, "BatchCheckPermission")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/api/v1beta1connect/preferences.go
+++ b/internal/api/v1beta1connect/preferences.go
@@ -2,6 +2,7 @@ package v1beta1connect
 
 import (
 	"context"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/preference"
@@ -20,7 +21,7 @@ func (h *ConnectHandler) ListPreferences(ctx context.Context, req *connect.Reque
 	})
 	if err != nil {
 		errorLogger.LogServiceError(ctx, req, "ListPreferences", err)
-		return nil, handlePreferenceError(err)
+		return nil, handlePreferenceError(ctx, err)
 	}
 
 	var pbPrefs []*frontierv1beta1.Preference
@@ -47,7 +48,7 @@ func (h *ConnectHandler) CreatePreferences(ctx context.Context, req *connect.Req
 			errorLogger.LogServiceError(ctx, req, "CreatePreferences", err,
 				"preference_name", prefBody.GetName(),
 				"preference_value", prefBody.GetValue())
-			return nil, handlePreferenceError(err)
+			return nil, handlePreferenceError(ctx, err)
 		}
 		createdPreferences = append(createdPreferences, pref)
 	}
@@ -78,7 +79,7 @@ func (h *ConnectHandler) CreateOrganizationPreferences(ctx context.Context, req 
 				"organization_id", req.Msg.GetId(),
 				"preference_name", prefBody.GetName(),
 				"preference_value", prefBody.GetValue())
-			return nil, handlePreferenceError(err)
+			return nil, handlePreferenceError(ctx, err)
 		}
 		createdPreferences = append(createdPreferences, pref)
 	}
@@ -102,7 +103,7 @@ func (h *ConnectHandler) ListOrganizationPreferences(ctx context.Context, req *c
 	if err != nil {
 		errorLogger.LogServiceError(ctx, req, "ListOrganizationPreferences", err,
 			"organization_id", req.Msg.GetId())
-		return nil, handlePreferenceError(err)
+		return nil, handlePreferenceError(ctx, err)
 	}
 
 	var pbPrefs []*frontierv1beta1.Preference
@@ -133,7 +134,7 @@ func (h *ConnectHandler) CreateUserPreferences(ctx context.Context, req *connect
 				"user_id", req.Msg.GetId(),
 				"preference_name", prefBody.GetName(),
 				"preference_value", prefBody.GetValue())
-			return nil, handlePreferenceError(err)
+			return nil, handlePreferenceError(ctx, err)
 		}
 		createdPreferences = append(createdPreferences, pref)
 	}
@@ -163,7 +164,7 @@ func (h *ConnectHandler) ListUserPreferences(ctx context.Context, req *connect.R
 	if err != nil {
 		errorLogger.LogServiceError(ctx, req, "ListUserPreferences", err,
 			"user_id", req.Msg.GetId())
-		return nil, handlePreferenceError(err)
+		return nil, handlePreferenceError(ctx, err)
 	}
 
 	var pbPrefs []*frontierv1beta1.Preference
@@ -201,7 +202,7 @@ func (h *ConnectHandler) CreateCurrentUserPreferences(ctx context.Context, req *
 				"principal_type", principal.Type,
 				"preference_name", prefBody.GetName(),
 				"preference_value", prefBody.GetValue())
-			return nil, handlePreferenceError(err)
+			return nil, handlePreferenceError(ctx, err)
 		}
 		createdPreferences = append(createdPreferences, pref)
 	}
@@ -238,7 +239,7 @@ func (h *ConnectHandler) ListCurrentUserPreferences(ctx context.Context, req *co
 		errorLogger.LogServiceError(ctx, req, "ListCurrentUserPreferences", err,
 			"principal_id", principal.ID,
 			"principal_type", principal.Type)
-		return nil, handlePreferenceError(err)
+		return nil, handlePreferenceError(ctx, err)
 	}
 
 	var pbPrefs []*frontierv1beta1.Preference
@@ -322,7 +323,7 @@ func transformPreferenceTraitToPB(pref preference.Trait) *frontierv1beta1.Prefer
 	return pbTrait
 }
 
-func handlePreferenceError(err error) *connect.Error {
+func handlePreferenceError(ctx context.Context, err error) *connect.Error {
 	switch {
 	case errors.Is(err, preference.ErrInvalidFilter):
 		return connect.NewError(connect.CodeInvalidArgument, ErrInvalidPreferenceFilter)
@@ -333,6 +334,7 @@ func handlePreferenceError(err error) *connect.Error {
 	case errors.Is(err, preference.ErrInvalidScope):
 		return connect.NewError(connect.CodeInvalidArgument, ErrInvalidPreferenceScope)
 	default:
+		slog.ErrorContext(ctx, "unhandled preference error", "error", err)
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 }

--- a/internal/api/v1beta1connect/project.go
+++ b/internal/api/v1beta1connect/project.go
@@ -2,6 +2,7 @@ package v1beta1connect
 
 import (
 	"context"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/audit"
@@ -69,7 +70,7 @@ func (h *ConnectHandler) CreateProject(ctx context.Context, request *connect.Req
 		errorLogger.LogServiceError(ctx, request, "CreateProject", err,
 			"project_name", request.Msg.GetBody().GetName(),
 			"org_id", request.Msg.GetBody().GetOrgId())
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	projectPB, err := transformProjectToPB(newProject)
@@ -89,7 +90,7 @@ func (h *ConnectHandler) GetProject(ctx context.Context, request *connect.Reques
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "GetProject", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	projectPB, err := transformProjectToPB(fetchedProject)
@@ -120,7 +121,7 @@ func (h *ConnectHandler) UpdateProject(ctx context.Context, request *connect.Req
 		errorLogger.LogServiceError(ctx, request, "UpdateProject", err,
 			"project_id", request.Msg.GetId(),
 			"project_name", request.Msg.GetBody().GetName())
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	projectPB, err := transformProjectToPB(updatedProject)
@@ -141,7 +142,7 @@ func (h *ConnectHandler) ListProjectAdmins(ctx context.Context, request *connect
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "ListProjectAdmins.Get", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	ownerRole, err := h.roleService.Get(ctx, project.OwnerRole)
@@ -192,7 +193,7 @@ func (h *ConnectHandler) ListProjectUsers(ctx context.Context, request *connect.
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "ListProjectUsers.Get", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	members, err := h.membershipService.ListPrincipalsByResource(ctx, prj.ID, schema.ProjectNamespace, membership.MemberFilter{
@@ -255,7 +256,7 @@ func (h *ConnectHandler) ListProjectServiceUsers(ctx context.Context, request *c
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "ListProjectServiceUsers.Get", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	members, err := h.membershipService.ListPrincipalsByResource(ctx, prj.ID, schema.ProjectNamespace, membership.MemberFilter{
@@ -321,7 +322,7 @@ func (h *ConnectHandler) ListProjectGroups(ctx context.Context, request *connect
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "ListProjectGroups.Get", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 
 	members, err := h.membershipService.ListPrincipalsByResource(ctx, prj.ID, schema.ProjectNamespace, membership.MemberFilter{
@@ -387,7 +388,7 @@ func (h *ConnectHandler) EnableProject(ctx context.Context, request *connect.Req
 	if err := h.projectService.Enable(ctx, projectID); err != nil {
 		errorLogger.LogServiceError(ctx, request, "EnableProject", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 	return connect.NewResponse(&frontierv1beta1.EnableProjectResponse{}), nil
 }
@@ -399,7 +400,7 @@ func (h *ConnectHandler) DisableProject(ctx context.Context, request *connect.Re
 	if err := h.projectService.Disable(ctx, projectID); err != nil {
 		errorLogger.LogServiceError(ctx, request, "DisableProject", err,
 			"project_id", projectID)
-		return nil, translateProjectServiceError(err)
+		return nil, translateProjectServiceError(ctx, err)
 	}
 	return connect.NewResponse(&frontierv1beta1.DisableProjectResponse{}), nil
 }
@@ -503,7 +504,7 @@ func transformProjectToPB(prj project.Project) (*frontierv1beta1.Project, error)
 	}, nil
 }
 
-func translateProjectServiceError(err error) error {
+func translateProjectServiceError(ctx context.Context, err error) error {
 	switch {
 	case errors.Is(err, user.ErrInvalidEmail):
 		return connect.NewError(connect.CodeUnauthenticated, ErrUnauthenticated)
@@ -514,6 +515,7 @@ func translateProjectServiceError(err error) error {
 	case errors.Is(err, project.ErrNotExist), errors.Is(err, project.ErrInvalidUUID), errors.Is(err, project.ErrInvalidID):
 		return connect.NewError(connect.CodeNotFound, ErrNotFound)
 	default:
+		slog.ErrorContext(ctx, "unhandled project service error", "error", err)
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 }

--- a/internal/api/v1beta1connect/prospect.go
+++ b/internal/api/v1beta1connect/prospect.go
@@ -227,6 +227,8 @@ func (h *ConnectHandler) UpdateProspect(ctx context.Context, request *connect.Re
 	subsStatus := frontierv1beta1.Prospect_Status_name[int32(reqStatus)] // convert using proto methods
 	metaDataMap, err := buildAndValidateMetadata(request.Msg.GetMetadata().AsMap(), h)
 	if err != nil {
+		errorLogger.LogServiceError(ctx, request, "UpdateProspect.buildAndValidateMetadata", err,
+			"prospect_id", prospectId)
 		return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 	updatedProspect, err := h.prospectService.Update(ctx, prospect.Prospect{

--- a/internal/api/v1beta1connect/serviceuser.go
+++ b/internal/api/v1beta1connect/serviceuser.go
@@ -504,12 +504,9 @@ func (h *ConnectHandler) ListServiceUserProjects(ctx context.Context, request *c
 		resourceIds := utils.Map(projList, func(res project.Project) string {
 			return res.ID
 		})
-		successCheckPairs, err := h.fetchAccessPairsOnResource(ctx, schema.ProjectNamespace, resourceIds, request.Msg.GetWithPermissions())
+		successCheckPairs, err := h.fetchAccessPairsOnResource(ctx, schema.ProjectNamespace, resourceIds, request.Msg.GetWithPermissions(),
+			errorLogger, request, "ListServiceUserProjects")
 		if err != nil {
-			errorLogger.LogServiceError(ctx, request, "ListServiceUserProjects.FetchAccessPairs", err,
-				"service_user_id", serviceUserID,
-				"org_id", orgID,
-				"with_permissions", request.Msg.GetWithPermissions())
 			return nil, err
 		}
 		permsByProject := map[string][]string{}

--- a/internal/api/v1beta1connect/user.go
+++ b/internal/api/v1beta1connect/user.go
@@ -544,12 +544,10 @@ func (h *ConnectHandler) ListCurrentUserGroups(ctx context.Context, request *con
 		resourceIds := utils.Map(groupsList, func(res group.Group) string {
 			return res.ID
 		})
-		successCheckPairs, err := h.fetchAccessPairsOnResource(ctx, schema.GroupNamespace, resourceIds, request.Msg.GetWithPermissions())
+		successCheckPairs, err := h.fetchAccessPairsOnResource(ctx, schema.GroupNamespace, resourceIds, request.Msg.GetWithPermissions(),
+			errorLogger, request, "ListCurrentUserGroups")
 		if err != nil {
-			errorLogger.LogUnexpectedError(ctx, request, "ListCurrentUserGroups", err,
-				"principal_id", principal.ID,
-				"org_id", request.Msg.GetOrgId())
-			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+			return nil, err
 		}
 		permsByGroup := map[string][]string{}
 		groupOrder := make([]string, 0, len(groupsList))
@@ -665,7 +663,7 @@ func (h *ConnectHandler) ExportUsers(ctx context.Context, request *connect.Reque
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 
-	return streamBytesInChunks(userDataBytes, contentType, stream)
+	return streamBytesInChunks(ctx, userDataBytes, contentType, stream)
 }
 
 func (h *ConnectHandler) SearchUsers(ctx context.Context, request *connect.Request[frontierv1beta1.SearchUsersRequest]) (*connect.Response[frontierv1beta1.SearchUsersResponse], error) {
@@ -943,13 +941,10 @@ func (h *ConnectHandler) ListProjectsByCurrentUser(ctx context.Context, request 
 		resourceIds := utils.Map(projList, func(res project.Project) string {
 			return res.ID
 		})
-		successCheckPairs, err := h.fetchAccessPairsOnResource(ctx, schema.ProjectNamespace, resourceIds, request.Msg.GetWithPermissions())
+		successCheckPairs, err := h.fetchAccessPairsOnResource(ctx, schema.ProjectNamespace, resourceIds, request.Msg.GetWithPermissions(),
+			errorLogger, request, "ListProjectsByCurrentUser")
 		if err != nil {
-			errorLogger.LogUnexpectedError(ctx, request, "ListProjectsByCurrentUser", err,
-				"principal_id", principal.ID,
-				"principal_type", principal.Type,
-				"org_id", request.Msg.GetOrgId())
-			return nil, connect.NewError(connect.CodeInternal, ErrInternalServerError)
+			return nil, err
 		}
 		// Group permissions by project id, emit one access pair per project in
 		// first-seen order. successCheckPairs is unique by (resID, permName) so

--- a/internal/api/v1beta1connect/user_pat.go
+++ b/internal/api/v1beta1connect/user_pat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/core/authenticate"
@@ -33,7 +34,7 @@ func (h *ConnectHandler) getLoggedInPrincipalWithUser(ctx context.Context) (*aut
 }
 
 // mapPATError maps PAT service errors to Connect RPC error codes.
-func mapPATError(err error) *connect.Error {
+func mapPATError(ctx context.Context, err error) *connect.Error {
 	switch {
 	case errors.Is(err, paterrors.ErrDisabled):
 		return connect.NewError(connect.CodeFailedPrecondition, err)
@@ -52,6 +53,7 @@ func mapPATError(err error) *connect.Error {
 		errors.Is(err, paterrors.ErrExpiryExceeded):
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	default:
+		slog.ErrorContext(ctx, "unhandled PAT service error", "error", err)
 		return connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
 }
@@ -83,7 +85,7 @@ func (h *ConnectHandler) CreateCurrentUserPAT(ctx context.Context, request *conn
 		errorLogger.LogServiceError(ctx, request, "CreateCurrentUserPAT", err,
 			"user_id", principal.User.ID,
 			"org_id", request.Msg.GetOrgId())
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.CreateCurrentUserPATResponse{
@@ -104,7 +106,7 @@ func (h *ConnectHandler) GetCurrentUserPAT(ctx context.Context, request *connect
 		errorLogger.LogServiceError(ctx, request, "GetCurrentUserPAT", err,
 			"user_id", principal.User.ID,
 			"pat_id", request.Msg.GetId())
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.GetCurrentUserPATResponse{
@@ -118,7 +120,7 @@ func (h *ConnectHandler) ListRolesForPAT(ctx context.Context, request *connect.R
 	roleList, err := h.userPATService.ListAllowedRoles(ctx, request.Msg.GetScopes())
 	if err != nil {
 		errorLogger.LogServiceError(ctx, request, "ListRolesForPAT", err)
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	var roles []*frontierv1beta1.Role
@@ -146,7 +148,7 @@ func (h *ConnectHandler) DeleteCurrentUserPAT(ctx context.Context, request *conn
 		errorLogger.LogServiceError(ctx, request, "DeleteCurrentUserPAT", err,
 			"user_id", principal.User.ID,
 			"pat_id", request.Msg.GetId())
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.DeleteCurrentUserPATResponse{}), nil
@@ -171,7 +173,7 @@ func (h *ConnectHandler) UpdateCurrentUserPAT(ctx context.Context, request *conn
 		errorLogger.LogServiceError(ctx, request, "UpdateCurrentUserPAT", err,
 			"user_id", principal.User.ID,
 			"pat_id", request.Msg.GetId())
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.UpdateCurrentUserPATResponse{
@@ -196,7 +198,7 @@ func (h *ConnectHandler) RegenerateCurrentUserPAT(ctx context.Context, request *
 		errorLogger.LogServiceError(ctx, request, "RegenerateCurrentUserPAT", err,
 			"user_id", principal.User.ID,
 			"pat_id", request.Msg.GetId())
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.RegenerateCurrentUserPATResponse{
@@ -217,7 +219,7 @@ func (h *ConnectHandler) CheckCurrentUserPATTitle(ctx context.Context, request *
 		errorLogger.LogServiceError(ctx, request, "CheckCurrentUserPATTitle", err,
 			"user_id", principal.User.ID,
 			"org_id", request.Msg.GetOrgId())
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.CheckCurrentUserPATTitleResponse{
@@ -301,7 +303,7 @@ func (h *ConnectHandler) SearchCurrentUserPATs(ctx context.Context, request *con
 			"user_id", userID,
 			"org_id", request.Msg.GetOrgId())
 
-		return nil, mapPATError(err)
+		return nil, mapPATError(ctx, err)
 	}
 
 	pbPATs := make([]*frontierv1beta1.PAT, 0, len(result.PATs))

--- a/internal/api/v1beta1connect/v1beta1connect.go
+++ b/internal/api/v1beta1connect/v1beta1connect.go
@@ -135,6 +135,9 @@ func (h *ConnectHandler) GetOrgIDFromSubscriptionID(ctx context.Context, subscri
 		if errors.Is(err, subscription.ErrNotFound) {
 			return "", connect.NewError(connect.CodeNotFound, err)
 		}
+		if errors.Is(err, subscription.ErrInvalidUUID) || errors.Is(err, subscription.ErrInvalidID) {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
+		}
 		slog.ErrorContext(ctx, "failed to get subscription for org lookup",
 			"subscription_id", subscriptionID, "error", err)
 		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
@@ -157,6 +160,9 @@ func (h *ConnectHandler) GetOrgIDFromCheckoutID(ctx context.Context, checkoutID 
 	if err != nil {
 		if errors.Is(err, checkout.ErrNotFound) {
 			return "", connect.NewError(connect.CodeNotFound, err)
+		}
+		if errors.Is(err, checkout.ErrInvalidUUID) || errors.Is(err, checkout.ErrInvalidID) {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
 		}
 		slog.ErrorContext(ctx, "failed to get checkout for org lookup",
 			"checkout_id", checkoutID, "error", err)

--- a/internal/api/v1beta1connect/v1beta1connect.go
+++ b/internal/api/v1beta1connect/v1beta1connect.go
@@ -2,9 +2,15 @@ package v1beta1connect
 
 import (
 	"context"
+	"log/slog"
 
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/billing/checkout"
+	"github.com/raystack/frontier/billing/customer"
+	"github.com/raystack/frontier/billing/subscription"
 	"github.com/raystack/frontier/core/authenticate"
 	"github.com/raystack/frontier/internal/api"
+	"github.com/raystack/frontier/pkg/errors"
 	frontierv1beta1connect "github.com/raystack/frontier/proto/v1beta1/frontierv1beta1connect"
 )
 
@@ -126,35 +132,61 @@ func (h *ConnectHandler) GetBillingAccountFromOrgID(ctx context.Context, orgID s
 func (h *ConnectHandler) GetOrgIDFromSubscriptionID(ctx context.Context, subscriptionID string) (string, error) {
 	sub, err := h.subscriptionService.GetByID(ctx, subscriptionID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, subscription.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, err)
+		}
+		slog.ErrorContext(ctx, "failed to get subscription for org lookup",
+			"subscription_id", subscriptionID, "error", err)
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	// Get the billing account (customer) to find the org
-	customer, err := h.customerService.GetByID(ctx, sub.CustomerID)
+	cust, err := h.customerService.GetByID(ctx, sub.CustomerID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, customer.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		slog.ErrorContext(ctx, "failed to get billing account for org lookup",
+			"customer_id", sub.CustomerID, "subscription_id", subscriptionID, "error", err)
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return customer.OrgID, nil
+	return cust.OrgID, nil
 }
 
 // GetOrgIDFromCheckoutID returns the organization ID for a given checkout
 func (h *ConnectHandler) GetOrgIDFromCheckoutID(ctx context.Context, checkoutID string) (string, error) {
-	checkout, err := h.checkoutService.GetByID(ctx, checkoutID)
+	co, err := h.checkoutService.GetByID(ctx, checkoutID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, checkout.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, err)
+		}
+		slog.ErrorContext(ctx, "failed to get checkout for org lookup",
+			"checkout_id", checkoutID, "error", err)
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	// Get the billing account (customer) to find the org
-	customer, err := h.customerService.GetByID(ctx, checkout.CustomerID)
+	cust, err := h.customerService.GetByID(ctx, co.CustomerID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, customer.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		slog.ErrorContext(ctx, "failed to get billing account for org lookup",
+			"customer_id", co.CustomerID, "checkout_id", checkoutID, "error", err)
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return customer.OrgID, nil
+	return cust.OrgID, nil
 }
 
 // GetOrgIDFromBillingAccountID returns the organization ID for a given billing account
 func (h *ConnectHandler) GetOrgIDFromBillingAccountID(ctx context.Context, billingAccountID string) (string, error) {
-	customer, err := h.customerService.GetByID(ctx, billingAccountID)
+	cust, err := h.customerService.GetByID(ctx, billingAccountID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, customer.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		if errors.Is(err, customer.ErrInvalidUUID) || errors.Is(err, customer.ErrInvalidID) {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		slog.ErrorContext(ctx, "failed to get billing account for org lookup",
+			"billing_account_id", billingAccountID, "error", err)
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return customer.OrgID, nil
+	return cust.OrgID, nil
 }

--- a/pkg/server/connect_interceptors/logger.go
+++ b/pkg/server/connect_interceptors/logger.go
@@ -62,10 +62,8 @@ func UnaryConnectLoggerInterceptor(logger *slog.Logger, opts *LoggerOptions) con
 			attrs := []any{
 				"system", "connect_rpc",
 				"start_time", startTime,
-				"method", req.Spec().Procedure,
 				"time_ms", duration.Milliseconds(),
 				"code", code.String(),
-				"request_id", requestID,
 			}
 			if err != nil {
 				attrs = append(attrs, "error", err)


### PR DESCRIPTION
## Summary

- Billing authZ interceptor helpers (`getOrgForBillingAccount`, `GetOrgIDFromBillingAccountID`, `GetOrgIDFromSubscriptionID`, `GetOrgIDFromCheckoutID`) were returning raw Go errors instead of `*connect.Error`, causing `code_0`/`unknown` in logs and metrics. Now wraps with proper `CodeNotFound`, `CodeInvalidArgument`, or `CodeInternal`.
- Adds error logging to 11 handler code paths that silently swallowed errors before returning `CodeInternal`.
- Fixes duplicate `request_id` and `method` fields in the interceptor log (were added to both context attrs and explicit attrs).

## Test plan

- [ ] Verify billing endpoints return `not_found` (404) for nonexistent billing accounts instead of `unknown`/500
- [ ] Verify subscription/checkout endpoints return `not_found` for nonexistent resources
- [ ] Verify all happy paths (list, get, create) are unchanged
- [ ] Verify `request_id` appears exactly once in log lines
- [ ] Verify new error logs contain the original error details (operation, error_type, error message)