### PR TITLE
fix(docker): run containers as non-root user and update alpine to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:3.18
+FROM alpine:3.21
 
-COPY frontier /usr/bin/frontier
-
+RUN adduser -D -h /home/frontier frontier
+COPY --chown=frontier frontier /usr/bin/frontier
+USER frontier
 ENTRYPOINT ["frontier"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,10 +23,12 @@ COPY --from=admin-builder /app/web/apps/admin/dist /app/web/apps/admin/dist
 RUN make build
 
 # Build the final image
-FROM alpine:3.18
+FROM alpine:3.21
+RUN adduser -D -h /home/frontier frontier
 COPY --from=builder /app/frontier /usr/bin/
 RUN apk update && \
     apk add --no-cache ca-certificates libc6-compat && \
     rm -rf /var/cache/apk/*
 
+USER frontier
 ENTRYPOINT ["frontier"]


### PR DESCRIPTION
## Summary
- Both `Dockerfile` and `Dockerfile.dev` ran as root (no `USER` directive)
- Added non-root `frontier` user and `USER frontier` directive to both
- Updated base image from `alpine:3.18` (June 2023, approaching EOL) to `alpine:3.21`

## Why this is safe
- Frontier binds to ports 8002, 9000, 8083 — all >1024, no root needed
- Zero file writes at runtime — no `os.Create`/`os.Write`/`os.Mkdir` in app code
- Binary at `/usr/bin/frontier` only needs read+execute, not ownership
- Config files are read-only at runtime

## Test plan
- [ ] Build production image: `docker build -t frontier-test .`
- [ ] Build dev image: `docker build -f Dockerfile.dev -t frontier-dev-test .`
- [ ] Verify process runs as non-root: `docker exec <container> whoami` → `frontier`
- [ ] Verify all ports (8002, 9000, 8083) respond normally
- [ ] Verify mounted config files are readable by the `frontier` user