### PR TITLE
fix(invitation): remove user relation on invitation delete

### DIFF
--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -247,12 +247,15 @@ func (s Service) createRelations(ctx context.Context, invitationID uuid.UUID, or
 }
 
 func (s Service) Delete(ctx context.Context, id uuid.UUID) error {
+	// Remove every relation anchored on the invitation object, not just the org
+	// one. createRelations writes both a user (app/invitation:<id>#user) and an
+	// org (app/invitation:<id>#org) tuple; filtering by org alone leaked the user
+	// tuple on every accept/expire/delete. Omitting RelationName matches both.
 	err := s.relationService.Delete(ctx, relation.Relation{
 		Object: relation.Object{
 			ID:        id.String(),
 			Namespace: schema.InvitationNamespace,
 		},
-		RelationName: schema.OrganizationRelationName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete relation for invitation: %w", err)

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -2319,6 +2319,14 @@ func (s *APIRegressionTestSuite) TestInvitationAPI() {
 		}))
 		s.Assert().Error(err)
 
+		// no SpiceDB relation should linger on the invitation object after accept:
+		// both the #user and #org tuples must be gone, not just #org (gap #1661.3)
+		leftoverInviteRelations, err := s.testBench.AdminClient.ListRelations(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.ListRelationsRequest{
+			Object: schema.JoinNamespaceAndResourceID(schema.InvitationNamespace, createdInvite.GetId()),
+		}))
+		s.Assert().NoError(err)
+		s.Assert().Empty(leftoverInviteRelations.Msg.GetRelations())
+
 		// should be part of group
 		listGroupUsersAfterAccept, err := s.testBench.Client.ListGroupUsers(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.ListGroupUsersRequest{
 			Id:    createGroupResp.Msg.GetGroup().GetId(),


### PR DESCRIPTION
## What

Invitation creation writes two SpiceDB tuples anchored on the invitation object:

- `app/invitation:<id>#user@app/user:<email>`
- `app/invitation:<id>#org@app/organization:<org>`

`Invitation.Delete` filtered the relation delete by the **org** relation name only, so the `#user` tuple was left behind on every **accept**, **expire**, and **delete**. These orphan tuples accumulated in SpiceDB over time.

## Fix

Drop the `RelationName` filter in `Delete` so it removes **every** relation anchored on the invitation object (the same pattern `role.Delete` already uses). `Accept` already routes its cleanup through `Delete`, so accept is covered too.

## Test

Extends the existing `TestInvitationAPI` accept flow with an assertion that, after accepting an invitation, `ListRelations` returns no relation on the invitation object. Verified the assertion **fails without the fix** (leftover `#user` tuple) and **passes with it**.

Addresses gap (3) of #1661.