### PR TITLE
test(user): assert session rejected on next request after user disable

### DIFF
--- a/core/user/service.go
+++ b/core/user/service.go
@@ -119,13 +119,16 @@ func (s Service) Enable(ctx context.Context, id string) error {
 	return s.repository.SetState(ctx, id, Enabled)
 }
 
-// Disable is a reversible soft-stop: it flips the user's state only and clears
-// active sessions, but deliberately leaves every SpiceDB relation in place so
-// Enable restores access exactly as it was. Disable is NOT a revocation —
-// tearing down the tuples is Delete's job (see core/deleter). User reads do not
-// filter on state today, so authz checks that read SpiceDB directly (including
-// token/PAT-based access) still pass while a user is disabled, even though
-// session-based login no longer works.
+// Disable is a reversible soft-stop: it flips the user's state to Disabled and
+// soft-deletes active sessions, but leaves SpiceDB relations in place so Enable
+// can restore the user's access exactly as it was. Disable is NOT a revocation —
+// tearing down the tuples is Delete's job (see core/deleter).
+//
+// All authenticated access stops while a user is disabled. Session cookies are
+// rejected because their rows are soft-deleted (and Session.IsValid filters
+// DeletedAt). PAT/JWT/client-credential auth all resolve the principal via
+// user.Service.GetByID, whose repository filters out users in the Disabled
+// state — so those flows fail with ErrNotExist for the same user.
 func (s Service) Disable(ctx context.Context, id string) error {
 	if !utils.IsValidUUID(id) {
 		return ErrInvalidID

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -1543,6 +1543,36 @@ func (s *APIRegressionTestSuite) TestUserAPI() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(1, len(listExistingUsers.Msg.GetUsers()))
 	})
+	s.Run("12. session is rejected on the next request after the user is disabled", func() {
+		const targetEmail = "disable-session-target@raystack.org"
+
+		createResp, err := s.testBench.Client.CreateUser(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreateUserRequest{
+			Body: &frontierv1beta1.UserRequestBody{
+				Title: "disable session target",
+				Email: targetEmail,
+				Name:  "disable_session_target",
+			},
+		}))
+		s.Require().NoError(err)
+		targetID := createResp.Msg.GetUser().GetId()
+
+		targetCookie, err := testbench.AuthenticateUser(context.Background(), s.testBench.Client, targetEmail)
+		s.Require().NoError(err)
+		ctxTarget := testbench.ContextWithAuth(context.Background(), targetCookie)
+
+		meResp, err := s.testBench.Client.GetCurrentUser(ctxTarget, connect.NewRequest(&frontierv1beta1.GetCurrentUserRequest{}))
+		s.Require().NoError(err)
+		s.Assert().Equal(targetEmail, meResp.Msg.GetUser().GetEmail())
+
+		_, err = s.testBench.Client.DisableUser(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.DisableUserRequest{
+			Id: targetID,
+		}))
+		s.Require().NoError(err)
+
+		_, err = s.testBench.Client.GetCurrentUser(ctxTarget, connect.NewRequest(&frontierv1beta1.GetCurrentUserRequest{}))
+		s.Require().Error(err)
+		s.Assert().Equal(connect.CodeUnauthenticated, connect.CodeOf(err))
+	})
 }
 
 func (s *APIRegressionTestSuite) TestRelationAPI() {


### PR DESCRIPTION
## Summary
- New e2e subtest in `test/e2e/regression/api_test.go::TestUserAPI` that creates a user, logs them in via mailotp, calls `DisableUser` as admin, and asserts the same cookie returns `connect.CodeUnauthenticated` on the next call.
- Rewrites the doc comment on `user.Service.Disable`. Previous text said PAT/token auth still passes for a disabled user; it doesn't, because `UserRepository.GetByID` filters out users in the `Disabled` state, so any flow that resolves the principal that way fails with `ErrNotExist`.

## Test plan
- [x] `go test -v -run TestEndToEndAPIRegressionTestSuite/TestUserAPI -count=1 ./test/e2e/regression/...` — all 12 subtests pass locally