### PR TITLE
fix(prospect): classify RQL helper errors as InvalidArgument

### DIFF
--- a/core/prospect/errors.go
+++ b/core/prospect/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrEmailActivityAlreadyExists = errors.New("email and activity combination already exists")
 	ErrNotExist                   = errors.New("prospect does not exist")
 	ErrInvalidUUID                = errors.New("invalid syntax of uuid")
+	ErrRepositoryBadInput         = errors.New("invalid repository input")
 )

--- a/internal/api/v1beta1connect/prospect.go
+++ b/internal/api/v1beta1connect/prospect.go
@@ -125,7 +125,14 @@ func (h *ConnectHandler) ListProspects(ctx context.Context, request *connect.Req
 
 	prospects, err := h.prospectService.List(ctx, requestQuery)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListProspects: %w", err))
+		switch {
+		case errors.Is(err, prospect.ErrInvalidUUID) || errors.Is(err, prospect.ErrRepositoryBadInput):
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		case errors.Is(err, prospect.ErrNotExist):
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		default:
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListProspects: %w", err))
+		}
 	}
 
 	var transformedProspects []*frontierv1beta1.Prospect

--- a/internal/api/v1beta1connect/prospect_test.go
+++ b/internal/api/v1beta1connect/prospect_test.go
@@ -288,6 +288,26 @@ func TestHandler_ListProspects(t *testing.T) {
 			err:  connect.NewError(connect.CodeInternal, fmt.Errorf("ListProspects: %w", errors.New("some error"))),
 		},
 		{
+			title: "should return invalid argument error for bad input",
+			setup: func(ctx context.Context, ps *mocks.ProspectService, ms *mocks.MetaSchemaService) context.Context {
+				ps.On("List", mock.Anything, mock.Anything).Return(prospect.ListProspects{}, prospect.ErrRepositoryBadInput)
+				return ctx
+			},
+			req:  connect.NewRequest(&frontierv1beta1.ListProspectsRequest{}),
+			want: nil,
+			err:  connect.NewError(connect.CodeInvalidArgument, prospect.ErrRepositoryBadInput),
+		},
+		{
+			title: "should return not found error if prospect not found",
+			setup: func(ctx context.Context, ps *mocks.ProspectService, ms *mocks.MetaSchemaService) context.Context {
+				ps.On("List", mock.Anything, mock.Anything).Return(prospect.ListProspects{}, prospect.ErrNotExist)
+				return ctx
+			},
+			req:  connect.NewRequest(&frontierv1beta1.ListProspectsRequest{}),
+			want: nil,
+			err:  connect.NewError(connect.CodeNotFound, prospect.ErrNotExist),
+		},
+		{
 			title: "should return success if prospect service return nil error",
 			setup: func(ctx context.Context, ps *mocks.ProspectService, ms *mocks.MetaSchemaService) context.Context {
 				ps.On("List", mock.Anything, mock.Anything).

--- a/internal/store/postgres/prospect_repository.go
+++ b/internal/store/postgres/prospect_repository.go
@@ -21,6 +21,10 @@ var (
 	rqlGroupSupportedColumns  = []string{"activity", "status", "source", "verified"}
 )
 
+func wrapBadInput(err error) error {
+	return fmt.Errorf("%w: %s", prospect.ErrRepositoryBadInput, err.Error())
+}
+
 type ProspectBillingGroup struct {
 	Name sql.NullString             `db:"name"`
 	Data []ProspectBillingGroupData `db:"data"`
@@ -135,13 +139,13 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 	// apply filters
 	baseStmt, err := utils.AddRQLFiltersInQuery(baseStmt, rqlQuery, rqlFilerSupportedColumns, prospect.Prospect{})
 	if err != nil {
-		return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.ListProspects{}, wrapBadInput(err)
 	}
 
 	// apply search
 	baseStmt, err = utils.AddRQLSearchInQuery(baseStmt, rqlQuery, rqlSearchSupportedColumns)
 	if err != nil {
-		return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.ListProspects{}, wrapBadInput(err)
 	}
 
 	listStmt := baseStmt
@@ -166,7 +170,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 	if len(rqlQuery.GroupBy) > 0 {
 		groupStmt, err = utils.AddGroupInQuery(groupStmt, rqlQuery, rqlGroupSupportedColumns)
 		if err != nil {
-			return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+			return prospect.ListProspects{}, wrapBadInput(err)
 		}
 
 		query, params, err := groupStmt.ToSQL()
@@ -188,7 +192,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 	// List prospects with pagination and sorting
 	listStmt, err = utils.AddRQLSortInQuery(listStmt, rqlQuery)
 	if err != nil {
-		return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.ListProspects{}, wrapBadInput(err)
 	}
 	listStmt, pagination := utils.AddRQLPaginationInQuery(listStmt, rqlQuery)
 


### PR DESCRIPTION
## Summary
`ListProspects` returned `CodeInternal` for every error from the service. RQL helper failures (unsupported filter/sort/group/search column from user input) now classify as `CodeInvalidArgument`, mirroring the existing pattern in `audit_record.go`.

## Changes
- `core/prospect/errors.go`: add `ErrRepositoryBadInput` sentinel.
- `internal/store/postgres/prospect_repository.go`: new `wrapBadInput` helper; the four RQL helper error sites (`AddRQLFiltersInQuery`, `AddRQLSearchInQuery`, `AddGroupInQuery`, `AddRQLSortInQuery`) wrap with `ErrRepositoryBadInput` instead of the generic `queryErr`. `ToSQL()` and database execution errors keep their existing wraps.
- `internal/api/v1beta1connect/prospect.go`: replace the single `CodeInternal` branch in `ListProspects` with a switch ladder: `ErrInvalidUUID`/`ErrRepositoryBadInput` → `CodeInvalidArgument`, `ErrNotExist` → `CodeNotFound`, default → `CodeInternal`.
- `internal/api/v1beta1connect/prospect_test.go`: add cases for `ErrRepositoryBadInput` → `CodeInvalidArgument` and `ErrNotExist` → `CodeNotFound`; existing `CodeInternal` case unchanged.

## Technical Details
- Pattern matches `internal/api/v1beta1connect/audit_record.go:128-135` and `internal/store/postgres/audit_record_repository.go:27` (`wrapValidationError`). Named differently here because both files live in `package postgres` and Go disallows duplicate top-level identifiers.
- Service layer (`core/prospect/service.go`) is a pass-through; no changes needed.

## Test Plan
- [x] `go test ./internal/api/v1beta1connect/...` — `TestHandler_ListProspects` 4/4 pass.
- [x] `go test ./internal/store/postgres/...` — Postgres integration suite green.
- [x] `go test ./core/prospect/...` — green.
- [x] `go build ./...` passes.
- [x] `golangci-lint run` on touched packages — 0 issues.

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
- [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
- [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
- [x] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)