### PR TITLE
docs(authz): document disable vs delete semantics

### DIFF
--- a/core/group/service.go
+++ b/core/group/service.go
@@ -188,6 +188,12 @@ func (s Service) Enable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Enabled)
 }
 
+// Disable is a reversible soft-stop: it flips the group's state only and
+// deliberately leaves every SpiceDB relation in place, so Enable restores
+// membership and access exactly as it was. Disable is NOT a revocation —
+// tearing down the tuples is Delete's job (see core/deleter). Group reads do
+// not filter on state today, so authz checks that read SpiceDB directly still
+// pass while a group is disabled.
 func (s Service) Disable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Disabled)
 }

--- a/core/organization/service.go
+++ b/core/organization/service.go
@@ -363,6 +363,13 @@ func (s Service) Enable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Enabled)
 }
 
+// Disable is a reversible soft-stop: it flips the org's state only and
+// deliberately leaves every SpiceDB relation in place. Disable is NOT a
+// revocation — re-enabling must restore access exactly as it was, which only
+// works if the tuples were never torn down. Revocation is Delete's job (see
+// core/deleter), which cascades the relations away. This service already keeps
+// disabled orgs out at read time (Get -> ErrDisabled); authz checks that read
+// SpiceDB directly will still pass while disabled, by design.
 func (s Service) Disable(ctx context.Context, id string) error {
 	err := s.repository.SetState(ctx, id, Disabled)
 	if err == nil {

--- a/core/project/service.go
+++ b/core/project/service.go
@@ -211,6 +211,11 @@ func (s Service) Enable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Enabled)
 }
 
+// Disable is a reversible soft-stop: it flips the project's state only and
+// deliberately leaves every SpiceDB relation in place, so Enable restores
+// access exactly as it was. Disable is NOT a revocation — tearing down the
+// tuples is Delete's job (see core/deleter). Authz checks that read SpiceDB
+// directly still pass while a project is disabled, by design.
 func (s Service) Disable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Disabled)
 }

--- a/core/user/service.go
+++ b/core/user/service.go
@@ -119,6 +119,13 @@ func (s Service) Enable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Enabled)
 }
 
+// Disable is a reversible soft-stop: it flips the user's state only and clears
+// active sessions, but deliberately leaves every SpiceDB relation in place so
+// Enable restores access exactly as it was. Disable is NOT a revocation —
+// tearing down the tuples is Delete's job (see core/deleter). User reads do not
+// filter on state today, so authz checks that read SpiceDB directly (including
+// token/PAT-based access) still pass while a user is disabled, even though
+// session-based login no longer works.
 func (s Service) Disable(ctx context.Context, id string) error {
 	if !utils.IsValidUUID(id) {
 		return ErrInvalidID

--- a/docs/content/docs/authz/disable-vs-delete.mdx
+++ b/docs/content/docs/authz/disable-vs-delete.mdx
@@ -1,0 +1,53 @@
+---
+title: Disable vs Delete
+order: 6
+---
+
+# Disable vs Delete
+
+Frontier treats **disabling** and **deleting** an entity (organization, project,
+group, or user) as two deliberately different operations. Knowing which one you
+want matters, because only one of them revokes access.
+
+## Disable — a reversible soft-stop
+
+`Disable` flips the entity's `state` to `disabled` and nothing else. Every
+SpiceDB relation the entity participates in is **left in place**:
+
+- an org's `member` / `owner` tuples,
+- a project's `parent` / grant tuples,
+- a group's `member` tuples,
+- a user's role bindings and ownership tuples.
+
+This is intentional. Disable is meant to be **reversible**: calling `Enable`
+must restore access exactly as it was before, and that is only possible if the
+relations were never torn down. Re-creating the full relation graph on enable
+would be lossy and error-prone, so we keep it instead.
+
+Because the tuples remain, an authorization `Check` that reads SpiceDB directly
+will still succeed for a disabled entity. Disabled state is enforced at the
+**read/application layer**, not in the relation graph:
+
+- `organization.Get` returns `ErrDisabled` for a disabled org (use `GetRaw` to
+  read the row regardless, e.g. for the enable flow);
+- `project.Get`, `group.Get`, and `user.Get` do **not** filter on state today,
+  so a disabled project/group still resolves and its members still pass authz
+  checks. Disabling a user additionally clears active sessions, so
+  session-based login stops working, but token/PAT-based access that resolves
+  through SpiceDB still passes.
+
+> Disable is **not** a security boundary on its own. If you need to guarantee an
+> entity can no longer be used, delete it.
+
+## Delete — revocation
+
+`Delete` (orchestrated by `core/deleter`) is the revocation path. It cascades
+the entity's relations out of SpiceDB along with the row, so no access survives.
+Deletion is **not** reversible.
+
+## Choosing between them
+
+| You want to…                                              | Use       |
+| --------------------------------------------------------- | --------- |
+| Temporarily suspend an entity and be able to restore it   | `Disable` |
+| Permanently remove an entity and revoke all of its access | `Delete`  |


### PR DESCRIPTION
## What

Documents the **disable vs delete** decision for organizations, projects, groups, and users. **No behaviour change** — comments and a docs page only.


Resolves the disable-vs-revoke design row (gap 8) of #1661.