### PR TITLE
feat(billing): audit customer portal session creation

### DIFF
--- a/internal/api/v1beta1connect/billing_checkout.go
+++ b/internal/api/v1beta1connect/billing_checkout.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/raystack/frontier/billing/checkout"
 	"github.com/raystack/frontier/billing/product"
+	"github.com/raystack/frontier/core/auditrecord"
+	pkgAuditRecord "github.com/raystack/frontier/pkg/auditrecord"
+	"github.com/raystack/frontier/pkg/metadata"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -47,6 +51,35 @@ func (h *ConnectHandler) CreateCheckout(ctx context.Context, request *connect.Re
 				return nil, connect.NewError(connect.CodeFailedPrecondition, ErrPortalChangesKycCompleted)
 			}
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("CreateCheckout.CreateSessionForCustomerPortal: billing_id=%s: %w", billingID, err))
+		}
+
+		// Audit the customer portal session creation so we can trace who (a super
+		// user or any other principal) opened the portal to update billing details.
+		// Actor and the super-user flag are auto-enriched from request context.
+		orgName := ""
+		if org, orgErr := h.orgService.GetRaw(ctx, request.Msg.GetOrgId()); orgErr == nil {
+			orgName = org.Title
+		}
+		if _, _, auditErr := h.auditRecordService.Create(ctx, auditrecord.AuditRecord{
+			Event: pkgAuditRecord.BillingCustomerPortalSessionCreatedEvent,
+			Resource: auditrecord.Resource{
+				ID:   request.Msg.GetOrgId(),
+				Type: pkgAuditRecord.OrganizationType,
+				Name: orgName,
+			},
+			Target: &auditrecord.Target{
+				ID:   billingID,
+				Type: pkgAuditRecord.BillingCustomerType,
+			},
+			OrgID:      request.Msg.GetOrgId(),
+			OrgName:    orgName,
+			OccurredAt: time.Now().UTC(),
+			Metadata: metadata.Metadata{
+				"checkout_id": newCheckout.ID,
+			},
+		}); auditErr != nil {
+			NewErrorLogger().LogServiceError(ctx, request, "CreateCheckout.AuditCustomerPortal", auditErr,
+				"org_id", request.Msg.GetOrgId(), "billing_id", billingID)
 		}
 
 		return connect.NewResponse(&frontierv1beta1.CreateCheckoutResponse{

--- a/internal/api/v1beta1connect/billing_checkout_test.go
+++ b/internal/api/v1beta1connect/billing_checkout_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/raystack/frontier/billing/customer"
 	"github.com/raystack/frontier/billing/product"
 	"github.com/raystack/frontier/billing/subscription"
+	"github.com/raystack/frontier/core/auditrecord"
+	"github.com/raystack/frontier/core/organization"
 	"github.com/raystack/frontier/internal/api/v1beta1connect/mocks"
+	pkgAuditRecord "github.com/raystack/frontier/pkg/auditrecord"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -336,11 +339,22 @@ func TestConnectHandler_CreateCheckout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockCheckoutSvc := mocks.NewCheckoutService(t)
 			mockCustomerSvc := mocks.NewCustomerService(t)
+			mockAuditSvc := mocks.NewAuditRecordService(t)
+			mockOrgSvc := mocks.NewOrganizationService(t)
+			// Customer portal checkouts emit an audit record (and resolve the org
+			// name); allow these leniently here and assert precisely in the
+			// dedicated audit test below.
+			mockAuditSvc.EXPECT().Create(mock.Anything, mock.Anything).
+				Return(auditrecord.AuditRecord{}, false, nil).Maybe()
+			mockOrgSvc.EXPECT().GetRaw(mock.Anything, mock.Anything).
+				Return(organization.Organization{}, nil).Maybe()
 			tt.setup(mockCheckoutSvc, mockCustomerSvc)
 
 			h := &ConnectHandler{
-				checkoutService: mockCheckoutSvc,
-				customerService: mockCustomerSvc,
+				checkoutService:    mockCheckoutSvc,
+				customerService:    mockCustomerSvc,
+				auditRecordService: mockAuditSvc,
+				orgService:         mockOrgSvc,
 			}
 
 			got, err := h.CreateCheckout(context.Background(), tt.req)
@@ -365,6 +379,50 @@ func TestConnectHandler_CreateCheckout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConnectHandler_CreateCheckout_CustomerPortalAuditRecord(t *testing.T) {
+	mockCheckoutSvc := mocks.NewCheckoutService(t)
+	mockCustomerSvc := mocks.NewCustomerService(t)
+	mockAuditSvc := mocks.NewAuditRecordService(t)
+	mockOrgSvc := mocks.NewOrganizationService(t)
+
+	mockCustomerSvc.EXPECT().GetByOrgID(mock.Anything, "org-123").
+		Return(customer.Customer{ID: "customer-123", OrgID: "org-123"}, nil)
+	mockCheckoutSvc.EXPECT().CreateSessionForCustomerPortal(mock.Anything, mock.Anything).
+		Return(testCheckout, nil)
+	mockOrgSvc.EXPECT().GetRaw(mock.Anything, "org-123").
+		Return(organization.Organization{ID: "org-123", Title: "Acme Corp"}, nil)
+	mockAuditSvc.EXPECT().Create(mock.Anything, mock.MatchedBy(func(r auditrecord.AuditRecord) bool {
+		return r.Event == pkgAuditRecord.BillingCustomerPortalSessionCreatedEvent &&
+			r.OrgID == "org-123" &&
+			r.OrgName == "Acme Corp" &&
+			r.Resource.ID == "org-123" &&
+			r.Resource.Type == pkgAuditRecord.OrganizationType &&
+			r.Resource.Name == "Acme Corp" &&
+			r.Target != nil &&
+			r.Target.ID == "customer-123" &&
+			r.Target.Type == pkgAuditRecord.BillingCustomerType
+	})).Return(auditrecord.AuditRecord{}, false, nil)
+
+	h := &ConnectHandler{
+		checkoutService:    mockCheckoutSvc,
+		customerService:    mockCustomerSvc,
+		auditRecordService: mockAuditSvc,
+		orgService:         mockOrgSvc,
+	}
+
+	got, err := h.CreateCheckout(context.Background(), connect.NewRequest(&frontierv1beta1.CreateCheckoutRequest{
+		OrgId:      "org-123",
+		SuccessUrl: "https://example.com/success",
+		CancelUrl:  "https://example.com/cancel",
+		SetupBody: &frontierv1beta1.CheckoutSetupBody{
+			CustomerPortal: true,
+		},
+	}))
+
+	assert.NoError(t, err)
+	assert.Equal(t, testCheckoutID, got.Msg.GetCheckoutSession().GetId())
 }
 
 func TestConnectHandler_DelegatedCheckout(t *testing.T) {

--- a/pkg/auditrecord/consts.go
+++ b/pkg/auditrecord/consts.go
@@ -16,6 +16,9 @@ const (
 	// Billing Checkout Events
 	BillingCheckoutCreatedEvent Event = "billing_checkout.created"
 
+	// Billing Customer Portal Events
+	BillingCustomerPortalSessionCreatedEvent Event = "billing_customer.portal_session_created"
+
 	// Billing Subscription Events
 	BillingSubscriptionCreatedEvent Event = "billing_subscription.created"
 	BillingSubscriptionChangedEvent Event = "billing_subscription.changed"


### PR DESCRIPTION
## What

Emit an audit record whenever a Stripe customer portal session is created via `FrontierService/CreateCheckout` (`setupBody.customerPortal = true`).

The portal is how billing details (address, tax IDs, etc.) get updated. Recording every session creation lets us trace **who** opened the portal to update — or attempt to update — billing details, including whether the actor was a platform super-user.

## How

- New event `billing_customer.portal_session_created` in `pkg/auditrecord/consts.go`.
- In the `CreateCheckout` handler's customer-portal branch, emit an audit record after the session is created successfully:
  - Resource = organization, Target = billing customer, with `checkout_id` in metadata.
  - Actor and the `is_super_user` flag are auto-enriched from request context (same mechanism as role/PAT audit records).
- Emission is **non-fatal**: a failure is logged and does not fail the portal request.

This covers both the client app flow and the upcoming admin-app super-user flow, since both go through the same RPC.

## Notes

- No authz or KYC changes. Super-users already pass `CreateCheckout` authz via the `platform->superuser` schema cascade, and the service has no KYC gate.

## Test plan

- New focused test `TestConnectHandler_CreateCheckout_CustomerPortalAuditRecord` asserts the record is emitted with the correct event, org, and billing-customer target.
- Existing `CreateCheckout` table tests updated to allow the emission.
- `go test ./internal/api/v1beta1connect/...` and `golangci-lint` pass.