### PR TITLE
fix(users): resolve user detail via frontierService.getUser instead of searchUsers

### DIFF
--- a/web/sdk/admin/views/users/details/security/block-user.tsx
+++ b/web/sdk/admin/views/users/details/security/block-user.tsx
@@ -7,21 +7,18 @@ import {
   useMutation,
   useTransport,
 } from "@connectrpc/connect-query";
-import {
-  AdminServiceQueries,
-  FrontierServiceQueries,
-} from "@raystack/proton/frontier";
+import { FrontierServiceQueries } from "@raystack/proton/frontier";
 import { useQueryClient } from "@tanstack/react-query";
 import { handleConnectError } from "~/utils/error";
 import { useTerminology } from "../../../../hooks/useTerminology";
 
 type ButtonColorType = ComponentProps<typeof Button>["color"];
 
-type SearchUsersQueryData = {
-  users: Array<{
+type GetUserQueryData = {
+  user?: {
     id: string;
     state?: string;
-  }>;
+  };
 };
 
 export const BlockUserDialog = () => {
@@ -36,20 +33,18 @@ export const BlockUserDialog = () => {
 
   const optimisticUpdateState = useCallback(
     (state: string) => {
-      queryClient.setQueryData<SearchUsersQueryData>(
+      queryClient.setQueryData<GetUserQueryData>(
         createConnectQueryKey({
-          schema: AdminServiceQueries.searchUsers,
+          schema: FrontierServiceQueries.getUser,
           transport,
-          input: { query: { search: user?.id || "" } },
+          input: { id: user?.id || "" },
           cardinality: "finite",
         }),
         oldData => {
-          if (!oldData) return oldData;
+          if (!oldData?.user) return oldData;
           return {
             ...oldData,
-            users: oldData.users.map(u =>
-              u.id === user?.id ? { ...u, state } : u,
-            ),
+            user: { ...oldData.user, state },
           };
         },
       );

--- a/web/sdk/admin/views/users/details/user-details.tsx
+++ b/web/sdk/admin/views/users/details/user-details.tsx
@@ -5,7 +5,7 @@ import { UserDetailsLayout } from "./layout";
 import { UserProvider } from "./user-context";
 import { useQuery } from "@connectrpc/connect-query";
 import type { User } from "@raystack/proton/frontier";
-import { AdminServiceQueries } from "@raystack/proton/frontier";
+import { FrontierServiceQueries } from "@raystack/proton/frontier";
 import { UserDetailsSecurityContent } from "./security/security";
 import { useTerminology } from "../../../hooks/useTerminology";
 
@@ -35,8 +35,8 @@ interface UserDetailsByUserIdProps {
 export const UserDetailsByUserId = ({ userId, currentPath, onNavigate }: UserDetailsByUserIdProps) => {
   const t = useTerminology();
   const { data, isLoading, refetch } = useQuery(
-    AdminServiceQueries.searchUsers,
-    { query: { search: userId } },
+    FrontierServiceQueries.getUser,
+    { id: userId },
     {
       enabled: !!userId,
       staleTime: 0,
@@ -45,7 +45,7 @@ export const UserDetailsByUserId = ({ userId, currentPath, onNavigate }: UserDet
       retryDelay: 1000,
     },
   );
-  const user = data?.users?.[0];
+  const user = data?.user;
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
Replaces the `searchUsers` RPC with `frontierService.getUser` for resolving a single user by ID in the `user-detail` view. 

searchUsers does a search-string match, which failed to resolve some IDs and caused 404s when the user-detail page was reached via the audit-logs sidepanel actor link. getUser fetches directly by ID, fixing both the audit-logs and Users-page detail flows (they share the same component).
  
## Changes
- user-details.tsx: UserDetailsByUserId now queries FrontierServiceQueries.getUser with { id } and reads data?.user, instead of searchUsers with { query: {search: userId } } / data?.users?.[0].
- block-user.tsx: Updated the block/unblock optimistic cache update to target the getUser query key ({ id }, single user) so state changes still reflect instantly; removed the now-unused AdminServiceQueries import.

## Technical Details
- Both the audit-logs actor link (/users/:id) and the Users-page detail view route through the same UserDetailsByUserId component, so one change coversboth scopes.
- The users list (list.tsx) intentionally keeps searchUsers — it's a paginated, filterable search query that getUser (single-user, by-ID) cannot replace.
- The optimistic-update key in block-user.tsx matches the getUser query exactly (same schema, { id } input, finite cardinality, transport), preserving the prior instant-feedback behavior.

## Test Plan
  - [x] Manual testing completed — audit-logs sidepanel actor link resolves to the user-detail page (no 404); block/unblock reflects immediately
  - [x] Build and type checking passes — tsc --noEmit clean for both files

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
N/A

