### PR TITLE
fix: remove unused user and org relations from app/pat schema

### DIFF
--- a/internal/bootstrap/schema/base_schema.zed
+++ b/internal/bootstrap/schema/base_schema.zed
@@ -6,10 +6,7 @@ definition app/serviceuser {
     permission manage = org->serviceusermanage
 }
 
-definition app/pat {
-	relation user: app/user
-	relation org: app/organization
-}
+definition app/pat {}
 
 definition app/platform {
 	relation admin: app/user | app/serviceuser

--- a/internal/bootstrap/testdata/compiled_schema.zed
+++ b/internal/bootstrap/testdata/compiled_schema.zed
@@ -69,10 +69,7 @@ definition app/organization {
 	permission update = platform->superuser + granted->app_organization_administer + granted->app_organization_update + owner
 }
 
-definition app/pat {
-	relation org: app/organization
-	relation user: app/user
-}
+definition app/pat {}
 
 definition app/platform {
 	relation admin: app/user | app/serviceuser


### PR DESCRIPTION
## What

The `app/pat` definition in the base SpiceDB schema declared two relations, `user` and `org`, that are never used. This removes them.

## Why they are unused

- **Nothing writes them.** When a PAT is created, its owning user and org are saved as columns on the `pat` Postgres table (`user_id`, `org_id`). The code never writes an `app/pat#user` or `app/pat#org` tuple. The only SpiceDB writes for a PAT are its role scopes, where the PAT is the subject (the bearer of a role).
- **Nothing reads them.** No permission refers to `pat->user` or `pat->org`.
- **Listing does not need them.** Listing PATs by user or org is a plain SQL query on the `pat` table.

## Impact

None on access. These relations sit in no permission rule, so removing them cannot change any permission check. `app/pat` stays valid as a subject type (like `app/user {}`), so it still appears as `app/pat:*` in role relations and as a `bearer` on rolebindings.

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)