### PR TITLE
fix(invitation): auto-delete expired invitations on a schedule

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -268,6 +268,17 @@ func StartServer(logger *slog.Logger, cfg *config.Frontier) error {
 		}
 	}()
 
+	// periodic cleanup of expired invitations (removes the row + both SpiceDB tuples)
+	if err := deps.InvitationService.InitInvitationCleanup(ctx); err != nil {
+		logger.Warn("invitation cleanup initialization failed", "err", err)
+	}
+	defer func() {
+		logger.Debug("cleaning up expired invitations job")
+		if err := deps.InvitationService.Close(); err != nil {
+			logger.Warn("invitation cleanup shutdown failed", "err", err)
+		}
+	}()
+
 	if cfg.Billing.StripeKey != "" {
 		// billing services initialization and cleanup
 		if err := deps.CustomerService.Init(ctx); err != nil {

--- a/core/invitation/mocks/repository.go
+++ b/core/invitation/mocks/repository.go
@@ -8,6 +8,8 @@ import (
 	invitation "github.com/raystack/frontier/core/invitation"
 	mock "github.com/stretchr/testify/mock"
 
+	time "time"
+
 	uuid "github.com/google/uuid"
 )
 
@@ -187,9 +189,9 @@ func (_c *Repository_List_Call) RunAndReturn(run func(context.Context, invitatio
 	return _c
 }
 
-// ListExpired provides a mock function with given fields: ctx
-func (_m *Repository) ListExpired(ctx context.Context) ([]invitation.Invitation, error) {
-	ret := _m.Called(ctx)
+// ListExpired provides a mock function with given fields: ctx, expiredBefore
+func (_m *Repository) ListExpired(ctx context.Context, expiredBefore time.Time) ([]invitation.Invitation, error) {
+	ret := _m.Called(ctx, expiredBefore)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListExpired")
@@ -197,19 +199,19 @@ func (_m *Repository) ListExpired(ctx context.Context) ([]invitation.Invitation,
 
 	var r0 []invitation.Invitation
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) ([]invitation.Invitation, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) ([]invitation.Invitation, error)); ok {
+		return rf(ctx, expiredBefore)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) []invitation.Invitation); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) []invitation.Invitation); ok {
+		r0 = rf(ctx, expiredBefore)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]invitation.Invitation)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
+		r1 = rf(ctx, expiredBefore)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -224,13 +226,14 @@ type Repository_ListExpired_Call struct {
 
 // ListExpired is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *Repository_Expecter) ListExpired(ctx interface{}) *Repository_ListExpired_Call {
-	return &Repository_ListExpired_Call{Call: _e.mock.On("ListExpired", ctx)}
+//   - expiredBefore time.Time
+func (_e *Repository_Expecter) ListExpired(ctx interface{}, expiredBefore interface{}) *Repository_ListExpired_Call {
+	return &Repository_ListExpired_Call{Call: _e.mock.On("ListExpired", ctx, expiredBefore)}
 }
 
-func (_c *Repository_ListExpired_Call) Run(run func(ctx context.Context)) *Repository_ListExpired_Call {
+func (_c *Repository_ListExpired_Call) Run(run func(ctx context.Context, expiredBefore time.Time)) *Repository_ListExpired_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(time.Time))
 	})
 	return _c
 }
@@ -240,7 +243,7 @@ func (_c *Repository_ListExpired_Call) Return(_a0 []invitation.Invitation, _a1 e
 	return _c
 }
 
-func (_c *Repository_ListExpired_Call) RunAndReturn(run func(context.Context) ([]invitation.Invitation, error)) *Repository_ListExpired_Call {
+func (_c *Repository_ListExpired_Call) RunAndReturn(run func(context.Context, time.Time) ([]invitation.Invitation, error)) *Repository_ListExpired_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/invitation/mocks/repository.go
+++ b/core/invitation/mocks/repository.go
@@ -187,6 +187,64 @@ func (_c *Repository_List_Call) RunAndReturn(run func(context.Context, invitatio
 	return _c
 }
 
+// ListExpired provides a mock function with given fields: ctx
+func (_m *Repository) ListExpired(ctx context.Context) ([]invitation.Invitation, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListExpired")
+	}
+
+	var r0 []invitation.Invitation
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]invitation.Invitation, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []invitation.Invitation); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]invitation.Invitation)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Repository_ListExpired_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListExpired'
+type Repository_ListExpired_Call struct {
+	*mock.Call
+}
+
+// ListExpired is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Repository_Expecter) ListExpired(ctx interface{}) *Repository_ListExpired_Call {
+	return &Repository_ListExpired_Call{Call: _e.mock.On("ListExpired", ctx)}
+}
+
+func (_c *Repository_ListExpired_Call) Run(run func(ctx context.Context)) *Repository_ListExpired_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *Repository_ListExpired_Call) Return(_a0 []invitation.Invitation, _a1 error) *Repository_ListExpired_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Repository_ListExpired_Call) RunAndReturn(run func(context.Context) ([]invitation.Invitation, error)) *Repository_ListExpired_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListByUser provides a mock function with given fields: ctx, id
 func (_m *Repository) ListByUser(ctx context.Context, id string) ([]invitation.Invitation, error) {
 	ret := _m.Called(ctx, id)

--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/raystack/frontier/core/membership"
 	"github.com/raystack/frontier/core/preference"
 	pkgAuditRecord "github.com/raystack/frontier/pkg/auditrecord"
+	"github.com/robfig/cron/v3"
 	"gopkg.in/mail.v2"
 
 	"github.com/raystack/frontier/pkg/mailer"
@@ -36,6 +37,7 @@ type Repository interface {
 	ListByUser(ctx context.Context, id string) ([]Invitation, error)
 	Get(ctx context.Context, id uuid.UUID) (Invitation, error)
 	Delete(ctx context.Context, id uuid.UUID) error
+	ListExpired(ctx context.Context) ([]Invitation, error)
 }
 
 type UserService interface {
@@ -80,7 +82,12 @@ type Service struct {
 	prefService           PreferencesService
 	auditRecordRepository AuditRecordRepository
 	membershipSvc         MembershipService
+	cron                  *cron.Cron
 }
+
+// invitationCleanupSchedule runs the expired-invitation cleanup once a day at
+// midnight (UTC).
+const invitationCleanupSchedule = "0 0 * * *"
 
 func NewService(dialer mailer.Dialer, repo Repository,
 	orgSvc OrganizationService, grpSvc GroupService,
@@ -98,6 +105,9 @@ func NewService(dialer mailer.Dialer, repo Repository,
 		prefService:           prefService,
 		auditRecordRepository: auditRecordRepository,
 		membershipSvc:         membershipSvc,
+		// Recover so a panic inside the cleanup job can't take down the scheduler
+		// (or the server) — the job just logs and the next tick runs as usual.
+		cron: cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
 	}
 }
 
@@ -261,6 +271,51 @@ func (s Service) Delete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("failed to delete relation for invitation: %w", err)
 	}
 	return s.repo.Delete(ctx, id)
+}
+
+// InitInvitationCleanup starts a background job that deletes expired invitations
+// on a daily schedule. Nothing else removes an invite once it expires (Accept
+// only rejects it, Create just writes a new one over it), so without this the
+// expired invites keep their row and both SpiceDB tuples forever.
+func (s Service) InitInvitationCleanup(ctx context.Context) error {
+	_, err := s.cron.AddFunc(invitationCleanupSchedule, func() {
+		if err := s.DeleteExpiredInvitations(ctx); err != nil {
+			slog.WarnContext(ctx, "failed to clean up expired invitations", "err", err)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	s.cron.Start()
+	return nil
+}
+
+// DeleteExpiredInvitations removes every invitation past its expiry. It goes
+// through Delete (not a raw row purge) so each invite's SpiceDB tuples AND its
+// invitations row are removed together — a row-only delete would leak the
+// #user / #org tuples behind.
+func (s Service) DeleteExpiredInvitations(ctx context.Context) error {
+	expired, err := s.repo.ListExpired(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list expired invitations: %w", err)
+	}
+	deleted := 0
+	for _, inv := range expired {
+		if err := s.Delete(ctx, inv.ID); err != nil {
+			slog.WarnContext(ctx, "failed to delete expired invitation", "invitation_id", inv.ID.String(), "err", err)
+			continue
+		}
+		deleted++
+	}
+	if deleted > 0 {
+		slog.DebugContext(ctx, "deleted expired invitations", "count", deleted)
+	}
+	return nil
+}
+
+// Close stops the background cleanup job.
+func (s Service) Close() error {
+	return s.cron.Stop().Err()
 }
 
 // check if user is already part of the organization that the invitation is created for

--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -108,9 +108,13 @@ func NewService(dialer mailer.Dialer, repo Repository,
 		prefService:           prefService,
 		auditRecordRepository: auditRecordRepository,
 		membershipSvc:         membershipSvc,
-		// Recover so a panic inside the cleanup job can't take down the scheduler
-		// (or the server) — the job just logs and the next tick runs as usual.
-		cron: cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger))),
+		// Pin to UTC so the schedule runs at midnight UTC regardless of the host's
+		// local time zone. Recover so a panic inside the cleanup job can't take down
+		// the scheduler (or the server) — the job just logs and the next tick runs.
+		cron: cron.New(
+			cron.WithLocation(time.UTC),
+			cron.WithChain(cron.Recover(cron.DefaultLogger)),
+		),
 	}
 }
 

--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -37,7 +37,7 @@ type Repository interface {
 	ListByUser(ctx context.Context, id string) ([]Invitation, error)
 	Get(ctx context.Context, id uuid.UUID) (Invitation, error)
 	Delete(ctx context.Context, id uuid.UUID) error
-	ListExpired(ctx context.Context) ([]Invitation, error)
+	ListExpired(ctx context.Context, expiredBefore time.Time) ([]Invitation, error)
 }
 
 type UserService interface {
@@ -86,6 +86,11 @@ type Service struct {
 }
 
 const refreshTime = "0 0 * * *" // Once a day at midnight (UTC)
+
+// invitationRetention is how long an invitation is kept after it expires before
+// the cleanup job deletes it. During this window a recently expired invite is
+// still returned by the list APIs; the cron removes it once it is this old.
+const invitationRetention = 7 * 24 * time.Hour
 
 func NewService(dialer mailer.Dialer, repo Repository,
 	orgSvc OrganizationService, grpSvc GroupService,
@@ -288,12 +293,15 @@ func (s Service) InitInvitationCleanup(ctx context.Context) error {
 	return nil
 }
 
-// DeleteExpiredInvitations removes every invitation past its expiry. It goes
-// through Delete (not a raw row purge) so each invite's SpiceDB tuples AND its
-// invitations row are removed together — a row-only delete would leak the
-// #user / #org tuples behind.
+// DeleteExpiredInvitations removes invitations that expired at least
+// invitationRetention ago. Recently expired invites are left alone so they
+// still show up in the list APIs; the next daily run deletes them once they
+// cross the retention window. It goes through Delete (not a raw row purge) so
+// each invite's SpiceDB tuples AND its invitations row are removed together —
+// a row-only delete would leak the #user / #org tuples behind.
 func (s Service) DeleteExpiredInvitations(ctx context.Context) error {
-	expired, err := s.repo.ListExpired(ctx)
+	expiredBefore := time.Now().UTC().Add(-invitationRetention)
+	expired, err := s.repo.ListExpired(ctx, expiredBefore)
 	if err != nil {
 		return fmt.Errorf("failed to list expired invitations: %w", err)
 	}

--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -277,9 +277,7 @@ func (s Service) Delete(ctx context.Context, id uuid.UUID) error {
 }
 
 // InitInvitationCleanup starts a background job that deletes expired invitations
-// on a daily schedule. Nothing else removes an invite once it expires (Accept
-// only rejects it, Create just writes a new one over it), so without this the
-// expired invites keep their row and both SpiceDB tuples forever.
+// on a daily schedule.
 func (s Service) InitInvitationCleanup(ctx context.Context) error {
 	_, err := s.cron.AddFunc(refreshTime, func() {
 		if err := s.DeleteExpiredInvitations(ctx); err != nil {
@@ -294,11 +292,7 @@ func (s Service) InitInvitationCleanup(ctx context.Context) error {
 }
 
 // DeleteExpiredInvitations removes invitations that expired at least
-// invitationRetention ago. Recently expired invites are left alone so they
-// still show up in the list APIs; the next daily run deletes them once they
-// cross the retention window. It goes through Delete (not a raw row purge) so
-// each invite's SpiceDB tuples AND its invitations row are removed together —
-// a row-only delete would leak the #user / #org tuples behind.
+// invitationRetention ago.
 func (s Service) DeleteExpiredInvitations(ctx context.Context) error {
 	expiredBefore := time.Now().UTC().Add(-invitationRetention)
 	expired, err := s.repo.ListExpired(ctx, expiredBefore)

--- a/core/invitation/service.go
+++ b/core/invitation/service.go
@@ -85,9 +85,7 @@ type Service struct {
 	cron                  *cron.Cron
 }
 
-// invitationCleanupSchedule runs the expired-invitation cleanup once a day at
-// midnight (UTC).
-const invitationCleanupSchedule = "0 0 * * *"
+const refreshTime = "0 0 * * *" // Once a day at midnight (UTC)
 
 func NewService(dialer mailer.Dialer, repo Repository,
 	orgSvc OrganizationService, grpSvc GroupService,
@@ -278,7 +276,7 @@ func (s Service) Delete(ctx context.Context, id uuid.UUID) error {
 // only rejects it, Create just writes a new one over it), so without this the
 // expired invites keep their row and both SpiceDB tuples forever.
 func (s Service) InitInvitationCleanup(ctx context.Context) error {
-	_, err := s.cron.AddFunc(invitationCleanupSchedule, func() {
+	_, err := s.cron.AddFunc(refreshTime, func() {
 		if err := s.DeleteExpiredInvitations(ctx); err != nil {
 			slog.WarnContext(ctx, "failed to clean up expired invitations", "err", err)
 		}

--- a/core/invitation/service_test.go
+++ b/core/invitation/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/raystack/frontier/core/invitation/mocks"
 	"github.com/raystack/frontier/core/membership"
 	"github.com/raystack/frontier/core/organization"
+	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/core/user"
 	"github.com/raystack/frontier/pkg/errors"
 	mocks2 "github.com/raystack/frontier/pkg/mailer/mocks"
@@ -145,4 +146,67 @@ func TestService_Accept_DedupesExistingGroupMembers(t *testing.T) {
 
 	err := svc.Accept(ctx, inviteID)
 	assert.NoError(t, err)
+}
+
+func TestService_DeleteExpiredInvitations(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes each expired invitation through Delete (row + both tuples)", func(t *testing.T) {
+		dialer, repo, orgService, groupService, userService, relationService, prefService, auditRecordRepo := mockService(t)
+		membershipSvc := mocks.NewMembershipService(t)
+
+		expired := []invitation.Invitation{
+			{ID: uuid.New(), OrgID: "org-1", UserEmailID: "a@example.com"},
+			{ID: uuid.New(), OrgID: "org-2", UserEmailID: "b@example.com"},
+		}
+		repo.EXPECT().ListExpired(ctx).Return(expired, nil)
+		for _, inv := range expired {
+			// Delete removes every relation on the invitation object (object-only,
+			// no RelationName) so both the #user and #org tuples go, then the row.
+			relationService.EXPECT().Delete(ctx, mock.AnythingOfType("relation.Relation")).Return(nil).Once()
+			repo.EXPECT().Delete(ctx, inv.ID).Return(nil).Once()
+		}
+
+		svc := invitation.NewService(dialer, repo, orgService, groupService,
+			userService, relationService, prefService, auditRecordRepo, membershipSvc)
+
+		assert.NoError(t, svc.DeleteExpiredInvitations(ctx))
+	})
+
+	t.Run("nothing expired is a no-op", func(t *testing.T) {
+		dialer, repo, orgService, groupService, userService, relationService, prefService, auditRecordRepo := mockService(t)
+		membershipSvc := mocks.NewMembershipService(t)
+
+		repo.EXPECT().ListExpired(ctx).Return(nil, nil)
+
+		svc := invitation.NewService(dialer, repo, orgService, groupService,
+			userService, relationService, prefService, auditRecordRepo, membershipSvc)
+
+		assert.NoError(t, svc.DeleteExpiredInvitations(ctx))
+	})
+
+	t.Run("one Delete failing does not stop the rest", func(t *testing.T) {
+		dialer, repo, orgService, groupService, userService, relationService, prefService, auditRecordRepo := mockService(t)
+		membershipSvc := mocks.NewMembershipService(t)
+
+		first := invitation.Invitation{ID: uuid.New(), OrgID: "org-1", UserEmailID: "a@example.com"}
+		second := invitation.Invitation{ID: uuid.New(), OrgID: "org-2", UserEmailID: "b@example.com"}
+		repo.EXPECT().ListExpired(ctx).Return([]invitation.Invitation{first, second}, nil)
+
+		// first invite: tuple delete fails -> Delete returns an error, row not touched
+		relationService.EXPECT().Delete(ctx, mock.MatchedBy(func(rel relation.Relation) bool {
+			return rel.Object.ID == first.ID.String()
+		})).Return(assert.AnError).Once()
+		// second invite still processed
+		relationService.EXPECT().Delete(ctx, mock.MatchedBy(func(rel relation.Relation) bool {
+			return rel.Object.ID == second.ID.String()
+		})).Return(nil).Once()
+		repo.EXPECT().Delete(ctx, second.ID).Return(nil).Once()
+
+		svc := invitation.NewService(dialer, repo, orgService, groupService,
+			userService, relationService, prefService, auditRecordRepo, membershipSvc)
+
+		// the sweep itself does not error; per-item failures are logged and skipped
+		assert.NoError(t, svc.DeleteExpiredInvitations(ctx))
+	})
 }

--- a/core/invitation/service_test.go
+++ b/core/invitation/service_test.go
@@ -159,7 +159,12 @@ func TestService_DeleteExpiredInvitations(t *testing.T) {
 			{ID: uuid.New(), OrgID: "org-1", UserEmailID: "a@example.com"},
 			{ID: uuid.New(), OrgID: "org-2", UserEmailID: "b@example.com"},
 		}
-		repo.EXPECT().ListExpired(ctx).Return(expired, nil)
+		// the sweep asks for invites that expired at least the retention window
+		// (7 days) ago — not just anything past its expiry.
+		repo.EXPECT().ListExpired(ctx, mock.MatchedBy(func(cutoff time.Time) bool {
+			want := time.Now().UTC().Add(-7 * 24 * time.Hour)
+			return cutoff.Sub(want) > -time.Minute && cutoff.Sub(want) < time.Minute
+		})).Return(expired, nil)
 		for _, inv := range expired {
 			// Delete removes every relation on the invitation object (object-only,
 			// no RelationName) so both the #user and #org tuples go, then the row.
@@ -177,7 +182,7 @@ func TestService_DeleteExpiredInvitations(t *testing.T) {
 		dialer, repo, orgService, groupService, userService, relationService, prefService, auditRecordRepo := mockService(t)
 		membershipSvc := mocks.NewMembershipService(t)
 
-		repo.EXPECT().ListExpired(ctx).Return(nil, nil)
+		repo.EXPECT().ListExpired(ctx, mock.AnythingOfType("time.Time")).Return(nil, nil)
 
 		svc := invitation.NewService(dialer, repo, orgService, groupService,
 			userService, relationService, prefService, auditRecordRepo, membershipSvc)
@@ -191,7 +196,7 @@ func TestService_DeleteExpiredInvitations(t *testing.T) {
 
 		first := invitation.Invitation{ID: uuid.New(), OrgID: "org-1", UserEmailID: "a@example.com"}
 		second := invitation.Invitation{ID: uuid.New(), OrgID: "org-2", UserEmailID: "b@example.com"}
-		repo.EXPECT().ListExpired(ctx).Return([]invitation.Invitation{first, second}, nil)
+		repo.EXPECT().ListExpired(ctx, mock.AnythingOfType("time.Time")).Return([]invitation.Invitation{first, second}, nil)
 
 		// first invite: tuple delete fails -> Delete returns an error, row not touched
 		relationService.EXPECT().Delete(ctx, mock.MatchedBy(func(rel relation.Relation) bool {

--- a/internal/store/postgres/invitation_repository.go
+++ b/internal/store/postgres/invitation_repository.go
@@ -244,10 +244,7 @@ func (s *InvitationRepository) Delete(ctx context.Context, id uuid.UUID) error {
 }
 
 // ListExpired returns every invitation whose expires_at is at or before
-// expiredBefore. The caller passes a cutoff in the past (now minus the
-// retention window) so recently expired invites are skipped, and deletes the
-// results through the invitation service so both the SpiceDB tuples and the
-// invitations row are removed
+// expiredBefore.
 func (s *InvitationRepository) ListExpired(ctx context.Context, expiredBefore time.Time) ([]invitation.Invitation, error) {
 	var fetchedInvitations []Invitation
 	query, params, err := dialect.From(TABLE_INVITATIONS).

--- a/internal/store/postgres/invitation_repository.go
+++ b/internal/store/postgres/invitation_repository.go
@@ -247,8 +247,7 @@ func (s *InvitationRepository) Delete(ctx context.Context, id uuid.UUID) error {
 // expiredBefore. The caller passes a cutoff in the past (now minus the
 // retention window) so recently expired invites are skipped, and deletes the
 // results through the invitation service so both the SpiceDB tuples and the
-// invitations row are removed together — a raw row delete here would leak the
-// invitation's #user / #org tuples behind.
+// invitations row are removed
 func (s *InvitationRepository) ListExpired(ctx context.Context, expiredBefore time.Time) ([]invitation.Invitation, error) {
 	var fetchedInvitations []Invitation
 	query, params, err := dialect.From(TABLE_INVITATIONS).

--- a/internal/store/postgres/invitation_repository.go
+++ b/internal/store/postgres/invitation_repository.go
@@ -243,27 +243,39 @@ func (s *InvitationRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	})
 }
 
-// TODO(kushsharma): schedue a cron for it
-func (s *InvitationRepository) GarbageCollect(ctx context.Context) error {
-	query, params, err := dialect.Delete(TABLE_INVITATIONS).
+// ListExpired returns every invitation whose expires_at is in the past. The
+// caller deletes them through the invitation service so both the SpiceDB tuples
+// and the invitations row are removed together — a raw row delete here would
+// leak the invitation's #user / #org tuples behind.
+func (s *InvitationRepository) ListExpired(ctx context.Context) ([]invitation.Invitation, error) {
+	var fetchedInvitations []Invitation
+	query, params, err := dialect.From(TABLE_INVITATIONS).
 		Where(
 			goqu.Ex{
 				"expires_at": goqu.Op{"lte": s.Now()},
 			},
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", queryErr, err)
 	}
 
-	return s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "GarbageCollect", func(ctx context.Context) error {
-		result, err := s.dbc.ExecContext(ctx, query, params...)
-		if err != nil {
-			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+	if err = s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "ListExpired", func(ctx context.Context) error {
+		return s.dbc.SelectContext(ctx, &fetchedInvitations, query, params...)
+	}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
 		}
+		return nil, fmt.Errorf("%w: %s", dbErr, err)
+	}
 
-		count, _ := result.RowsAffected()
-		s.log.DebugContext(ctx, "deleted expired invitation", "expired_invitations_count", count)
-		return nil
-	})
+	var transformedInvitations []invitation.Invitation
+	for _, o := range fetchedInvitations {
+		transPerm, err := o.transformToInvitation()
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform invitation model: %w", err)
+		}
+		transformedInvitations = append(transformedInvitations, transPerm)
+	}
+
+	return transformedInvitations, nil
 }

--- a/internal/store/postgres/invitation_repository.go
+++ b/internal/store/postgres/invitation_repository.go
@@ -243,16 +243,18 @@ func (s *InvitationRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	})
 }
 
-// ListExpired returns every invitation whose expires_at is in the past. The
-// caller deletes them through the invitation service so both the SpiceDB tuples
-// and the invitations row are removed together — a raw row delete here would
-// leak the invitation's #user / #org tuples behind.
-func (s *InvitationRepository) ListExpired(ctx context.Context) ([]invitation.Invitation, error) {
+// ListExpired returns every invitation whose expires_at is at or before
+// expiredBefore. The caller passes a cutoff in the past (now minus the
+// retention window) so recently expired invites are skipped, and deletes the
+// results through the invitation service so both the SpiceDB tuples and the
+// invitations row are removed together — a raw row delete here would leak the
+// invitation's #user / #org tuples behind.
+func (s *InvitationRepository) ListExpired(ctx context.Context, expiredBefore time.Time) ([]invitation.Invitation, error) {
 	var fetchedInvitations []Invitation
 	query, params, err := dialect.From(TABLE_INVITATIONS).
 		Where(
 			goqu.Ex{
-				"expires_at": goqu.Op{"lte": s.Now()},
+				"expires_at": goqu.Op{"lte": expiredBefore},
 			},
 		).ToSQL()
 	if err != nil {

--- a/internal/store/postgres/invitation_repository_test.go
+++ b/internal/store/postgres/invitation_repository_test.go
@@ -323,29 +323,32 @@ func (s *InvitationRespositoryTestSuite) TestDelete() {
 	}
 }
 
-func (s *InvitationRespositoryTestSuite) TestGarbageCollect() {
-	type testCase struct {
-		Name          string
-		ExpectedError error
-	}
+func (s *InvitationRespositoryTestSuite) TestListExpired() {
+	// the two seeded invites use the default expiry (now + 7 days), so they are
+	// not expired.
+	s.Run("returns nothing when no invite is past its expiry", func() {
+		expired, err := s.repository.ListExpired(s.ctx)
+		require.NoError(s.T(), err)
+		require.Empty(s.T(), expired)
+	})
 
-	var testCases = []testCase{
-		{
-			Name:          "garbage collect",
-			ExpectedError: nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		s.T().Run(tc.Name, func(t *testing.T) {
-			err := s.repository.GarbageCollect(s.ctx)
-			if tc.ExpectedError != nil {
-				require.EqualError(t, err, tc.ExpectedError.Error())
-			} else {
-				require.NoError(t, err)
-			}
+	s.Run("returns only invites past their expiry", func() {
+		expiredID := uuid.New()
+		_, err := s.repository.Set(s.ctx, invitation.Invitation{
+			ID:          expiredID,
+			UserEmailID: s.users[0].Email,
+			OrgID:       s.orgs[0].ID,
+			GroupIDs:    []string{s.groups[0].ID},
+			CreatedAt:   time.Now().UTC().Add(-48 * time.Hour),
+			ExpiresAt:   time.Now().UTC().Add(-24 * time.Hour),
 		})
-	}
+		require.NoError(s.T(), err)
+
+		expired, err := s.repository.ListExpired(s.ctx)
+		require.NoError(s.T(), err)
+		require.Len(s.T(), expired, 1)
+		require.Equal(s.T(), expiredID, expired[0].ID)
+	})
 }
 
 func TestInvitationRespository(t *testing.T) {

--- a/internal/store/postgres/invitation_repository_test.go
+++ b/internal/store/postgres/invitation_repository_test.go
@@ -324,30 +324,49 @@ func (s *InvitationRespositoryTestSuite) TestDelete() {
 }
 
 func (s *InvitationRespositoryTestSuite) TestListExpired() {
+	cutoff := time.Now().UTC().Add(-7 * 24 * time.Hour) // retention window: 7 days
+
 	// the two seeded invites use the default expiry (now + 7 days), so they are
 	// not expired.
-	s.Run("returns nothing when no invite is past its expiry", func() {
-		expired, err := s.repository.ListExpired(s.ctx)
+	s.Run("returns nothing when no invite is older than the cutoff", func() {
+		expired, err := s.repository.ListExpired(s.ctx, cutoff)
 		require.NoError(s.T(), err)
 		require.Empty(s.T(), expired)
 	})
 
-	s.Run("returns only invites past their expiry", func() {
-		expiredID := uuid.New()
+	s.Run("skips a recently expired invite that is still within the retention window", func() {
+		recentID := uuid.New()
 		_, err := s.repository.Set(s.ctx, invitation.Invitation{
-			ID:          expiredID,
+			ID:          recentID,
 			UserEmailID: s.users[0].Email,
 			OrgID:       s.orgs[0].ID,
 			GroupIDs:    []string{s.groups[0].ID},
-			CreatedAt:   time.Now().UTC().Add(-48 * time.Hour),
-			ExpiresAt:   time.Now().UTC().Add(-24 * time.Hour),
+			CreatedAt:   time.Now().UTC().Add(-8 * 24 * time.Hour),
+			ExpiresAt:   time.Now().UTC().Add(-24 * time.Hour), // expired 1 day ago
 		})
 		require.NoError(s.T(), err)
 
-		expired, err := s.repository.ListExpired(s.ctx)
+		expired, err := s.repository.ListExpired(s.ctx, cutoff)
+		require.NoError(s.T(), err)
+		require.Empty(s.T(), expired)
+	})
+
+	s.Run("returns only invites that expired before the cutoff", func() {
+		oldID := uuid.New()
+		_, err := s.repository.Set(s.ctx, invitation.Invitation{
+			ID:          oldID,
+			UserEmailID: s.users[0].Email,
+			OrgID:       s.orgs[0].ID,
+			GroupIDs:    []string{s.groups[0].ID},
+			CreatedAt:   time.Now().UTC().Add(-15 * 24 * time.Hour),
+			ExpiresAt:   time.Now().UTC().Add(-8 * 24 * time.Hour), // expired 8 days ago
+		})
+		require.NoError(s.T(), err)
+
+		expired, err := s.repository.ListExpired(s.ctx, cutoff)
 		require.NoError(s.T(), err)
 		require.Len(s.T(), expired, 1)
-		require.Equal(s.T(), expiredID, expired[0].ID)
+		require.Equal(s.T(), oldID, expired[0].ID)
 	})
 }
 


### PR DESCRIPTION
## The problem

Expired invitations were not getting cleaned up.

If you try to accept an expired invite, it just fails. If someone sends a new invite to the same person, it writes over the old one. Neither of these actually removes the expired invite.

So an invite that is never accepted and never deleted stays around forever. Each invite is stored in three places: one row in the `invitations` table, and two records in SpiceDB (one links the invite to the user, one links it to the org). All three keep piling up over time.

## The fix

Add a job that runs once a day, at midnight UTC, and deletes expired invites. This matches how the domain and session cleanup jobs already work. If the job ever crashes, the crash is caught so it can't take down the server.

The job does not delete an invite the moment it expires. It waits until the invite has been expired for 7 days. That way a recently expired invite still shows up in the list for a week, and the job cleans it up after that.

To delete, the job uses the existing `invitation.Delete`. That one call removes the table row and both SpiceDB records together.

This is the important part. The code already had a `GarbageCollect` function that deleted only the table row, with a plain SQL delete. That would have left the two SpiceDB records behind with nothing pointing to them. So I removed it and replaced it with a read-only `ListExpired` that just finds the old invites. The job then deletes each one the safe way.

If one invite fails to delete, the job logs it and moves on, so the rest still get cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)