### PR TITLE
fix: wait for background goroutines during shutdown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -333,6 +333,14 @@ func StartServer(logger *slog.Logger, cfg *config.Frontier) error {
 		return server.ServeConnect(gctx, logger, cfg.App, deps, promRegistry)
 	})
 
+	// Once shutdown starts, unregister the signal handler so a second
+	// SIGINT/SIGTERM gets default handling and can kill a stuck drain
+	// instead of being swallowed.
+	go func() {
+		<-gctx.Done()
+		cancelFunc()
+	}()
+
 	// Wait for every server to finish draining before the deferred cleanup
 	// above closes the database and other dependencies under them.
 	return g.Wait()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,14 +3,18 @@ package cmd
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/raystack/frontier/core/aggregates/orgbilling"
 	"github.com/raystack/frontier/core/aggregates/orginvoices"
@@ -28,8 +32,6 @@ import (
 	"github.com/raystack/frontier/core/kyc"
 	"github.com/raystack/frontier/core/prospect"
 	"github.com/raystack/frontier/core/userpat"
-
-	"slices"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/jackc/pgx/v4"
@@ -311,16 +313,29 @@ func StartServer(logger *slog.Logger, cfg *config.Frontier) error {
 		}()
 	}
 
-	go func() {
-		if err := deps.LogListener.Listen(ctx); err != nil {
+	// gctx is cancelled when ctx is cancelled or when any member returns an
+	// error, so a connect server failure also winds down the UI and listener.
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		if err := deps.LogListener.Listen(gctx); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Warn("log listener failed", "err", err)
 		}
-	}()
+		return nil
+	})
 
-	go server.ServeUI(ctx, logger, cfg.UI, cfg.App)
+	g.Go(func() error {
+		server.ServeUI(gctx, logger, cfg.UI, cfg.App)
+		return nil
+	})
 
-	// start connect server (blocking)
-	return server.ServeConnect(ctx, logger, cfg.App, deps, promRegistry)
+	g.Go(func() error {
+		return server.ServeConnect(gctx, logger, cfg.App, deps, promRegistry)
+	})
+
+	// Wait for every server to finish draining before the deferred cleanup
+	// above closes the database and other dependencies under them.
+	return g.Wait()
 }
 
 func buildAPIDependencies(

--- a/pkg/server/serve_ui_test.go
+++ b/pkg/server/serve_ui_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestServeUIReturnsAfterShutdownOnContextCancel(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not find a free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ServeUI(ctx, logger, UIConfig{Port: port}, Config{})
+	}()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/configs", port)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatalf("ui server did not respond at %s in time", url)
+		}
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("ServeUI did not return after context cancel")
+	}
+}
+
+func TestServeUIReturnsWhenPortNotConfigured(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ServeUI(context.Background(), logger, UIConfig{}, Config{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeUI did not return when no port is configured")
+	}
+}

--- a/pkg/server/serve_ui_test.go
+++ b/pkg/server/serve_ui_test.go
@@ -9,9 +9,17 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/raystack/frontier/web/apps/admin"
 )
 
 func TestServeUIReturnsAfterShutdownOnContextCancel(t *testing.T) {
+	if f, err := admin.Assets.Open("dist/admin/index.html"); err != nil {
+		t.Skip("admin SPA assets are not built; ServeUI exits before starting the server")
+	} else {
+		f.Close()
+	}
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -12,8 +13,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-
-	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/raystack/salt/server/spa"
@@ -66,48 +65,72 @@ func ServeUI(ctx context.Context, logger *slog.Logger, uiConfig UIConfig, apiSer
 	if err != nil {
 		logger.Warn("failed to load ui", "err", err)
 		return
-	} else {
-		connectRemoteHost := fmt.Sprintf("http://%s:%d", apiServerConfig.Host, apiServerConfig.Connect.Port)
-		connectRemote, err := url.Parse(connectRemoteHost)
-		if err != nil {
-			logger.Error("ui server failed: unable to parse connect server host")
-			return
+	}
+
+	connectRemoteHost := fmt.Sprintf("http://%s:%d", apiServerConfig.Host, apiServerConfig.Connect.Port)
+	connectRemote, err := url.Parse(connectRemoteHost)
+	if err != nil {
+		logger.Error("ui server failed: unable to parse connect server host")
+		return
+	}
+
+	connectProxyHandler := func(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
+			r.URL.Path = strings.Replace(r.URL.Path, "/frontier-connect", "", -1)
+			r.Host = connectRemoteHost
+			p.ServeHTTP(w, r)
 		}
+	}
 
-		connectProxyHandler := func(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
-			return func(w http.ResponseWriter, r *http.Request) {
-				r.URL.Path = strings.Replace(r.URL.Path, "/frontier-connect", "", -1)
-				r.Host = connectRemoteHost
-				p.ServeHTTP(w, r)
-			}
+	connectProxy := httputil.NewSingleHostReverseProxy(connectRemote)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/configs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		confResp := UIConfigApiResponse{
+			Title:             uiConfig.Title,
+			Logo:              uiConfig.Logo,
+			AppUrl:            uiConfig.AppURL,
+			TokenProductId:    uiConfig.TokenProductId,
+			OrganizationTypes: uiConfig.OrganizationTypes,
+			Webhooks: WebhooksConfigApiResponse{
+				EnableDelete: uiConfig.Webhooks.EnableDelete,
+			},
+			Terminology: uiConfig.Terminology,
 		}
+		json.NewEncoder(w).Encode(confResp)
+	})
 
-		connectProxy := httputil.NewSingleHostReverseProxy(connectRemote)
+	mux.HandleFunc("/frontier-connect/", connectProxyHandler(connectProxy))
+	mux.Handle("/", http.StripPrefix("/", spaHandler))
 
-		http.HandleFunc("/configs", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			confResp := UIConfigApiResponse{
-				Title:             uiConfig.Title,
-				Logo:              uiConfig.Logo,
-				AppUrl:            uiConfig.AppURL,
-				TokenProductId:    uiConfig.TokenProductId,
-				OrganizationTypes: uiConfig.OrganizationTypes,
-				Webhooks: WebhooksConfigApiResponse{
-					EnableDelete: uiConfig.Webhooks.EnableDelete,
-				},
-				Terminology: uiConfig.Terminology,
-			}
-			json.NewEncoder(w).Encode(confResp)
-		})
-
-		http.HandleFunc("/frontier-connect/", connectProxyHandler(connectProxy))
-		http.Handle("/", http.StripPrefix("/", spaHandler))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", uiConfig.Port),
+		Handler: mux,
 	}
 
 	logger.Info("ui server starting", "http-port", uiConfig.Port)
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", uiConfig.Port), nil); err != nil {
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serveErr:
 		logger.Error("ui server failed", "err", err)
+		return
+	case <-ctx.Done():
 	}
+
+	ctxShutdown, cancel := context.WithTimeout(context.Background(), connectServerGracePeriod)
+	defer cancel()
+
+	if err := server.Shutdown(ctxShutdown); err != nil {
+		logger.ErrorContext(ctxShutdown, "ui server shutdown error", "err", err)
+		return
+	}
+
+	logger.Info("Graceful shutdown of ui server complete")
 }
 
 func ServeConnect(ctx context.Context, logger *slog.Logger, cfg Config, deps api.Deps, promRegistry *prometheus.Registry) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,7 +70,7 @@ func ServeUI(ctx context.Context, logger *slog.Logger, uiConfig UIConfig, apiSer
 	connectRemoteHost := fmt.Sprintf("http://%s:%d", apiServerConfig.Host, apiServerConfig.Connect.Port)
 	connectRemote, err := url.Parse(connectRemoteHost)
 	if err != nil {
-		logger.Error("ui server failed: unable to parse connect server host")
+		logger.Error("ui server failed: unable to parse connect server host", "err", err)
 		return
 	}
 


### PR DESCRIPTION
Based on #1747 — merge that first; this base retargets to main after.

## Summary
`StartServer` now waits for the UI server and the audit log listener to
finish shutting down before running deferred cleanup, instead of only
waiting for the connect server.

## Changes
- The log listener, UI server, and connect server run under an
  `errgroup`; `StartServer` returns `g.Wait()`, so deferred cleanup
  (database and service `Close()` calls) runs only after all three
  finish.
- All three receive the group context, so a connect server startup
  failure also winds down the UI server and listener.
- A cancelled context is no longer logged as "log listener failed" on
  normal shutdown.

## Technical Details
`errgroup.WithContext` cancels the group context when any member
returns an error. Only `ServeConnect` returns a non-nil error, so
`g.Wait()` returns exactly what `StartServer` returned before.

## Test Plan
- [x] `go build`, `go vet`, `golangci-lint` clean
- [x] Manual: Ctrl-C logs both server "complete" lines before the first
  "cleaning up" line, with no listener warning
- No new unit test: `StartServer` needs live Postgres and SpiceDB before
  reaching this code; the composed pieces are tested in #1745 and #1747

🤖 Generated with [Claude Code](https://claude.com/claude-code)