### PR TITLE
feat(bootstrap): grant project-create to org member role

### DIFF
--- a/internal/bootstrap/schema/schema.go
+++ b/internal/bootstrap/schema/schema.go
@@ -344,14 +344,7 @@ var PredefinedRoles = []RoleDefinition{
 		Name:  RoleOrganizationViewer,
 		Permissions: []string{
 			"app_organization_get",
-		},
-		Scopes: []string{OrganizationNamespace},
-	},
-	{
-		Title: "Group Viewer",
-		Name:  RoleOrganizationViewer,
-		Permissions: []string{
-			"app_organization_get",
+			"app_organization_projectcreate",
 		},
 		Scopes: []string{OrganizationNamespace},
 	},


### PR DESCRIPTION
## What

1. Grants `app_organization_projectcreate` to the predefined organization viewer ("Member") role, so an org Member can create projects rather than only reading the org.
2. Removes a duplicate `PredefinedRoles` entry titled "Group Viewer" that reused the same `Name` (`RoleOrganizationViewer` = `app_organization_viewer`).

## Why the duplicate removal

`PredefinedRoles` defined `RoleOrganizationViewer` twice — "Member" and "Group Viewer" — with the same `Name`, so it never created a distinct role. `MigrateRoles` reconciled the same role twice (last write winning), which meant any edit to the Member role had to be mirrored in both entries or the second would reset it. The "Group Viewer" copy traces back to #399 and looks like a copy/paste that reused the org-viewer name instead of a dedicated group-viewer constant. Removing it is functionally inert (same `Name`, no separate role) and makes the role single-sourced.

## Impact

Additive for permissions — Member gains `projectcreate`, nothing is removed. The dedupe changes no runtime behavior (the duplicate was a redundant reconcile of the same role). Applied via the normal boot-time role reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
