### PR TITLE
fix(admin): fix Org Security loading state UI

### DIFF
--- a/web/sdk/admin/views/organizations/details/security/domains-list.tsx
+++ b/web/sdk/admin/views/organizations/details/security/domains-list.tsx
@@ -3,12 +3,12 @@ import {
   Button,
   Flex,
   IconButton,
+  Skeleton,
   Text,
   toastManager,
 } from "@raystack/apsara";
 import styles from "./security.module.css";
 import { CheckCircledIcon, TrashIcon } from "@radix-ui/react-icons";
-import Skeleton from "react-loading-skeleton";
 import { useContext, useState } from "react";
 import { useMutation, createConnectQueryKey, useTransport } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
@@ -23,7 +23,7 @@ interface DeleteDomainDialogProps {
 const DeleteDomainDialog = ({
   domain,
 }: DeleteDomainDialogProps) => {
-  const {organization} = useContext(OrganizationContext);
+  const { organization } = useContext(OrganizationContext);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const queryClient = useQueryClient();
   const transport = useTransport();
@@ -133,21 +133,49 @@ const DomainItem = ({ domain }: DomainItemProps) => {
 interface DomainsListProps {
   isLoading: boolean;
   domains: Domain[];
+  error?: Error | null;
+  onRetry: () => void;
 }
 
 export const DomainsList = ({
   isLoading,
   domains = [],
+  error,
+  onRetry,
 }: DomainsListProps) => {
+  if (!isLoading && error) {
+    return (
+      <Flex
+        justify="between"
+        align="center"
+        className={styles["domains-list"]}
+        style={{ padding: "var(--rs-space-5) var(--rs-space-7)" }}
+      >
+        <Text size="small" variant="secondary">
+          Couldn&apos;t load email domains
+        </Text>
+        <Button
+          variant="outline"
+          color="neutral"
+          size="small"
+          onClick={() => onRetry()}
+          data-test-id="retry-domains-button"
+        >
+          Retry
+        </Button>
+      </Flex>
+    );
+  }
+
   return isLoading ? (
-    <Flex direction="column" className={styles["domains-list"]}>
-      {[...Array(3)].map((_, index) => (
-        <Skeleton
-          key={index}
-          height={20}
-          style={{ margin: "var(--rs-space-5) 0" }}
-        />
-      ))}
+    <Flex
+      justify="between"
+      align="center"
+      className={styles["domains-list"]}
+      style={{ padding: "var(--rs-space-5) var(--rs-space-7)" }}
+    >
+      <Skeleton height={16} width={180} />
+      <Skeleton height={20} width={20} borderRadius="var(--rs-radius-2)" />
     </Flex>
   ) : domains.length ? (
     <Flex direction="column" className={styles["domains-list"]}>
@@ -158,5 +186,15 @@ export const DomainsList = ({
         />
       ))}
     </Flex>
-  ) : null;
+  ) : (
+    <Flex className={styles["domains-list"]}>
+      <Text
+        size="small"
+        variant="secondary"
+        style={{ padding: "var(--rs-space-5) 0" }}
+      >
+        No allowed email domains added yet
+      </Text>
+    </Flex>
+  );
 };

--- a/web/sdk/admin/views/organizations/details/security/domains-list.tsx
+++ b/web/sdk/admin/views/organizations/details/security/domains-list.tsx
@@ -148,8 +148,7 @@ export const DomainsList = ({
       <Flex
         justify="between"
         align="center"
-        className={styles["domains-list"]}
-        style={{ padding: "var(--rs-space-5) var(--rs-space-7)" }}
+        className={`${styles["domains-list"]} ${styles["domains-list-status"]}`}
       >
         <Text size="small" variant="secondary">
           Couldn&apos;t load email domains
@@ -158,7 +157,7 @@ export const DomainsList = ({
           variant="outline"
           color="neutral"
           size="small"
-          onClick={() => onRetry()}
+          onClick={onRetry}
           data-test-id="retry-domains-button"
         >
           Retry
@@ -171,8 +170,7 @@ export const DomainsList = ({
     <Flex
       justify="between"
       align="center"
-      className={styles["domains-list"]}
-      style={{ padding: "var(--rs-space-5) var(--rs-space-7)" }}
+      className={`${styles["domains-list"]} ${styles["domains-list-status"]}`}
     >
       <Skeleton height={16} width={180} />
       <Skeleton height={20} width={20} borderRadius="var(--rs-radius-2)" />
@@ -187,12 +185,8 @@ export const DomainsList = ({
       ))}
     </Flex>
   ) : (
-    <Flex className={styles["domains-list"]}>
-      <Text
-        size="small"
-        variant="secondary"
-        style={{ padding: "var(--rs-space-5) 0" }}
-      >
+    <Flex className={`${styles["domains-list"]} ${styles["domains-list-empty"]}`}>
+      <Text size="small" variant="secondary">
         No allowed email domains added yet
       </Text>
     </Flex>

--- a/web/sdk/admin/views/organizations/details/security/index.tsx
+++ b/web/sdk/admin/views/organizations/details/security/index.tsx
@@ -88,7 +88,7 @@ export const OrganizationSecurity = () => {
           isLoading={isLoading}
           domains={domains ?? []}
           error={error}
-          onRetry={() => refetch()}
+          onRetry={refetch}
         />
         <Separator />
         <BlockOrganizationSection />

--- a/web/sdk/admin/views/organizations/details/security/index.tsx
+++ b/web/sdk/admin/views/organizations/details/security/index.tsx
@@ -55,7 +55,7 @@ const AddDomainSection = () => {
 export const OrganizationSecurity = () => {
   const { organization } = useContext(OrganizationContext);
 
-  const { data: domains, isLoading, error } = useQuery(
+  const { data: domains, isLoading, error, refetch } = useQuery(
     FrontierServiceQueries.listOrganizationDomains,
     create(ListOrganizationDomainsRequestSchema, {
       orgId: organization?.id
@@ -87,6 +87,8 @@ export const OrganizationSecurity = () => {
         <DomainsList
           isLoading={isLoading}
           domains={domains ?? []}
+          error={error}
+          onRetry={() => refetch()}
         />
         <Separator />
         <BlockOrganizationSection />

--- a/web/sdk/admin/views/organizations/details/security/security.module.css
+++ b/web/sdk/admin/views/organizations/details/security/security.module.css
@@ -15,6 +15,16 @@
   background: var(--rs-color-background-base-primary);
 }
 
+.domains-list-status {
+  padding: var(--rs-space-5) var(--rs-space-7);
+}
+
+.domains-list-empty {
+  padding: var(--rs-space-5) 0;
+  justify-content: center;
+  text-align: center;
+}
+
 .domains-list-item {
   padding: var(--rs-space-5) 0;
   border-bottom: 1px solid var(--rs-color-border-base-primary);


### PR DESCRIPTION
## Summary
The Org → Security page had a buggy loading state — the "Allowed email domains" loader showed up as an unstyled empty box, and the whole section would vanish or behave oddly depending on the data. This PR fixes the loader and makes the loading, empty, and error states consistent and clear.

## Changes
- Switched the domains loader from `react-loading-skeleton` to Apsara's `Skeleton` (self-styled, no extra CSS needed).
- Loading, list, empty, and error states now all render inside the same bordered box, so nothing pops in or collapses.
- Added a friendly empty state ("No allowed email domains added yet") instead of rendering nothing.
- Added a distinct error state with a **Retry** button, so a failed fetch is no longer mistaken for an org with no domains.
  
## Technical Details
- The root cause: the default `react-loading-skeleton` `Skeleton` relies on `react-loading-skeleton/dist/skeleton.css`, which is never imported anywhere in `web/sdk/admin` or `web/apps/admin`. The app's `<SkeletonTheme>` only provides color variables, not the base skeleton styles — so the skeleton rendered as an invisible/empty box. Apsara's `Skeleton` ships its own styles, so it works out of the box (same approach as `session-skeleton.tsx` and `apis/details-dialog.tsx`).
- Previously the component had three branches (skeleton / rows / `null`). The `null` empty case made the bordered box disappear, causing the "abrupt close" jump. All four states (loading/list/empty/error) now share the same `.domains-list` container for a stable layout.
- The error state gets `error` + `onRetry` from the `listOrganizationDomains` query in `index.tsx`; Retry calls the query's `refetch()`. The existing error toast is kept.

## Test Plan
- [x] Manual testing completed
  - Loaded the Org → Security page and confirmed the domains loader shows a proper skeleton, then swaps into the list without any layout jump.
  - Verified an org with no domains shows the empty-state text instead of a blank/collapsing box.
  - Simulated an API failure (blocked the `ListOrganizationDomains` request in DevTools) and confirmed the error state + Retry button appear; Retry re-fetches and recovers.
- [x] Build and type checking passes (`tsc --noEmit` clean for the changed files)

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
N/A

