### PR TITLE
feat(image-upload): add button to clear uploaded image

### DIFF
--- a/web/sdk/admin/views/organizations/details/edit/organization.tsx
+++ b/web/sdk/admin/views/organizations/details/edit/organization.tsx
@@ -71,6 +71,7 @@ function getDefaultValue(organization: Organization, industries: string[]) {
   return {
     title: organization?.title || "",
     name: organization?.name || "",
+    avatar: organization?.avatar || "",
     size: metadata?.size || 0,
     type: type,
     otherType: otherType,

--- a/web/sdk/client/components/image-upload/image-upload.module.css
+++ b/web/sdk/client/components/image-upload/image-upload.module.css
@@ -8,6 +8,11 @@
   padding: 0;
 }
 
+.avatarWrapper {
+  position: relative;
+  display: inline-flex;
+}
+
 .avatar {
   position: absolute;
   inset: 0;
@@ -22,7 +27,7 @@
   border-color: transparent;
 }
 
-/* On hover, hide avatar and restore dashed border */
+/* On hover, hide avatar and restore dashed border + upload icon */
 .iconButton:hover .avatar {
   opacity: 0;
   visibility: hidden;
@@ -30,6 +35,16 @@
 
 .iconButton:hover {
   border-color: var(--rs-color-border-accent-primary);
+}
+
+.cornerButton {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background-color: var(--rs-color-background-base-primary);
+  border: 1px solid var(--rs-color-border-base-primary);
+  border-radius: var(--rs-radius-full);
+  box-shadow: var(--rs-shadow-sm);
 }
 
 .uploadIcon {

--- a/web/sdk/client/components/image-upload/image-upload.tsx
+++ b/web/sdk/client/components/image-upload/image-upload.tsx
@@ -8,7 +8,7 @@ import ReactCrop, {
   centerCrop,
   makeAspectCrop
 } from 'react-image-crop';
-import { UploadIcon } from '@radix-ui/react-icons';
+import { UploadIcon, Cross2Icon } from '@radix-ui/react-icons';
 import {
   Avatar,
   Button,
@@ -193,21 +193,45 @@ export function ImageUpload({
     onChange?.(data);
   }
 
+  function onClearClick() {
+    // Logo is optional; clear it entirely.
+    onChange?.('');
+  }
+
   return (
     <Flex direction="column" gap={5} align="start" data-test-id={rest['data-test-id']}>
-      <IconButton
-        size={4}
-        aria-label="Upload image"
-        className={styles.iconButton}
-        onClick={disabled ? undefined : onUploadIconClick}
-        disabled={disabled}
-        data-test-id="frontier-sdk-image-upload-icon"
-      >
-        {(value || initials) && (
-          <Avatar src={value} fallback={initials} size={10} radius="small" className={styles.avatar} />
+      <div className={styles.avatarWrapper}>
+        <IconButton
+          size={4}
+          aria-label="Upload image"
+          className={styles.iconButton}
+          onClick={disabled ? undefined : onUploadIconClick}
+          disabled={disabled}
+          data-test-id="frontier-sdk-image-upload-icon"
+        >
+          {(value || initials) && (
+            <Avatar
+              src={value}
+              fallback={initials}
+              size={10}
+              radius="small"
+              className={styles.avatar}
+            />
+          )}
+          <UploadIcon className={styles.uploadIcon} />
+        </IconButton>
+        {!disabled && value && (
+          <IconButton
+            size={1}
+            aria-label="Clear image"
+            className={styles.cornerButton}
+            onClick={onClearClick}
+            data-test-id="frontier-sdk-image-upload-clear"
+          >
+            <Cross2Icon />
+          </IconButton>
         )}
-        <UploadIcon className={styles.uploadIcon} />
-      </IconButton>
+      </div>
 
       {description ? (
         <Text size="regular" variant="secondary">


### PR DESCRIPTION
## Summary
Adds a "clear" affordance to the shared `ImageUpload` component so users can remove a previously uploaded image (e.g. an organization logo), which was previously impossible once an image was set. Also wires the organization `avatar` field into the edit form's default values so then current logo renders and can be cleared/edited correctly.

## Changes
- **`image-upload.tsx`**: Added a small corner "clear" button (`Cross2Icon`) that appears over the avatar when a value is present and the field is enabled. Clicking it calls `onChange('')` to clear the image. Wrapped the upload `IconButton` in a positioned `avatarWrapper` so the corner button can be anchored to it.
- **`image-upload.module.css`**: Added `.avatarWrapper` (relative, inline-flex positioning context) and `.cornerButton` (absolutely positioned top-right badge styling) styles.
- **`organization.tsx`**: Added `avatar: organization?.avatar || ""` to `getDefaultValue()` so the existing org logo populates the edit form's default values.

## Technical Details
- The clear button is only rendered when `!disabled && value` — an empty field just shows the upload icon, and disabled fields can't be cleared.
- Clearing is treated as an intentional state: the logo is optional, so `onClearClick` emits an empty string through the existing `onChange` handler rather than introducing a separate callback. This keeps the component's API unchanged for consumers.
- `.cornerButton` uses design-system tokens (`--rs-color-*`, `--rs-radius-full`, `--rs-shadow-sm`) for consistency with the rest of the SDK.

## Test Plan
- [x] Manual testing completed
    - Uploaded an org logo, confirmed the clear (✕) button appears on the corner.
    - Clicked clear and verified the image is removed and the upload icon reappears.
    - Confirmed the button does not appear when no image is set or when the field is disabled.
    - Confirmed the org edit form loads with the existing avatar as its default value.
- [x] Build and type checking passes

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
N/A