### PR TITLE
fix(api): add error sanitizer interceptor and fix billing response codes

### DIFF
--- a/internal/api/v1beta1connect/errors.go
+++ b/internal/api/v1beta1connect/errors.go
@@ -8,7 +8,7 @@ var (
 	ErrBadRequest                  = errors.New("invalid syntax in body")
 	ErrInvalidMetadata             = errors.New("metadata schema validation failed")
 	ErrOperationUnsupported        = errors.New("operation not supported")
-	ErrInternalServerError         = errors.New("internal server error")
+	ErrInternalServerError         = errors.ErrInternalServerError
 	ErrUnauthenticated             = errors.New("not authenticated")
 	ErrUnauthorized                = errors.New("not authorized")
 	ErrNotFound                    = errors.New("not found")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -11,8 +11,9 @@ var (
 )
 
 var (
-	ErrUnauthenticated = errors.New("not authenticated")
-	ErrForbidden       = errors.New("not authorized")
-	ErrInvalidUUID     = errors.New("invalid syntax of uuid")
-	ErrNotFound        = errors.New("not found")
+	ErrUnauthenticated     = errors.New("not authenticated")
+	ErrForbidden           = errors.New("not authorized")
+	ErrInvalidUUID         = errors.New("invalid syntax of uuid")
+	ErrNotFound            = errors.New("not found")
+	ErrInternalServerError = errors.New("internal server error")
 )

--- a/pkg/server/connect_interceptors/error_sanitizer.go
+++ b/pkg/server/connect_interceptors/error_sanitizer.go
@@ -1,0 +1,31 @@
+package connectinterceptors
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+func UnaryConnectErrorSanitizerInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			resp, err := next(ctx, req)
+			if err == nil {
+				return resp, nil
+			}
+
+			var connectErr *connect.Error
+			if !errors.As(err, &connectErr) {
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
+			}
+
+			code := connectErr.Code()
+			if code == connect.CodeInternal || code == connect.CodeUnknown {
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
+			}
+
+			return resp, err
+		}
+	}
+}

--- a/pkg/server/connect_interceptors/error_sanitizer.go
+++ b/pkg/server/connect_interceptors/error_sanitizer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"connectrpc.com/connect"
+	pkgerrors "github.com/raystack/frontier/pkg/errors"
 )
 
 func UnaryConnectErrorSanitizerInterceptor() connect.UnaryInterceptorFunc {
@@ -17,12 +18,12 @@ func UnaryConnectErrorSanitizerInterceptor() connect.UnaryInterceptorFunc {
 
 			var connectErr *connect.Error
 			if !errors.As(err, &connectErr) {
-				return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
+				return nil, connect.NewError(connect.CodeInternal, pkgerrors.ErrInternalServerError)
 			}
 
 			code := connectErr.Code()
 			if code == connect.CodeInternal || code == connect.CodeUnknown {
-				return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
+				return nil, connect.NewError(connect.CodeInternal, pkgerrors.ErrInternalServerError)
 			}
 
 			return resp, err

--- a/pkg/server/connect_interceptors/error_sanitizer_test.go
+++ b/pkg/server/connect_interceptors/error_sanitizer_test.go
@@ -1,0 +1,115 @@
+package connectinterceptors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+)
+
+func TestUnaryConnectErrorSanitizerInterceptor(t *testing.T) {
+	sanitizer := UnaryConnectErrorSanitizerInterceptor()
+
+	tests := []struct {
+		name        string
+		handlerErr  error
+		wantCode    connect.Code
+		wantMessage string
+		wantSameErr bool
+	}{
+		{
+			name:        "nil error passes through",
+			handlerErr:  nil,
+			wantSameErr: true,
+		},
+		{
+			name:        "CodeNotFound passes through unchanged",
+			handlerErr:  connect.NewError(connect.CodeNotFound, errors.New("user not found")),
+			wantCode:    connect.CodeNotFound,
+			wantMessage: "user not found",
+			wantSameErr: true,
+		},
+		{
+			name:        "CodeInvalidArgument passes through unchanged",
+			handlerErr:  connect.NewError(connect.CodeInvalidArgument, errors.New("bad input")),
+			wantCode:    connect.CodeInvalidArgument,
+			wantMessage: "bad input",
+			wantSameErr: true,
+		},
+		{
+			name:        "CodePermissionDenied passes through unchanged",
+			handlerErr:  connect.NewError(connect.CodePermissionDenied, errors.New("forbidden")),
+			wantCode:    connect.CodePermissionDenied,
+			wantMessage: "forbidden",
+			wantSameErr: true,
+		},
+		{
+			name:        "CodeUnauthenticated passes through unchanged",
+			handlerErr:  connect.NewError(connect.CodeUnauthenticated, errors.New("not logged in")),
+			wantCode:    connect.CodeUnauthenticated,
+			wantMessage: "not logged in",
+			wantSameErr: true,
+		},
+		{
+			name:        "CodeInternal is sanitized",
+			handlerErr:  connect.NewError(connect.CodeInternal, errors.New("pq: connection refused")),
+			wantCode:    connect.CodeInternal,
+			wantMessage: "internal server error",
+		},
+		{
+			name:        "CodeUnknown is sanitized to CodeInternal",
+			handlerErr:  connect.NewError(connect.CodeUnknown, errors.New("customer not found")),
+			wantCode:    connect.CodeInternal,
+			wantMessage: "internal server error",
+		},
+		{
+			name:        "raw non-connect error is sanitized to CodeInternal",
+			handlerErr:  errors.New("sql: no rows in result set"),
+			wantCode:    connect.CodeInternal,
+			wantMessage: "internal server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := sanitizer(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+				return nil, tt.handlerErr
+			})
+
+			_, err := interceptor(context.Background(), nil)
+
+			if tt.handlerErr == nil {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+
+			if tt.wantSameErr {
+				if err != tt.handlerErr {
+					t.Fatalf("expected error to pass through unchanged, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var connectErr *connect.Error
+			if !errors.As(err, &connectErr) {
+				t.Fatalf("expected *connect.Error, got %T", err)
+			}
+			if connectErr.Code() != tt.wantCode {
+				t.Errorf("code = %v, want %v", connectErr.Code(), tt.wantCode)
+			}
+			if connectErr.Message() != tt.wantMessage {
+				t.Errorf("message = %q, want %q", connectErr.Message(), tt.wantMessage)
+			}
+			if err == tt.handlerErr {
+				t.Error("expected sanitized error to be a new instance, got same pointer")
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -149,6 +149,7 @@ func ServeConnect(ctx context.Context, logger *slog.Logger, cfg Config, deps api
 
 	interceptors := connect.WithInterceptors(
 		otelInterceptor,
+		connectinterceptors.UnaryConnectErrorSanitizerInterceptor(),
 		connectinterceptors.UnaryConnectLoggerInterceptor(logger, loggerOpts),
 		connectinterceptors.UnaryConnectErrorResponseInterceptor(),
 		sessionInterceptor,


### PR DESCRIPTION
## Summary

Add a Connect RPC interceptor that sanitizes `CodeInternal` and `CodeUnknown` errors before they reach clients — prevents leaking internal error details (e.g. database errors, raw service messages).

## How it works

The `UnaryConnectErrorSanitizerInterceptor` sits between OTEL and the logger in the interceptor chain. On the response path: the logger logs the original error with full detail, then the sanitizer replaces `CodeInternal`/`CodeUnknown`/non-connect errors with a generic `CodeInternal: "internal server error"` before the response reaches the client.

This makes it safe for handlers to return `connect.NewError(connect.CodeInternal, err)` with the real error — the interceptor ensures the client only ever sees the generic message.

## Test plan

- [x] `go test ./pkg/server/connect_interceptors/ -run TestUnaryConnectErrorSanitizerInterceptor -v` — 8 unit tests for the interceptor
- [x] `go build ./...` — full build passes