### PR TITLE
feat(invite): make org dropdown searchable and show title instead of name

### DIFF
--- a/web/sdk/admin/views/users/list/invite-users.tsx
+++ b/web/sdk/admin/views/users/list/invite-users.tsx
@@ -244,7 +244,8 @@ export const InviteUser = () => {
                             }}>
                             {organizations?.map(org => (
                               <Select.Item key={org.id} value={org.id ?? ""}>
-                                {org.name}
+                                {/* show display title (matches the org list & invite email); fall back to the slug if unset */}
+                                {org.title || org.name}
                               </Select.Item>
                             ))}
                           </Select.Content>

--- a/web/sdk/admin/views/users/list/invite-users.tsx
+++ b/web/sdk/admin/views/users/list/invite-users.tsx
@@ -24,7 +24,7 @@ import {
   FrontierServiceQueries,
   ListRolesRequestSchema,
 } from "@raystack/proton/frontier";
-import {create} from "@bufbuild/protobuf";
+import { create } from "@bufbuild/protobuf";
 import { handleConnectError } from "~/utils/error";
 import { useTerminology } from "../../../hooks/useTerminology";
 
@@ -49,7 +49,7 @@ export const InviteUser = () => {
     error: organizationsError,
   } = useQuery(
     AdminServiceQueries.searchOrganizations,
-    create(SearchOrganizationsRequestSchema, {query: {}}),
+    create(SearchOrganizationsRequestSchema, { query: {} }),
     {
       select: (data) => data?.organizations || [],
     }
@@ -231,6 +231,7 @@ export const InviteUser = () => {
                       <>
                         <Select
                           {...rest}
+                          autocomplete
                           onValueChange={value => field.onChange(value)}>
                           <Select.Trigger ref={ref}>
                             <Select.Value
@@ -238,13 +239,13 @@ export const InviteUser = () => {
                             />
                           </Select.Trigger>
                           <Select.Content
+                            searchPlaceholder={`Search ${t.organization({ case: "lower" })}`}
                             style={{
                               maxHeight: 280,
                               overflowY: "auto",
                             }}>
                             {organizations?.map(org => (
                               <Select.Item key={org.id} value={org.id ?? ""}>
-                                {/* show display title (matches the org list & invite email); fall back to the slug if unset */}
                                 {org.title || org.name}
                               </Select.Item>
                             ))}


### PR DESCRIPTION
## Summary
Two related improvements to the admin "Invite user" organization dropdown:

1. **Searchable dropdown** — with many organizations the plain dropdown was slow and error-prone to scan. It's now type-to-filter (matches on the org name as you type).
2. **Correct label** — the dropdown rendered each org's URL slug (`org.name`) instead of its display title (`org.title`). Since the org list view and the invite email both use the title, the option didn't match what users saw elsewhere — selecting an org produced an invite email showing a different name.

## Changes
- Add `autocomplete` to the organization `Select` to enable type-to-filter search, with a `searchPlaceholder` on `Select.Content` for the
search input.
- Display `org.title` (falling back to `org.name` when title is unset) in the organization dropdown of the admin member-invite dialog.


## Technical Details
In Frontier's org model, `title` is the human-readable display name while `name` is the URL slug / unique identifier. The invite dropdown in `web/sdk/admin/views/users/list/invite-users.tsx` was rendering `org.name`, whereas the org list (`organizations/list/columns.tsx`) and the invite email use `org.title`, causing the perceived mismatch. The submitted form value is still `org.id`, so the invite target is unaffected — only the visible label changed.

Search is powered by Apsara's `Select` autocomplete (default `autocompleteMode="auto"`); no mode prop is needed. Filtering matches against the rendered option label (`org.title || org.name`), so results match on the name users see.

## Test Plan
  - [ ] Manual testing completed
    - Open admin → Users → Invite user; confirm the organization dropdown is searchable and the option labels match the names shown in the organization list.
    - Type a partial org name and confirm the list filters to matching organizations.
    - Send an invite and verify the org name in the received email matches the selected dropdown option.
  - [ ] Build and type checking passes

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
N/A — frontend-only change; no `*_repository.go` or `goqu.*` files touched.

