### PR TITLE
feat: scope and preselect PAT org role in create dialog

### DIFF
--- a/web/sdk/client/views/pat/components/pat-form-dialog.tsx
+++ b/web/sdk/client/views/pat/components/pat-form-dialog.tsx
@@ -224,6 +224,21 @@ export function PATFormDialog({
     }
   }, [isOrgAdmin, setValue]);
 
+  useEffect(() => {
+    if (isRolesLoading || isOrgPermissionsFetching) return;
+    if (selectableOrgRoles.length === 1 && !watchedOrgRoleId) {
+      setValue('orgRoleId', selectableOrgRoles[0].id, {
+        shouldDirty: true,
+      });
+    }
+  }, [
+    isRolesLoading,
+    isOrgPermissionsFetching,
+    selectableOrgRoles,
+    watchedOrgRoleId,
+    setValue
+  ]);
+
   const { mutateAsync: createPAT } = useMutation(
     FrontierServiceQueries.createCurrentUserPAT
   );

--- a/web/sdk/client/views/pat/components/pat-form-dialog.tsx
+++ b/web/sdk/client/views/pat/components/pat-form-dialog.tsx
@@ -17,7 +17,7 @@ import {
   ListRolesForPATRequestSchema,
   ListProjectsByCurrentUserRequestSchema
 } from '@raystack/proton/frontier';
-import type { PAT } from '@raystack/proton/frontier';
+import type { PAT, Role } from '@raystack/proton/frontier';
 import {
   Button,
   Chip,
@@ -35,12 +35,21 @@ import {
 } from '@raystack/apsara';
 import { useFrontier } from '~/client/contexts/FrontierContext';
 import { DEFAULT_DATE_FORMAT } from '~/client/utils/constants';
-import { PERMISSIONS } from '../../../../utils';
+import { usePermissions } from '~/client/hooks/usePermissions';
+import { PERMISSIONS, shouldShowComponent } from '../../../../utils';
 import { handleConnectError } from '~/utils/error';
 import { EXPIRY_OPTIONS } from '../utils';
 import styles from '../pat-view.module.css';
 
 const MAX_VISIBLE_PROJECT_CHIPS = 2;
+
+const ORG_UPDATE_PERMISSION = `${PERMISSIONS.OrganizationNamespace.replace(
+  '/',
+  '_'
+)}_${PERMISSIONS.UpdatePermission}`;
+
+const roleGrantsOrgUpdate = (role: Role) =>
+  role.permissions?.includes(ORG_UPDATE_PERMISSION) ?? false;
 
 const baseFields = {
   title: yup.string().required('Name is required'),
@@ -176,13 +185,36 @@ export function PATFormDialog({
     };
   }, [rolesData]);
 
+  const orgResource = `${PERMISSIONS.OrganizationNamespace}:${orgId}`;
+  const orgPermissionChecks = useMemo(
+    () => [{ permission: PERMISSIONS.UpdatePermission, resource: orgResource }],
+    [orgResource]
+  );
+
+  const { permissions: orgPermissions, isFetching: isOrgPermissionsFetching } =
+    usePermissions(orgPermissionChecks, Boolean(orgId));
+
+  const canUpdateOrg = useMemo(
+    () =>
+      shouldShowComponent(
+        orgPermissions,
+        `${PERMISSIONS.UpdatePermission}::${orgResource}`
+      ),
+    [orgPermissions, orgResource]
+  );
+
+  const selectableOrgRoles = useMemo(
+    () =>
+      canUpdateOrg
+        ? orgRoles
+        : orgRoles.filter(role => !roleGrantsOrgUpdate(role)),
+    [orgRoles, canUpdateOrg]
+  );
+
   const watchedOrgRoleId = watch('orgRoleId');
   const isOrgAdmin = useMemo(() => {
     const role = orgRoles.find(r => r.id === watchedOrgRoleId);
-    if (!role) return false;
-    const orgNs = PERMISSIONS.OrganizationNamespace.replace('/', '_');
-    const updatePerm = `${orgNs}_${PERMISSIONS.UpdatePermission}`;
-    return role.permissions?.some(p => p === updatePerm) ?? false;
+    return role ? roleGrantsOrgUpdate(role) : false;
   }, [orgRoles, watchedOrgRoleId]);
 
   useEffect(() => {
@@ -333,7 +365,8 @@ export function PATFormDialog({
     ]
   );
 
-  const isDataLoading = isProjectsLoading || isRolesLoading;
+  const isDataLoading =
+    isProjectsLoading || isRolesLoading || isOrgPermissionsFetching;
 
   return (
     <Dialog handle={handle} onOpenChange={handleOpenChange}>
@@ -444,7 +477,7 @@ export function PATFormDialog({
                             <Select.Value placeholder="Select role" />
                           </Select.Trigger>
                           <Select.Content>
-                            {orgRoles.map(role => (
+                            {selectableOrgRoles.map(role => (
                               <Select.Item key={role.id} value={role.id}>
                                 {role.title || role.name}
                               </Select.Item>

--- a/web/sdk/client/views/pat/pat-view.tsx
+++ b/web/sdk/client/views/pat/pat-view.tsx
@@ -146,9 +146,6 @@ export function PatsView({ onPATClick }: PatsViewProps = {}) {
 
   const handlePATCreated = (token: string) => {
     patCreatedDialogHandle.openWithPayload({ token });
-  };
-
-  const handleSuccessDialogClose = () => {
     refetch();
   };
 
@@ -247,7 +244,6 @@ export function PatsView({ onPATClick }: PatsViewProps = {}) {
       />
       <PATCreatedDialog
         handle={patCreatedDialogHandle}
-        onClose={handleSuccessDialogClose}
       />
       <RevokePATDialog
         handle={revokePATDialogHandle}


### PR DESCRIPTION
## Summary

- Scope the organization-role select to the requesting user's permission level: members without org `update` permission now only see non-admin roles. Uses a single `BatchCheckPermission` self-check; no privilege escalation since the backend already caps a PAT at `min(user role, PAT scope)`.
- Auto-preselect the org role when exactly one option is available, gated on both the roles and permission queries having settled — fixes a first-load race where the temporarily-filtered list could wrongly preselect a role.
- De-duplicate the org-update permission-string logic shared between the role filter and the admin check.
- Refetch PATs immediately on creation instead of on success-dialog close, removing the now-unused `onClose` handler.