### PR TITLE
fix(api): remove duplicate request_id and method from logger attrs

### DIFF
--- a/pkg/server/connect_interceptors/logger.go
+++ b/pkg/server/connect_interceptors/logger.go
@@ -62,10 +62,8 @@ func UnaryConnectLoggerInterceptor(logger *slog.Logger, opts *LoggerOptions) con
 			attrs := []any{
 				"system", "connect_rpc",
 				"start_time", startTime,
-				"method", req.Spec().Procedure,
 				"time_ms", duration.Milliseconds(),
 				"code", code.String(),
-				"request_id", requestID,
 			}
 			if err != nil {
 				attrs = append(attrs, "error", err)


### PR DESCRIPTION
## Summary

The logger interceptor adds `request_id` and `method` to the context via `AppendCtx`, but also includes them as explicit attrs in the log call — resulting in each field appearing twice in every log line.

This removes the explicit duplicates so each field appears exactly once.