### PR TITLE
chore: upgrade Go from 1.24.4 to 1.26.4 to fix 32 stdlib vulnerabilities

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.2.1
+          version: v2.12.2
   js-sdk-lint:
     name: JS SDK Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: install dependencies
         run: go mod tidy
       - name: run unit tests
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: install dependencies
         run: go mod tidy
       - name: run smoke tests
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.4"
+          go-version: "1.26.4"
       - name: install dependencies
         run: go mod tidy
       - name: run regression tests

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,7 @@ ENV CI=true
 RUN make admin-app
 
 # Build the Go binary
-FROM golang:1.24.4-alpine3.21 AS builder
+FROM golang:1.26.4-alpine3.23 AS builder
 RUN apk add --no-cache make
 WORKDIR /app
 

--- a/billing/customer/service.go
+++ b/billing/customer/service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/raystack/frontier/billing"
 	"github.com/raystack/frontier/internal/metrics"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/raystack/frontier/pkg/metadata"
 

--- a/billing/entitlement/service.go
+++ b/billing/entitlement/service.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/raystack/frontier/billing/plan"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/raystack/frontier/billing/product"
 	"github.com/raystack/frontier/billing/subscription"

--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mcuadros/go-defaults"
 	"github.com/stripe/stripe-go/v79"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/raystack/frontier/pkg/utils"

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -29,7 +29,7 @@ import (
 	"github.com/raystack/frontier/core/prospect"
 	"github.com/raystack/frontier/core/userpat"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/jackc/pgx/v4"

--- a/config/init.go
+++ b/config/init.go
@@ -3,7 +3,6 @@ package config
 import (
 	_ "embed"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ func Init(configFile string) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(configFile, data, 0655); err != nil {
+	if err := os.WriteFile(configFile, data, 0655); err != nil {
 		return err
 	}
 

--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 )

--- a/core/audit/service.go
+++ b/core/audit/service.go
@@ -3,7 +3,7 @@ package audit
 import (
 	"context"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/raystack/frontier/core/webhook"

--- a/core/authenticate/service.go
+++ b/core/authenticate/service.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/raystack/frontier/core/audit"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	frontiersession "github.com/raystack/frontier/core/authenticate/session"
 	"github.com/raystack/frontier/core/serviceuser"

--- a/core/preference/validator.go
+++ b/core/preference/validator.go
@@ -3,7 +3,7 @@ package preference
 import (
 	"strings"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 type PreferenceValidator interface {

--- a/core/webhook/service.go
+++ b/core/webhook/service.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/raystack/frontier/pkg/server/consts"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/raystack/frontier
 
-go 1.24.0
+go 1.26.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1

--- a/internal/store/blob/blob.go
+++ b/internal/store/blob/blob.go
@@ -3,7 +3,6 @@ package blob
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -45,7 +44,7 @@ func NewStore(ctx context.Context, storagePath, storageSecret string) (Bucket, e
 			}
 		case "file":
 			{
-				fileContent, err := ioutil.ReadFile(parsedSecretURL.Path)
+				fileContent, err := os.ReadFile(parsedSecretURL.Path)
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to read secret content at "+parsedSecretURL.Path)
 				}

--- a/internal/store/postgres/billing_customer_repository_test.go
+++ b/internal/store/postgres/billing_customer_repository_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/pkg/utils"

--- a/internal/store/postgres/org_billing_repository.go
+++ b/internal/store/postgres/org_billing_repository.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/doug-martin/goqu/v9"
 	"github.com/jmoiron/sqlx"
 	svc "github.com/raystack/frontier/core/aggregates/orgbilling"
 	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/pkg/db"
 	"github.com/raystack/salt/rql"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ func DirExists(path string) bool {
 // File extension matters, only file with extension
 // json, yaml, or yml that is parsable
 func Parse(filePath string, v interface{}) error {
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/rql.go
+++ b/pkg/utils/rql.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/doug-martin/goqu/v9"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/raystack/salt/rql"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/raystack/frontier/pkg/utils"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/raystack/frontier/pkg/server"
 


### PR DESCRIPTION
## Summary
- Upgrades Go from 1.24.4 → 1.26.4 to fix 32 stdlib vulnerabilities reported by `govulncheck`
- Upgrades golangci-lint from v2.2.1 → v2.12.2 for Go 1.26 compatibility
- Replaces deprecated `ioutil.ReadFile`/`ioutil.WriteFile` with `os.ReadFile`/`os.WriteFile` (3 files)
- Migrates `golang.org/x/exp/slices` to stdlib `slices` package (13 files)

## Changes
| File | Change |
|---|---|
| `go.mod` | `go 1.24.0` → `go 1.26.4` |
| `Dockerfile.dev` | `golang:1.24.4-alpine3.21` → `golang:1.26.4-alpine3.23` |
| `.github/workflows/release.yml` | `go-version: "1.26.4"` (3 instances) |
| `.github/workflows/main.yml` | `go-version: "1.26.4"` (1 instance) |
| `.github/workflows/test.yml` | `go-version: "1.26.4"` (3 instances) |
| `.github/workflows/lint.yml` | `go-version: "1.26.4"` + golangci-lint v2.12.2 |
| `config/init.go` | `ioutil.WriteFile` → `os.WriteFile` |
| `internal/store/blob/blob.go` | `ioutil.ReadFile` → `os.ReadFile` |
| `pkg/file/file.go` | `ioutil.ReadFile` → `os.ReadFile` |
| 13 files | `golang.org/x/exp/slices` → stdlib `slices` |

## Stdlib vulns fixed (32)
`crypto/tls`, `crypto/x509`, `net/http`, `net/url`, `net/mail`, `net/textproto`, `html/template`, `os`, `os/exec`, `database/sql`, `encoding/asn1`, `encoding/pem`, `net/http/httputil`, `net`

## Test plan
- [x] `go build ./...` — pass
- [x] `go vet ./...` — pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./core/... ./internal/api/... ./billing/... ./pkg/... ./cmd/...` — all pass
- [x] Zero remaining references to Go 1.24
- [ ] CI workflows pass
- [ ] Docker build succeeds with `golang:1.26.4-alpine3.23`