### PR TITLE
feat(client): open stripe customer portal in a new tab

### DIFF
--- a/web/sdk/client/views/billing/billing-view.tsx
+++ b/web/sdk/client/views/billing/billing-view.tsx
@@ -116,6 +116,12 @@ export function BillingView({ onNavigateToPlans }: BillingViewProps) {
     const orgId = activeOrganization?.id || '';
     if (!orgId) return;
 
+    // Open the tab synchronously within the click gesture so popup blockers
+    // allow it; it is navigated once the portal URL is ready. Opened without
+    // 'noopener' so we can set its location, then opener is severed for safety.
+    const portalTab = window.open('', '_blank');
+    if (portalTab) portalTab.opener = null;
+
     try {
       const query = qs.stringify(
         {
@@ -144,10 +150,15 @@ export function BillingView({ onNavigateToPlans }: BillingViewProps) {
         })
       );
       const checkoutUrl = resp?.checkoutSession?.checkoutUrl;
-      if (checkoutUrl) {
-        window.location.href = checkoutUrl;
+      if (checkoutUrl && portalTab) {
+        portalTab.location.href = checkoutUrl;
+      } else if (checkoutUrl) {
+        window.open(checkoutUrl, '_blank', 'noopener,noreferrer');
+      } else {
+        portalTab?.close();
       }
     } catch (err) {
+      portalTab?.close();
       console.error(err);
     }
   }, [


### PR DESCRIPTION
The client SDK billing card now opens the Stripe customer portal in a **new tab** instead of a same-tab redirect (`window.location.href`).

The tab is opened synchronously within the click gesture so it isn't blocked by popup blockers, then navigated once the checkout URL is ready. The opener is severed for safety, and the tab is closed if the request fails (with a `noopener,noreferrer` fallback if the synchronous open was blocked).

This mirrors the admin-side behavior introduced in #1715.