### PR TITLE
fix(billing): advance credit overdraft invoice window past last invoiced range

### DIFF
--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -507,23 +507,7 @@ func (s *Service) GenerateForCredits(ctx context.Context) error {
 			}
 		}
 
-		// check if invoice line items are of type credit and matches the current range
-		// if yes, don't create a new invoice
-		var alreadyInvoiced bool
-		if lastOverdraftInvoice != nil {
-			for _, item := range lastOverdraftInvoice.Items {
-				if item.TimeRangeEnd != nil && item.TimeRangeStart.Before(startRange) {
-					// if before the start range, update the start range
-					startRange = *item.TimeRangeEnd
-				}
-
-				if item.TimeRangeStart != nil && item.TimeRangeStart.Equal(startRange) &&
-					item.TimeRangeEnd != nil && item.TimeRangeEnd.Equal(endRange) {
-					alreadyInvoiced = true
-					break
-				}
-			}
-		}
+		startRange, alreadyInvoiced := computeOverdraftWindow(startRange, endRange, lastOverdraftInvoice)
 		if alreadyInvoiced {
 			continue
 		}
@@ -570,6 +554,30 @@ func (s *Service) GenerateForCredits(ctx context.Context) error {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// computeOverdraftWindow returns the start of the invoice window for the
+// customer and whether the current range is already covered by the last
+// credit overdraft invoice. startRange is the fallback window start when no
+// overdraft invoice exists, normally the customer creation time.
+func computeOverdraftWindow(startRange time.Time, endRange time.Time, lastOverdraftInvoice *Invoice) (time.Time, bool) {
+	var alreadyInvoiced bool
+	if lastOverdraftInvoice != nil {
+		for _, item := range lastOverdraftInvoice.Items {
+			if item.TimeRangeEnd == nil {
+				continue
+			}
+			// move the window start past the range billed by the last invoice
+			if item.TimeRangeEnd.After(startRange) {
+				startRange = *item.TimeRangeEnd
+			}
+			if !item.TimeRangeEnd.Before(endRange) {
+				// the last invoice already covers the current range end
+				alreadyInvoiced = true
+			}
+		}
+	}
+	return startRange, alreadyInvoiced
 }
 
 // getCreditOverdraftEndDate get range start and end, end date will be the current date with time set to 00:00:00

--- a/billing/invoice/service_test.go
+++ b/billing/invoice/service_test.go
@@ -6,6 +6,96 @@ import (
 	"time"
 )
 
+func TestService_computeOverdraftWindow(t *testing.T) {
+	createdAt := time.Date(2024, 8, 12, 7, 59, 50, 544323000, time.UTC)
+	// providers store item ranges in whole seconds, so the first invoice's
+	// start is the creation time truncated to the second
+	createdAtTruncated := createdAt.Truncate(time.Second)
+	feb1 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	mar1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	may1 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	jun1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	jul1 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	creditItem := func(start, end *time.Time) Invoice {
+		return Invoice{
+			Items: []Item{
+				{
+					Type:           CreditItemType,
+					TimeRangeStart: start,
+					TimeRangeEnd:   end,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		endRange            time.Time
+		lastInvoice         *Invoice
+		wantStart           time.Time
+		wantAlreadyInvoiced bool
+	}{
+		{
+			name:      "no previous overdraft invoice starts window at customer creation",
+			endRange:  jul1,
+			wantStart: createdAt,
+		},
+		{
+			name:        "first invoice anchors window at its end",
+			endRange:    mar1,
+			lastInvoice: ptr(creditItem(&createdAtTruncated, &feb1)),
+			wantStart:   feb1,
+		},
+		{
+			name:        "first invoice anchors window when its start equals creation time",
+			endRange:    mar1,
+			lastInvoice: ptr(creditItem(&createdAt, &feb1)),
+			wantStart:   feb1,
+		},
+		{
+			name:        "later invoice anchors window at its end instead of customer creation",
+			endRange:    jul1,
+			lastInvoice: ptr(creditItem(&may1, &jun1)),
+			wantStart:   jun1,
+		},
+		{
+			name:                "range ending at window end is already invoiced",
+			endRange:            jul1,
+			lastInvoice:         ptr(creditItem(&may1, &jul1)),
+			wantStart:           jul1,
+			wantAlreadyInvoiced: true,
+		},
+		{
+			name:        "item without range start does not panic",
+			endRange:    jul1,
+			lastInvoice: ptr(creditItem(nil, &jun1)),
+			wantStart:   jun1,
+		},
+		{
+			name:        "item without range end keeps window at customer creation",
+			endRange:    jul1,
+			lastInvoice: ptr(creditItem(&may1, nil)),
+			wantStart:   createdAt,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, alreadyInvoiced := computeOverdraftWindow(createdAt, tt.endRange, tt.lastInvoice)
+			if !start.Equal(tt.wantStart) {
+				t.Errorf("computeOverdraftWindow() start = %v, want %v", start, tt.wantStart)
+			}
+			if alreadyInvoiced != tt.wantAlreadyInvoiced {
+				t.Errorf("computeOverdraftWindow() alreadyInvoiced = %v, want %v", alreadyInvoiced, tt.wantAlreadyInvoiced)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestService_getCreditOverdraftRange(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Problem

`GenerateForCredits` computes the invoice window start from the last credit overdraft invoice with this condition:

```go
if item.TimeRangeEnd != nil && item.TimeRangeStart.Before(startRange) {
    startRange = *item.TimeRangeEnd
}
```

It compares the anchor item's *start* against the customer's creation time. That is only true for an invoice whose window began at creation — and even then only because providers store item ranges in whole seconds, truncating the creation timestamp's sub-second part. Any later invoice starts after creation, the condition is false, and the window snaps back to the customer's creation time.

Since #1502 excluded overdraft payment credits from the range balance, a snapped-back window counts all previously invoiced usage again. Combined with #1498 (anchor = newest invoice), the result alternates: one tick produces the correct invoice, the next tick anchors on it, snaps back, and bills the customer's entire history as a duplicate.

Observed in a deployment: a customer expecting one $386 invoice on Jul 1 received $386 (correct window) at 00:02 and $2,756 (= all usage since account creation, including two already-paid invoices) at 00:07, one sync tick later.

Two more defects in the same block:
- The `alreadyInvoiced` equality check compares against `startRange` *after* the same item mutated it, so it can never match a single-item invoice; same-day dedup only worked by accident via the empty-window balance.
- `item.TimeRangeStart.Before(...)` is dereferenced with only `TimeRangeEnd` nil-checked — an item with a null `range_start` panics the whole sync tick.

## Fix

Extract the window computation into `computeOverdraftWindow` and base it solely on `TimeRangeEnd`:
- advance the window start to the anchor item's `TimeRangeEnd` whenever that end is after the current start,
- report `alreadyInvoiced` when the anchor's end already reaches the current range end,
- skip items without `TimeRangeEnd` instead of dereferencing a possibly-nil `TimeRangeStart`.

## Tests

Table-driven tests for `computeOverdraftWindow` covering: no prior invoice, first-invoice anchoring (both truncated and whole-second creation times), later-invoice anchoring (the snap-back reproduction), same-day rerun dedup, and nil range start/end. The snap-back, whole-second, same-day, and nil-start cases fail on the previous logic (the nil-start case panicked).