### PR TITLE
fix(products): redirect unknown product id to list instead of dangling URL

### DIFF
--- a/web/sdk/admin/views/products/index.tsx
+++ b/web/sdk/admin/views/products/index.tsx
@@ -1,5 +1,5 @@
 import { EmptyState, Flex, DataTable } from "@raystack/apsara";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { useQuery } from "@connectrpc/connect-query";
 import { FrontierServiceQueries } from "@raystack/proton/frontier";
 import type { Product } from "@raystack/proton/frontier";
@@ -46,6 +46,14 @@ export default function ProductsView({
   const products = productsResponse?.products || [];
   const productMapById = reduceByKey(products ?? [], "id");
   const product = selectedProductId ? productMapById[selectedProductId] ?? null : null;
+
+  // Unknown product id (e.g. /products/create): drop it from the URL.
+  // Skip on error, when the list load — not the id — is what failed.
+  useEffect(() => {
+    if (selectedProductId && !isProductsLoading && !isError && !product) {
+      onCloseDetail?.();
+    }
+  }, [selectedProductId, isProductsLoading, isError, product, onCloseDetail]);
 
   const columns = getColumns(onNavigateToPrices);
 


### PR DESCRIPTION
## Summary
Fixes the /products/create staging URL, which rendered the Products list page but left the URL stuck at /products/create. There is no product-create page in the admin UI (products are managed directly in the DB via YAML), so any unresolved product id now cleanly falls back to the list.

## Changes
- Redirect to /products when the URL carries a product id that resolves to no product (covers /products/create and any stale/invalid id).
- Reuses the existing "close detail" navigation instead of adding a special-case route for create.

## Technical Details
- /products/create was matching the dynamic products/:productId route with productId = "create". ProductsView found no matching product and silently showed the list, but the URL never updated.
- Added an effect in ProductsView that calls onCloseDetail (→ navigate("/products")) when a selectedProductId resolves to no product — only after the list has finished loading, and skipped on load error so a valid deep link isn't bounced when it's the list fetch that failed.

## Test Plan
- [x] Manual testing completed
  - /products/create → redirects to /products and shows the list.
  - /products/<invalid-id> → redirects to /products.
  - /products/<valid-id> → opens the product detail as before.
  - Direct load / refresh on a valid product id doesn't get bounced mid-load.
- [x] Build and type checking passes (no new type errors introduced)

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
N/A

