### PR TITLE
fix(authz): allow platform superusers to delete/read policies on deleted resources

### DIFF
--- a/pkg/server/connect_interceptors/authorization.go
+++ b/pkg/server/connect_interceptors/authorization.go
@@ -636,6 +636,12 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 		return handler.IsSuperUser(ctx, req)
 	},
 	"/raystack.frontier.v1beta1.FrontierService/GetPolicy": func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {
+		// A platform superuser may read any policy, including ones whose resource
+		// has been deleted: the resource-scoped check below cannot resolve once
+		// the resource no longer exists in the graph.
+		if err := handler.IsSuperUser(ctx, req); err == nil {
+			return nil
+		}
 		pbreq := req.(*connect.Request[frontierv1beta1.GetPolicyRequest])
 		policyResp, err := handler.GetPolicy(ctx, connect.NewRequest(&frontierv1beta1.GetPolicyRequest{Id: pbreq.Msg.GetId()}))
 		if err != nil {
@@ -658,6 +664,13 @@ var authorizationValidationMap = map[string]func(ctx context.Context, handler *v
 		return ErrNotAvailable
 	},
 	"/raystack.frontier.v1beta1.FrontierService/DeletePolicy": func(ctx context.Context, handler *v1beta1connect.ConnectHandler, req connect.AnyRequest) error {
+		// A platform superuser may delete any policy, including ones whose resource
+		// has been deleted: the resource-scoped check below cannot resolve once
+		// the resource no longer exists in the graph, which would otherwise leave
+		// orphaned policies impossible to clean up.
+		if err := handler.IsSuperUser(ctx, req); err == nil {
+			return nil
+		}
 		pbreq := req.(*connect.Request[frontierv1beta1.DeletePolicyRequest])
 		policyResp, err := handler.GetPolicy(ctx, connect.NewRequest(&frontierv1beta1.GetPolicyRequest{Id: pbreq.Msg.GetId()}))
 		if err != nil {


### PR DESCRIPTION
## What

Allow a platform superuser to read or delete a policy even after the policy's resource (a project or group) has already been deleted.

## Why

`DeletePolicy` and `GetPolicy` check permission on the policy's resource. If the project or group is gone, that resource has no relationships left in SpiceDB, so the check can't find a path to the superuser, and the call is denied with "not authorized".

The effect: policies left behind on deleted resources can't be cleaned up through the API at all — not even by an admin. They just sit there.

## Testing

- Built the full binary.
- On a local server: before the change, reading or deleting a policy on a deleted project/group returned "not authorized". After the change, an admin could read and delete them, and a bulk cleanup of leftover policies ran without failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
