### PR TITLE
feat(admin): open stripe customer portal from billing section

### DIFF
--- a/web/sdk/admin/views/organizations/details/side-panel/billing-details-section.tsx
+++ b/web/sdk/admin/views/organizations/details/side-panel/billing-details-section.tsx
@@ -1,12 +1,12 @@
-import { Amount, CopyButton, Flex, Link, List, Text } from "@raystack/apsara";
+import { Amount, CopyButton, Flex, IconButton, Link, List, Text, Tooltip, toastManager } from "@raystack/apsara";
 import styles from "./side-panel.module.css";
 import { convertBillingAddressToString } from "../../../../utils/helper";
 import Skeleton from "react-loading-skeleton";
 import { useContext, useEffect } from "react";
-import { CalendarIcon } from "@radix-ui/react-icons";
+import { CalendarIcon, Pencil1Icon } from "@radix-ui/react-icons";
 import { OrganizationContext } from "../contexts/organization-context";
-import { useQuery } from "@connectrpc/connect-query";
-import { FrontierServiceQueries, GetUpcomingInvoiceRequestSchema } from "@raystack/proton/frontier";
+import { useMutation, useQuery } from "@connectrpc/connect-query";
+import { CreateCheckoutRequestSchema, FrontierServiceQueries, GetUpcomingInvoiceRequestSchema } from "@raystack/proton/frontier";
 import { create } from "@bufbuild/protobuf";
 import { timestampToDayjs } from "../../../../utils/connect-timestamp";
 
@@ -39,9 +39,83 @@ export const BillingDetailsSection = () => {
     ? "https://dashboard.stripe.com/customers/" + billingAccount?.providerId
     : "";
 
+  const { mutateAsync: createCheckout, isPending: isPortalLoading } =
+    useMutation(FrontierServiceQueries.createCheckout, {
+      onError: (error) => {
+        toastManager.add({
+          title: "Something went wrong",
+          description: error.rawMessage,
+          type: "error",
+        });
+        console.error("Unable to open billing portal:", error);
+      },
+    });
+
+  const isBillingPortalDisabled = isPortalLoading || !billingAccountId;
+
+  const handleOpenBillingPortal = async () => {
+    if (isBillingPortalDisabled) return;
+    const returnUrl = window.location.href;
+    // Open the tab synchronously within the click gesture so popup blockers
+    // allow it; it is navigated once the portal URL is ready. Opened without
+    // "noopener" so we can set its location, then opener is severed for safety.
+    const portalTab = window.open("", "_blank");
+    if (portalTab) portalTab.opener = null;
+    try {
+      const resp = await createCheckout(
+        create(CreateCheckoutRequestSchema, {
+          orgId: organizationId,
+          cancelUrl: returnUrl,
+          successUrl: returnUrl,
+          setupBody: { paymentMethod: false, customerPortal: true },
+        })
+      );
+      const checkoutUrl = resp?.checkoutSession?.checkoutUrl;
+      if (checkoutUrl && portalTab) {
+        portalTab.location.href = checkoutUrl;
+      } else if (checkoutUrl) {
+        window.open(checkoutUrl, "_blank", "noopener,noreferrer");
+      } else {
+        portalTab?.close();
+      }
+    } catch {
+      // the error toast is surfaced by the mutation's onError handler
+      portalTab?.close();
+    }
+  };
+
   return (
-    <List>
-      <List.Header>Billing</List.Header>
+    <List className={styles["billing-section"]}>
+      <List.Header className={styles["billing-header"]}>
+        Billing
+        <Tooltip>
+          {/* aria-disabled (not the native attribute) keeps the trigger
+              hoverable so the tooltip shows even when the action is disabled */}
+          <Tooltip.Trigger
+            render={
+              <IconButton
+                size={2}
+                aria-label="Update billing details"
+                data-test-id="admin-billing-portal-button"
+                aria-disabled={isBillingPortalDisabled}
+                className={
+                  isBillingPortalDisabled
+                    ? `${styles["billing-edit"]} ${styles["billing-edit-disabled"]}`
+                    : styles["billing-edit"]
+                }
+                onClick={handleOpenBillingPortal}
+              >
+                <Pencil1Icon />
+              </IconButton>
+            }
+          />
+          <Tooltip.Content>
+            {billingAccountId
+              ? "Update billing details"
+              : "No billing account for this organization"}
+          </Tooltip.Content>
+        </Tooltip>
+      </List.Header>
       <List.Item>
         <List.Label className={styles["side-panel-section-item-label"]}>
           Name

--- a/web/sdk/admin/views/organizations/details/side-panel/side-panel.module.css
+++ b/web/sdk/admin/views/organizations/details/side-panel/side-panel.module.css
@@ -14,3 +14,35 @@
   height: var(--rs-space-5);
   width: var(--rs-space-5);
 }
+
+.billing-header > span {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.billing-edit {
+  opacity: 0;
+  transition: opacity 120ms ease-in-out;
+}
+
+.billing-section:hover .billing-edit,
+.billing-section:focus-within .billing-edit {
+  opacity: 1;
+}
+
+/* These rules re-create a "disabled but still hoverable (so the tooltip shows)"
+   icon button. This behaviour should ideally be provided by the apsara
+   IconButton/Tooltip components rather than worked around here. */
+.billing-section:hover .billing-edit-disabled,
+.billing-section:focus-within .billing-edit-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.billing-section:hover .billing-edit-disabled:hover,
+.billing-section:hover .billing-edit-disabled:active {
+  background-color: transparent;
+  color: var(--rs-color-foreground-base-secondary);
+}


### PR DESCRIPTION
## What

Adds an edit (pencil) action to the right of the **Billing** section header in the organization details side panel of the admin app (matching the Figma). Clicking it opens the Stripe customer portal for that org so a super user can update the customer's billing address / details.

This works **even when the org's KYC is completed** — unlike the client app, the admin app does not gate the action on KYC.

## How

- Reuses the existing `FrontierService/CreateCheckout` RPC with `setupBody.customerPortal = true` (the same call the client app's billing view uses). Super-user authorization already resolves via the `platform->superuser` schema cascade, so **no backend change is needed**.
- **Opens in a new tab, popup-blocker safe**: the tab is opened synchronously within the click gesture and navigated once the portal URL is ready (opener severed for safety; the tab is closed if the request fails or returns no URL). Stripe's return URL is the current admin page.
- **Disabled state + tooltip**: the action is disabled while the request is in flight or when the org has no billing account. It uses `aria-disabled` (not the native attribute) so it stays hoverable and shows a tooltip — "No billing account for this organization" when disabled, "Update billing details" otherwise. Errors surface via `toastManager`.
- **Icon**: apsara `1.0.0-rc.12` ships no edit/pencil icon, so this uses `Pencil1Icon` from `@radix-ui/react-icons` (already used across the admin app). The header lays the title + action out as a flex row so the icon is right-aligned.

## Related

- Backend audit-record PR (independent): #1714 — records who (super user or any other principal) opened the portal.
- Client-side new-tab PR (independent): #1717 — applies the same new-tab behavior to the client billing card.

## Test plan

- `eslint` passes on the changed file.
- Manual (verified against a local sandbox):
  - Org **with** a billing account → pencil enabled, right-aligned, tooltip "Update billing details"; clicking calls `CreateCheckout` and opens the portal in a new tab.
  - Org **without** a billing account → pencil disabled, with tooltip "No billing account for this organization".
  - Works regardless of KYC status.
