### PR TITLE
fix(pat): clear expiry-alert metadata on PAT regeneration

### DIFF
--- a/core/userpat/alert_service.go
+++ b/core/userpat/alert_service.go
@@ -6,11 +6,10 @@ import (
 	"errors"
 	"fmt"
 	htmltemplate "html/template"
+	"log/slog"
 	"math"
 	texttemplate "text/template"
 	"time"
-
-	"log/slog"
 
 	auditmodels "github.com/raystack/frontier/core/auditrecord/models"
 	"github.com/raystack/frontier/core/organization"
@@ -34,8 +33,8 @@ const (
 	defaultExpiryReminderSubject = `Your personal access token "{{.Title}}" expires in {{.DaysLeft}} days`
 	defaultExpiredNoticeSubject  = `Your personal access token "{{.Title}}" has expired`
 
-	expiryReminderMetadataKey = "expiry_reminder_sent_at"
-	expiredNoticeMetadataKey  = "expired_notice_sent_at"
+	ExpiryReminderMetadataKey = "expiry_reminder_sent_at"
+	ExpiredNoticeMetadataKey  = "expired_notice_sent_at"
 )
 
 // AlertUserService resolves user details from user ID.
@@ -167,7 +166,7 @@ func (s *AlertService) sendExpiryReminders(ctx context.Context) {
 	}
 
 	for _, pat := range pats {
-		if err := s.sendAlert(ctx, pat, subjectTpl, bodyTpl, expiryReminderMetadataKey, pkgauditrecord.PATExpiryReminderEvent); err != nil {
+		if err := s.sendAlert(ctx, pat, subjectTpl, bodyTpl, ExpiryReminderMetadataKey, pkgauditrecord.PATExpiryReminderEvent); err != nil {
 			s.logger.ErrorContext(ctx, "failed to send expiry reminder",
 				"pat_id", pat.ID, "error", err)
 		}
@@ -191,7 +190,7 @@ func (s *AlertService) sendExpiredNotices(ctx context.Context) {
 	}
 
 	for _, pat := range pats {
-		if err := s.sendAlert(ctx, pat, subjectTpl, bodyTpl, expiredNoticeMetadataKey, pkgauditrecord.PATExpiredNoticeEvent); err != nil {
+		if err := s.sendAlert(ctx, pat, subjectTpl, bodyTpl, ExpiredNoticeMetadataKey, pkgauditrecord.PATExpiredNoticeEvent); err != nil {
 			s.logger.ErrorContext(ctx, "failed to send expired notice",
 				"pat_id", pat.ID, "error", err)
 		}

--- a/internal/store/postgres/userpat_repository.go
+++ b/internal/store/postgres/userpat_repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 
+	"github.com/raystack/frontier/core/userpat"
 	paterrors "github.com/raystack/frontier/core/userpat/errors"
 	"github.com/raystack/frontier/core/userpat/models"
 	"github.com/raystack/frontier/pkg/db"
@@ -327,6 +328,8 @@ func (r UserPATRepository) Regenerate(ctx context.Context, id, secretHash string
 			"secret_hash":    secretHash,
 			"expires_at":     expiresAt,
 			"regenerated_at": time.Now().UTC(),
+			// Reset the alert-sent keys so the new expiry cycle re-sends reminders.
+			"metadata": goqu.L("COALESCE(metadata, '{}'::jsonb) - ? - ?", userpat.ExpiryReminderMetadataKey, userpat.ExpiredNoticeMetadataKey),
 		}).
 		Where(
 			goqu.Ex{"id": id},
@@ -360,7 +363,7 @@ func (r UserPATRepository) ListExpiryReminderPending(ctx context.Context, days i
 		goqu.Ex{"deleted_at": nil},
 		goqu.L("expires_at > NOW()"),
 		goqu.L("expires_at <= NOW() + make_interval(days => ?)", days),
-		goqu.L("(metadata->>'expiry_reminder_sent_at') IS NULL"),
+		goqu.L("(metadata->>?) IS NULL", userpat.ExpiryReminderMetadataKey),
 	).ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", queryErr, err)
@@ -386,7 +389,7 @@ func (r UserPATRepository) ListExpiredNoticePending(ctx context.Context) ([]mode
 	query, params, err := dialect.From(TABLE_USER_PATS).Where(
 		goqu.Ex{"deleted_at": nil},
 		goqu.L("expires_at < NOW()"),
-		goqu.L("(metadata->>'expired_notice_sent_at') IS NULL"),
+		goqu.L("(metadata->>?) IS NULL", userpat.ExpiredNoticeMetadataKey),
 	).ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", queryErr, err)

--- a/internal/store/postgres/userpat_repository_test.go
+++ b/internal/store/postgres/userpat_repository_test.go
@@ -358,6 +358,63 @@ func (s *UserPATRepositoryTestSuite) TestListByUser_EmptyWhenNoTokens() {
 	s.Empty(got)
 }
 
+func (s *UserPATRepositoryTestSuite) TestRegenerate() {
+	s.Run("clears alert-sent keys but preserves other metadata", func() {
+		s.truncateTokens()
+
+		created, err := s.repository.Create(s.ctx, models.PAT{
+			UserID:     s.users[0].ID,
+			OrgID:      s.orgs[0].ID,
+			Title:      "regen-token",
+			SecretHash: "hashRegenOld",
+			Metadata: map[string]any{
+				"expiry_reminder_sent_at": "2026-01-01T00:00:00Z",
+				"expired_notice_sent_at":  "2026-01-02T00:00:00Z",
+				"env":                     "prod",
+			},
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
+		s.Require().NoError(err)
+
+		newExpiry := time.Now().Add(72 * time.Hour).Truncate(time.Microsecond)
+		regenerated, err := s.repository.Regenerate(s.ctx, created.ID, "hashRegenNew", newExpiry)
+		s.Require().NoError(err)
+
+		s.Equal("hashRegenNew", regenerated.SecretHash)
+		s.WithinDuration(newExpiry, regenerated.ExpiresAt, time.Microsecond)
+		s.Require().NotNil(regenerated.RegeneratedAt)
+		s.NotContains(regenerated.Metadata, "expiry_reminder_sent_at")
+		s.NotContains(regenerated.Metadata, "expired_notice_sent_at")
+		s.Equal("prod", regenerated.Metadata["env"])
+	})
+
+	s.Run("makes a previously-alerted PAT eligible for reminders again", func() {
+		s.truncateTokens()
+
+		created, err := s.repository.Create(s.ctx, models.PAT{
+			UserID:     s.users[0].ID,
+			OrgID:      s.orgs[0].ID,
+			Title:      "regen-eligible",
+			SecretHash: "hashEligibleOld",
+			Metadata:   map[string]any{"expiry_reminder_sent_at": "2026-01-01T00:00:00Z"},
+			ExpiresAt:  time.Now().Add(48 * time.Hour),
+		})
+		s.Require().NoError(err)
+
+		pending, err := s.repository.ListExpiryReminderPending(s.ctx, 3)
+		s.Require().NoError(err)
+		s.Empty(pending)
+
+		_, err = s.repository.Regenerate(s.ctx, created.ID, "hashEligibleNew", time.Now().Add(48*time.Hour))
+		s.Require().NoError(err)
+
+		pending, err = s.repository.ListExpiryReminderPending(s.ctx, 3)
+		s.Require().NoError(err)
+		s.Require().Len(pending, 1)
+		s.Equal(created.ID, pending[0].ID)
+	})
+}
+
 func TestUserPATRepository(t *testing.T) {
 	suite.Run(t, new(UserPATRepositoryTestSuite))
 }


### PR DESCRIPTION
## Summary
Regenerating a PAT did not reset its expiry-alert state, so a regenerated token received no reminder for its new expiry when one had already been sent for the previous cycle.

## Changes
- `Regenerate` clears the `expiry_reminder_sent_at` and `expired_notice_sent_at` metadata keys in the same `UPDATE`, so the new expiry cycle re-sends alerts.
- Alert-sent metadata keys are exported from the alert service (`ExpiryReminderMetadataKey`, `ExpiredNoticeMetadataKey`) and referenced by the repository queries.
- Added `TestRegenerate` covering key clearing and reminder re-eligibility.

## Technical Details
Keys are removed via JSONB key subtraction (`metadata - 'key'`) in the existing `Regenerate` `UPDATE`, preserving all other metadata. The pending-alert queries keep a plain `IS NULL` gate.

## Test Plan
- [x] Manual testing completed
- [x] Build and type checking passes
- `go test ./core/userpat/` passes; `TestRegenerate` (postgres repo) added — runs under Docker via the dockertest suite.

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
- [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
- [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
- [x] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
