### PR TITLE
fix(admin): open billing portal in same tab to reflect edits on return

### DIFF
--- a/web/sdk/admin/views/organizations/details/side-panel/billing-details-section.tsx
+++ b/web/sdk/admin/views/organizations/details/side-panel/billing-details-section.tsx
@@ -56,11 +56,6 @@ export const BillingDetailsSection = () => {
   const handleOpenBillingPortal = async () => {
     if (isBillingPortalDisabled) return;
     const returnUrl = window.location.href;
-    // Open the tab synchronously within the click gesture so popup blockers
-    // allow it; it is navigated once the portal URL is ready. Opened without
-    // "noopener" so we can set its location, then opener is severed for safety.
-    const portalTab = window.open("", "_blank");
-    if (portalTab) portalTab.opener = null;
     try {
       const resp = await createCheckout(
         create(CreateCheckoutRequestSchema, {
@@ -71,16 +66,11 @@ export const BillingDetailsSection = () => {
         })
       );
       const checkoutUrl = resp?.checkoutSession?.checkoutUrl;
-      if (checkoutUrl && portalTab) {
-        portalTab.location.href = checkoutUrl;
-      } else if (checkoutUrl) {
-        window.open(checkoutUrl, "_blank", "noopener,noreferrer");
-      } else {
-        portalTab?.close();
+      if (checkoutUrl) {
+        window.location.href = checkoutUrl;
       }
     } catch {
       // the error toast is surfaced by the mutation's onError handler
-      portalTab?.close();
     }
   };
 


### PR DESCRIPTION
## What

Opens the Stripe customer portal in the **same tab** from the admin org Billing side panel (the pencil action from #1715), instead of a new tab.

This matches the client app's billing flow: the admin page navigates away to Stripe, and when the super user finishes (via Stripe's return link or the browser back button) they land back on a freshly loaded admin page — so any billing address / details they edited show up without any manual refresh.

## Why

The new-tab approach left the admin panel showing the stale address after an edit, because the original tab was never reloaded. Rather than adding tab-visibility refetch logic, this mirrors the client app and lets a normal page navigation do the work.

## How

- Replaces the new-tab `window.open` (and its popup-blocker workaround) with `window.location.href = checkoutUrl`, the same pattern used in the client billing view.
- Drops the now-unnecessary refresh plumbing (visibility listener, ref flag, and the `fetchBillingAccountDetails` context call).
- `successUrl`/`cancelUrl` remain the current admin page, so Stripe returns the user here.

## Test plan

- `eslint` passes on the changed file.
- Manual: open an org in the admin app → Billing → pencil → the page navigates to the Stripe portal → edit the billing address → return (Stripe's return link or back button) → the admin page reloads and shows the updated address.