### PR TITLE
fix(admin): invoice amount filter units, org URL error, search focus

### DIFF
--- a/web/sdk/admin/views/organizations/details/invoices/index.tsx
+++ b/web/sdk/admin/views/organizations/details/invoices/index.tsx
@@ -35,6 +35,26 @@ const TRANSFORM_OPTIONS = {
   },
 };
 
+// The backend stores invoice amounts in cents, but the amount filter input
+// takes dollars — convert the filter value to cents before sending the query.
+function convertAmountFiltersToCents(query: DataTableQuery): DataTableQuery {
+  if (!query.filters?.length) return query;
+  return {
+    ...query,
+    filters: query.filters.map(filter =>
+      filter.name === "amount"
+        ? {
+            ...filter,
+            value: Math.round(Number(filter.value) * 100),
+            ...(filter.numberValue !== undefined && {
+              numberValue: Math.round(filter.numberValue * 100),
+            }),
+          }
+        : filter,
+    ),
+  };
+}
+
 const NoInvoices = () => {
   return (
     <EmptyState
@@ -81,7 +101,10 @@ export function OrganizationInvoicesView() {
   const title = `Invoices | ${organization?.title} | ${t.organization({ plural: true, case: "capital" })}`;
 
   const computedQuery = useMemo(() => {
-    const tempQuery = transformDataTableQueryToRQLRequest(tableQuery, TRANSFORM_OPTIONS);
+    const tempQuery = transformDataTableQueryToRQLRequest(
+      convertAmountFiltersToCents(tableQuery),
+      TRANSFORM_OPTIONS,
+    );
     return {
       ...tempQuery,
       search: searchQuery || "",

--- a/web/sdk/admin/views/organizations/list/create.tsx
+++ b/web/sdk/admin/views/organizations/list/create.tsx
@@ -110,7 +110,7 @@ export function CreateOrganizationPanel({
       onError: (error) => {
         if (error?.code === Code.AlreadyExists) {
           setError("name", {
-            message: `${t.organization({ case: "capital" })} name already exists`,
+            message: `${t.organization({ case: "capital" })} URL is already taken`,
           });
         } else {
           console.error("Unable to create new org:", error);

--- a/web/sdk/admin/views/organizations/list/navbar.tsx
+++ b/web/sdk/admin/views/organizations/list/navbar.tsx
@@ -79,6 +79,7 @@ export const OrganizationsNavabar = ({
             showClearButton={true}
             size="small"
             onBlur={onSearchBlur}
+            autoFocus
           />
         ) : (
           <IconButton


### PR DESCRIPTION
## Summary

- Convert the invoice amount filter value from dollars to cents before sending the `SearchOrganizationInvoices` RQL query — the backend stores amounts in cents, but the filter input was sending dollars, so number filters never matched
- Fix misleading duplicate-org error in the create organization panel: the `AlreadyExists` error now says "Organization URL is already taken" instead of "name already exists", matching the field's label ("Organization URL")
- Auto-focus the organizations list search input when it's opened