### PR TITLE
refactor(schema): remove dead membership permission, drop + member from get

### DIFF
--- a/internal/bootstrap/schema/base_schema.zed
+++ b/internal/bootstrap/schema/base_schema.zed
@@ -38,11 +38,9 @@ definition app/organization {
 
 	// permissions
     // org
-    permission membership = member + owner
-
     permission delete = platform->superuser + granted->app_organization_administer + granted->app_organization_delete + owner
     permission update = platform->superuser + granted->app_organization_administer + granted->app_organization_update + owner
-    permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update + owner + member
+    permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update + owner
     permission rolemanage = platform->superuser + granted->app_organization_administer + granted->app_organization_rolemanage + owner
     permission policymanage = platform->superuser + granted->app_organization_administer + granted->app_organization_policymanage + owner
     permission projectlist = platform->superuser + granted->app_organization_administer + granted->app_organization_projectlist + owner
@@ -76,10 +74,9 @@ definition app/group {
 	relation owner: app/user | app/serviceuser
 
 	// permissions
-	permission membership = member + owner
     permission delete = org->group_delete + granted->app_group_administer + granted->app_group_delete + owner
     permission update = org->group_update + granted->app_group_administer + granted->app_group_update + owner
-    permission get = org->group_get + granted->app_group_administer + granted->app_group_get + member + owner
+    permission get = org->group_get + granted->app_group_administer + granted->app_group_get + owner
 }
 
 definition app/project {

--- a/internal/bootstrap/schema/schema.go
+++ b/internal/bootstrap/schema/schema.go
@@ -64,9 +64,6 @@ const (
 	PlatformSudoPermission  = "superuser"
 	PlatformCheckPermission = "check"
 
-	// synthetic permission
-	MembershipPermission = "membership"
-
 	// principals
 	UserPrincipal        = "app/user"
 	ServiceUserPrincipal = "app/serviceuser"

--- a/internal/bootstrap/testdata/compiled_schema.zed
+++ b/internal/bootstrap/testdata/compiled_schema.zed
@@ -1,13 +1,11 @@
 
 
 definition app/group {
+	// permissions
 	permission delete = org->group_delete + granted->app_group_administer + granted->app_group_delete + owner
-	permission get = org->group_get + granted->app_group_administer + granted->app_group_get + member + owner
+	permission get = org->group_get + granted->app_group_administer + granted->app_group_get + owner
 	relation granted: app/rolebinding
 	relation member: app/user
-
-	// permissions
-	permission membership = member + owner
 
 	// relations
 	relation org: app/organization
@@ -32,8 +30,11 @@ definition app/organization {
 	permission compute_order_update = owner + platform->superuser + granted->app_organization_administer + granted->compute_order_update + pat_granted->app_project_administer + pat_granted->compute_order_update
 	permission compute_receipt_get = owner + platform->superuser + granted->app_organization_administer + granted->compute_receipt_get + pat_granted->app_project_administer + pat_granted->compute_receipt_get
 	permission compute_receipt_update = owner + platform->superuser + granted->app_organization_administer + granted->compute_receipt_update + pat_granted->app_project_administer + pat_granted->compute_receipt_update
+
+	// permissions
+	// org
 	permission delete = platform->superuser + granted->app_organization_administer + granted->app_organization_delete + owner
-	permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update + owner + member
+	permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update + owner
 	relation granted: app/rolebinding
 
 	// synthetic permissions - group
@@ -45,10 +46,6 @@ definition app/organization {
 	permission invitationcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationcreate + owner
 	permission invitationlist = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationlist + owner
 	relation member: app/user | app/group#member | app/serviceuser
-
-	// permissions
-	// org
-	permission membership = member + owner
 	relation owner: app/user | app/serviceuser
 	relation pat_granted: app/rolebinding
 


### PR DESCRIPTION
## Summary

Phase 2 of the SpiceDB schema cleanup (parent: #1478). Removes the dead `membership` permission entirely and drops `+ member` from visibility permissions, so stale member relations no longer grant access.

### Changes to `base_schema.zed`

**Organization:**
- **Removed** `permission membership = member + owner` — zero consumers in Go code, frontend code, or other schema permissions. Verified: the `MembershipPermission` constant exists in both `schema.go` (Go) and `web/sdk/utils/index.ts` (frontend) but is never imported or referenced by any caller in either codebase.
- **`permission get`** — removed `+ member`. Visibility now requires `granted->app_organization_get` (policy-backed via rolebinding) or `+ owner` (direct owner relation). A stale `member` relation without a backing policy no longer grants visibility.

**Group:**
- **Removed** `permission membership = member + owner` — same reasoning.
- **`permission get`** — removed `+ member`. Group visibility now requires a rolebinding or owner relation.

**Kept as-is:**
- `+ owner` on all org/group permissions — functionally equivalent to `app_organization_administer` (membership service maps owner role -> owner relation). Removing it from ~20 permissions is a separate, larger change.
- `member` and `owner` **relations** — still actively written by Go code. The relations aren't going away; what changed is that `get` no longer resolves through `member`.

### Also removed
- `schema.MembershipPermission` constant (`"membership"`) from Go — zero callers since PR #1694.
- Regenerated `testdata/compiled_schema.zed` from the compiler (not manually edited).

**Note:** The matching frontend constant (`web/sdk/utils/index.ts:83`) is left for a separate SDK cleanup — it's dead code (never imported) and changing it here would touch the SDK build/release pipeline.

### Deployment note
Requires that `MigrateServiceUserOrgPolicies` has run — without it, pre-policy service users that only have a `member` relation would lose org/group visibility. The backfill runs automatically on `frontier serve`.

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` clean
- [x] `internal/bootstrap` tests pass (golden schema regenerated from compiler)
- [x] Verified zero callers of `MembershipPermission` / `'membership'` in Go and frontend
- [ ] e2e regression (CI)
- [ ] Manual verification: auth check on org.get and group.get still passes for policy-backed members