### PR TITLE
feat(billing): use credit product title as overdraft invoice line item name

### DIFF
--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -33,6 +33,9 @@ const (
 	// MonthCreditRangeForInvoice only month is supported for now, could be week or year
 	MonthCreditRangeForInvoice = "month"
 	CreditOverdraftDescription = "Invoice for the underpayment of credit utilization"
+	// DefaultCreditOverdraftItemName is the invoice line item description
+	// used when the overdraft product has no title
+	DefaultCreditOverdraftItemName = "Credit Overdraft"
 )
 
 type Repository interface {
@@ -80,6 +83,7 @@ type Service struct {
 
 	stripeAutoTax                  bool
 	creditOverdraftProduct         string
+	creditOverdraftItemName        string
 	creditOverdraftUnitAmount      int64
 	creditOverdraftInvoiceCurrency string
 	creditOverdraftInvoiceDay      int
@@ -135,9 +139,11 @@ func (s *Service) Init(ctx context.Context) error {
 		}
 		s.creditOverdraftInvoiceCurrency = creditPrice.Currency
 		s.creditOverdraftUnitAmount = int64(float64(creditPrice.Amount) / float64(creditProduct.Config.CreditAmount))
+		s.creditOverdraftItemName = creditProduct.Title
 		s.log.InfoContext(ctx, "credit overdraft product details",
 			"unit_amount", s.creditOverdraftUnitAmount,
-			"currency", s.creditOverdraftInvoiceCurrency)
+			"currency", s.creditOverdraftInvoiceCurrency,
+			"item_name", s.overdraftItemName())
 	}
 	return nil
 }
@@ -529,7 +535,7 @@ func (s *Service) GenerateForCredits(ctx context.Context) error {
 		items := []Item{
 			{
 				ID:             uuid.New().String(),
-				Name:           "Credit Overdraft",
+				Name:           s.overdraftItemName(),
 				Type:           CreditItemType,
 				UnitAmount:     s.creditOverdraftUnitAmount,
 				Quantity:       abs(balance),
@@ -578,6 +584,15 @@ func computeOverdraftWindow(startRange time.Time, endRange time.Time, lastOverdr
 		}
 	}
 	return startRange, alreadyInvoiced
+}
+
+// overdraftItemName returns the description used on the credit overdraft
+// invoice line item, the overdraft product title when available
+func (s *Service) overdraftItemName() string {
+	if s.creditOverdraftItemName != "" {
+		return s.creditOverdraftItemName
+	}
+	return DefaultCreditOverdraftItemName
 }
 
 // getCreditOverdraftEndDate get range start and end, end date will be the current date with time set to 00:00:00

--- a/billing/invoice/service_test.go
+++ b/billing/invoice/service_test.go
@@ -150,3 +150,29 @@ func TestService_getCreditOverdraftRange(t *testing.T) {
 		})
 	}
 }
+
+func TestService_overdraftItemName(t *testing.T) {
+	tests := []struct {
+		name     string
+		itemName string
+		want     string
+	}{
+		{
+			name:     "uses the overdraft product title when set",
+			itemName: "For Satellite Images and Data Analytics Services",
+			want:     "For Satellite Images and Data Analytics Services",
+		},
+		{
+			name: "falls back to default when product title is empty",
+			want: DefaultCreditOverdraftItemName,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{creditOverdraftItemName: tt.itemName}
+			if got := s.overdraftItemName(); got != tt.want {
+				t.Errorf("overdraftItemName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this changes

The monthly credit overdraft invoice shows a hardcoded line item text: "Credit Overdraft".

This PR changes it to use the title of the configured credit overdraft product. If the title is empty, it falls back to "Credit Overdraft" as before.

## Why

The finance team wants a proper service description on the invoice line. The token purchase invoice already prints the product title (Stripe uses the product name as the line text). With this change, the overdraft invoice reads from the same field. Operators can then set the wording once, in the product config.

## How it works

- `Init` already loads the overdraft product for its price. It now also stores the product title.
- `GenerateForCredits` uses that title as the invoice item name.
- The item name becomes the Stripe line description in `CreateInProvider`.

## Notes

- No change if the product has no title: the line still says "Credit Overdraft".
- Invoice reconciliation is not affected. It matches items by type, not by name.