### PR TITLE
fix(bootstrap): reconcile predefined roles instead of add-only migrate

### DIFF
--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -36,6 +36,7 @@ type RoleService interface {
 	Get(ctx context.Context, id string) (role.Role, error)
 	List(ctx context.Context, f role.Filter) ([]role.Role, error)
 	Upsert(ctx context.Context, toCreate role.Role) (role.Role, error)
+	Update(ctx context.Context, toUpdate role.Role) (role.Role, error)
 }
 
 type RelationService interface {
@@ -248,7 +249,7 @@ func (s Service) MigrateRoles(ctx context.Context) error {
 	var err error
 	// migrate predefined roles to org
 	for _, defRole := range schema.PredefinedRoles {
-		if err = s.createRole(ctx, defaultOrgID, defRole); err != nil {
+		if err = s.migrateRole(ctx, defaultOrgID, defRole); err != nil {
 			return err
 		}
 	}
@@ -259,7 +260,7 @@ func (s Service) MigrateRoles(ctx context.Context) error {
 		return err
 	}
 	for _, defRole := range serviceDefinition.Roles {
-		if err = s.createRole(ctx, defaultOrgID, defRole); err != nil {
+		if err = s.migrateRole(ctx, defaultOrgID, defRole); err != nil {
 			return err
 		}
 	}
@@ -271,12 +272,23 @@ func (s Service) MigrateRoles(ctx context.Context) error {
 	return nil
 }
 
-func (s Service) createRole(ctx context.Context, orgID string, defRole schema.RoleDefinition) error {
-	if _, err := s.roleService.Get(ctx, defRole.Name); err == nil {
-		// role already exists
-		return nil
+// migrateRole makes the stored role match its definition: create when missing,
+// reconcile when present. Roles are keyed by name, so renaming a definition
+// produces a new role rather than renaming the existing one.
+func (s Service) migrateRole(ctx context.Context, orgID string, defRole schema.RoleDefinition) error {
+	existing, err := s.roleService.Get(ctx, defRole.Name)
+	if errors.Is(err, role.ErrNotExist) {
+		return s.createRole(ctx, orgID, defRole)
 	}
+	if err != nil {
+		// A transient Get failure must not fall through to create: that would
+		// re-Upsert an existing role and skip the prune, the very drift this fixes.
+		return fmt.Errorf("get role %s: %w: %s", defRole.Name, schema.ErrMigration, err.Error())
+	}
+	return s.reconcileRole(ctx, existing, defRole)
+}
 
+func (s Service) createRole(ctx context.Context, orgID string, defRole schema.RoleDefinition) error {
 	_, err := s.roleService.Upsert(ctx, role.Role{
 		Title:       defRole.Title,
 		Name:        defRole.Name,
@@ -292,6 +304,50 @@ func (s Service) createRole(ctx context.Context, orgID string, defRole schema.Ro
 		return fmt.Errorf("can't migrate role: %w: %s", schema.ErrMigration, err.Error())
 	}
 	return nil
+}
+
+// reconcileRole writes the definition onto an existing role only when its
+// permission set differs. The write goes through role.Update (not a raw row
+// update) because that is what prunes the SpiceDB permission tuples a narrowed
+// definition no longer grants; the equality short-circuit keeps every boot from
+// rewriting unchanged roles and emitting a spurious RoleUpdated audit record.
+func (s Service) reconcileRole(ctx context.Context, existing role.Role, defRole schema.RoleDefinition) error {
+	if permissionsEqual(existing.Permissions, defRole.Permissions) {
+		return nil
+	}
+	existing.Title = defRole.Title
+	existing.Permissions = defRole.Permissions
+	existing.Scopes = defRole.Scopes
+	if existing.Metadata == nil {
+		existing.Metadata = map[string]any{}
+	}
+	existing.Metadata["description"] = defRole.Description
+	if _, err := s.roleService.Update(ctx, existing); err != nil {
+		return fmt.Errorf("can't reconcile role: %w: %s", schema.ErrMigration, err.Error())
+	}
+	return nil
+}
+
+// permissionsEqual reports whether two permission slug sets are equal, ignoring
+// order and duplicates.
+func permissionsEqual(a, b []string) bool {
+	setA := make(map[string]struct{}, len(a))
+	for _, p := range a {
+		setA[p] = struct{}{}
+	}
+	setB := make(map[string]struct{}, len(b))
+	for _, p := range b {
+		setB[p] = struct{}{}
+	}
+	if len(setA) != len(setB) {
+		return false
+	}
+	for p := range setB {
+		if _, ok := setA[p]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // MigrateServiceUserOrgPolicies backfills the org policy for service users that

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -35,6 +35,11 @@ func (m *mockRoleService) Upsert(ctx context.Context, toCreate role.Role) (role.
 	return args.Get(0).(role.Role), args.Error(1)
 }
 
+func (m *mockRoleService) Update(ctx context.Context, toUpdate role.Role) (role.Role, error) {
+	args := m.Called(ctx, toUpdate)
+	return args.Get(0).(role.Role), args.Error(1)
+}
+
 // mockRelationService implements bootstrap.RelationService
 type mockRelationService struct {
 	mock.Mock
@@ -234,4 +239,98 @@ func Test_migratePATRelations(t *testing.T) {
 		assert.NoError(t, err)
 		relSvc.AssertNotCalled(t, "Delete")
 	})
+}
+
+func Test_migrateRole(t *testing.T) {
+	def := schema.RoleDefinition{
+		Title:       "Organization Manager",
+		Name:        "app_organization_manager",
+		Permissions: []string{"app_organization_get", "app_organization_update"},
+		Scopes:      []string{schema.OrganizationNamespace},
+	}
+
+	t.Run("creates the role when it does not exist", func(t *testing.T) {
+		roleSvc := new(mockRoleService)
+		roleSvc.On("Get", mock.Anything, def.Name).Return(role.Role{}, role.ErrNotExist)
+		roleSvc.On("Upsert", mock.Anything, mock.MatchedBy(func(r role.Role) bool {
+			return r.Name == def.Name && len(r.Permissions) == 2
+		})).Return(role.Role{ID: "role-1"}, nil)
+
+		svc := Service{roleService: roleSvc}
+		assert.NoError(t, svc.migrateRole(context.Background(), "org-1", def))
+		roleSvc.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("skips reconcile when the permission set is unchanged", func(t *testing.T) {
+		roleSvc := new(mockRoleService)
+		roleSvc.On("Get", mock.Anything, def.Name).Return(role.Role{
+			ID:   "role-1",
+			Name: def.Name,
+			// same set, different order -> still equal
+			Permissions: []string{"app_organization_update", "app_organization_get"},
+		}, nil)
+
+		svc := Service{roleService: roleSvc}
+		assert.NoError(t, svc.migrateRole(context.Background(), "org-1", def))
+		roleSvc.AssertNotCalled(t, "Upsert")
+		roleSvc.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("reconciles a drifted (over-granting) role to the definition", func(t *testing.T) {
+		roleSvc := new(mockRoleService)
+		roleSvc.On("Get", mock.Anything, def.Name).Return(role.Role{
+			ID:   "role-1",
+			Name: def.Name,
+			// has an extra permission no longer in the definition
+			Permissions: []string{"app_organization_get", "app_organization_update", "app_organization_delete"},
+		}, nil)
+		roleSvc.On("Update", mock.Anything, mock.MatchedBy(func(r role.Role) bool {
+			return r.ID == "role-1" && len(r.Permissions) == 2 &&
+				!contains(r.Permissions, "app_organization_delete")
+		})).Return(role.Role{ID: "role-1"}, nil)
+
+		svc := Service{roleService: roleSvc}
+		assert.NoError(t, svc.migrateRole(context.Background(), "org-1", def))
+		roleSvc.AssertNotCalled(t, "Upsert")
+	})
+
+	t.Run("propagates a transient Get error instead of creating", func(t *testing.T) {
+		roleSvc := new(mockRoleService)
+		// a non-ErrNotExist failure must not fall through to Upsert/Update
+		roleSvc.On("Get", mock.Anything, def.Name).Return(role.Role{}, errors.New("db timeout"))
+
+		svc := Service{roleService: roleSvc}
+		err := svc.migrateRole(context.Background(), "org-1", def)
+		assert.Error(t, err)
+		roleSvc.AssertNotCalled(t, "Upsert")
+		roleSvc.AssertNotCalled(t, "Update")
+	})
+}
+
+func contains(s []string, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}
+
+func Test_permissionsEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"equal ignoring order", []string{"x", "y"}, []string{"y", "x"}, true},
+		{"equal ignoring duplicates", []string{"x", "x"}, []string{"x"}, true},
+		{"different members", []string{"x", "y"}, []string{"x", "z"}, false},
+		{"superset", []string{"x"}, []string{"x", "y"}, false},
+		{"both empty", nil, []string{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, permissionsEqual(c.a, c.b))
+		})
+	}
 }


### PR DESCRIPTION
## What

`MigrateRoles` skipped any predefined role that already existed, making it **add-only**. When a predefined role was narrowed in a later release (a permission removed from its definition), the dropped permission kept granting access on existing deployments — the boot migration never reconciled the role to the new definition. (The reverse, a role *gaining* a permission, was equally unapplied.)

## How role permissions work (context for reviewers)

A role grants a permission via a SpiceDB tuple per principal type:

```
app/role:<roleID>#<permission>@app/user:*
app/role:<roleID>#<permission>@app/serviceuser:*
app/role:<roleID>#<permission>@app/pat:*      (skipped if the perm is PAT-denied)
```

`<permission>` is the relation name; `*` is a wildcard subject ("any holder of the role"). A rolebinding then ties a concrete principal + resource to the role (`permission = bearer & role->permission`). So **dropping a permission from a role means deleting these `app/role#perm@*` tuples** — updating the DB row alone is not enough. `role.Update` does this; `role.Upsert` only adds, never prunes.

### How a removed permission's tuples get deleted

`role.Update` wipes-then-recreates rather than diffing:

- It deletes by object + subject with **no relation name**, so it removes *every* `app/role:<id>#<anyperm>@<principal>:*` tuple for the role.
- It then recreates tuples only for permissions still in the definition; the removed one is simply never recreated, so it's gone from SpiceDB.
- Delete works off Frontier's Postgres `relations` mirror (query matching tuples → delete from both SpiceDB and the table), so it needn't enumerate permissions. `Upsert` skips the wipe, which is why the dropped tuple would otherwise survive.

## Fix

Split the old `createRole` (which had become create-or-update) into:

- `migrateRole` — dispatcher: create when the role is missing, reconcile when present.
- `createRole` — pure create (`role.Upsert`).
- `reconcileRole` — writes the definition via `role.Update` **only when the permission set differs**, so a normal boot produces no tuple churn or audit noise; on drift, `Update` prunes the removed perm tuples and rewrites the set.

`Update` is added to the bootstrap `RoleService` interface.

> Scope note: covers narrowed/expanded predefined roles (gap 2's concern). Pruning *removed* predefined roles is intentionally left out — it requires distinguishing system- from user-created roles and risks deleting legitimate ones.

## Test

Unit tests for `migrateRole` (create / unchanged-skip / drifted-reconcile) and for `permissionsEqual` (order- and duplicate-insensitive set comparison).

Addresses gap (2) of #1661.