### PR TITLE
fix(api): wrap billing org-lookup errors in proper connect codes

### DIFF
--- a/internal/api/v1beta1connect/v1beta1connect.go
+++ b/internal/api/v1beta1connect/v1beta1connect.go
@@ -3,8 +3,13 @@ package v1beta1connect
 import (
 	"context"
 
+	"connectrpc.com/connect"
+	"github.com/raystack/frontier/billing/checkout"
+	"github.com/raystack/frontier/billing/customer"
+	"github.com/raystack/frontier/billing/subscription"
 	"github.com/raystack/frontier/core/authenticate"
 	"github.com/raystack/frontier/internal/api"
+	"github.com/raystack/frontier/pkg/errors"
 	frontierv1beta1connect "github.com/raystack/frontier/proto/v1beta1/frontierv1beta1connect"
 )
 
@@ -126,35 +131,57 @@ func (h *ConnectHandler) GetBillingAccountFromOrgID(ctx context.Context, orgID s
 func (h *ConnectHandler) GetOrgIDFromSubscriptionID(ctx context.Context, subscriptionID string) (string, error) {
 	sub, err := h.subscriptionService.GetByID(ctx, subscriptionID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, subscription.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		if errors.Is(err, subscription.ErrInvalidUUID) || errors.Is(err, subscription.ErrInvalidID) {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	// Get the billing account (customer) to find the org
-	customer, err := h.customerService.GetByID(ctx, sub.CustomerID)
+	cust, err := h.customerService.GetByID(ctx, sub.CustomerID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, customer.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return customer.OrgID, nil
+	return cust.OrgID, nil
 }
 
 // GetOrgIDFromCheckoutID returns the organization ID for a given checkout
 func (h *ConnectHandler) GetOrgIDFromCheckoutID(ctx context.Context, checkoutID string) (string, error) {
-	checkout, err := h.checkoutService.GetByID(ctx, checkoutID)
+	co, err := h.checkoutService.GetByID(ctx, checkoutID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, checkout.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		if errors.Is(err, checkout.ErrInvalidUUID) || errors.Is(err, checkout.ErrInvalidID) {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	// Get the billing account (customer) to find the org
-	customer, err := h.customerService.GetByID(ctx, checkout.CustomerID)
+	cust, err := h.customerService.GetByID(ctx, co.CustomerID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, customer.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return customer.OrgID, nil
+	return cust.OrgID, nil
 }
 
 // GetOrgIDFromBillingAccountID returns the organization ID for a given billing account
 func (h *ConnectHandler) GetOrgIDFromBillingAccountID(ctx context.Context, billingAccountID string) (string, error) {
-	customer, err := h.customerService.GetByID(ctx, billingAccountID)
+	cust, err := h.customerService.GetByID(ctx, billingAccountID)
 	if err != nil {
-		return "", err
+		if errors.Is(err, customer.ErrNotFound) {
+			return "", connect.NewError(connect.CodeNotFound, ErrNotFound)
+		}
+		if errors.Is(err, customer.ErrInvalidUUID) || errors.Is(err, customer.ErrInvalidID) {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		return "", connect.NewError(connect.CodeInternal, ErrInternalServerError)
 	}
-	return customer.OrgID, nil
+	return cust.OrgID, nil
 }


### PR DESCRIPTION
## Summary

`GetOrgIDFromBillingAccountID`, `GetOrgIDFromSubscriptionID`, and `GetOrgIDFromCheckoutID` are called exclusively from the authorization interceptor (`authorization.go`) to infer the org ID for billing-related endpoints. The authZ interceptor does not handle their errors — it passes them through as-is via `return nil, err`.

On main, these functions return raw Go errors (e.g. `customer.ErrNotFound`), which are not `*connect.Error`. Connect treats non-connect errors as `CodeUnknown`, so the client sees `code_0` / `unknown` (500) with the raw internal message leaked (e.g. "customer not found"). This was the root cause of a production alert on `GetBillingBalance` and `GetBillingAccount`.

This PR wraps all error paths in those three functions with proper Connect codes:
- `ErrNotFound` → `CodeNotFound` (404)
- `ErrInvalidUUID` / `ErrInvalidID` → `CodeInvalidArgument` (400)
- Everything else → `CodeInternal` with generic `ErrInternalServerError` sentinel

## Breaking changes

Billing, subscription, and checkout endpoints that previously returned `code_0` / `unknown` (500) for missing resources now return `not_found` (404) or `invalid_argument` (400).

## Test plan

- [x] `go test ./internal/api/v1beta1connect/...` — existing handler tests pass
- [x] `go build ./...` — full build passes