### PR TITLE
fix: drop orgId from group RPCs

### DIFF
--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "1.0.0-rc.12",
     "@raystack/frontier": "workspace:^",
-    "@raystack/proton": "0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839",
+    "@raystack/proton": "0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/web/apps/admin/package.json
+++ b/web/apps/admin/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@raystack/apsara": "1.0.0-rc.12",
     "@raystack/frontier": "workspace:^",
-    "@raystack/proton": "0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e",
+    "@raystack/proton": "0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839",
     "@stitches/react": "^1.2.8",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:../../sdk
       '@raystack/proton':
-        specifier: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e
-        version: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839
+        version: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.2.4)
@@ -222,8 +222,8 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.71.2(react@19.2.4))
       '@raystack/proton':
-        specifier: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e
-        version: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839
+        version: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -1587,8 +1587,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e':
-    resolution: {integrity: sha512-82QvGoJjcp5zGt/QIkdSJEn2iX8vn/g2H4jm8O3QH3YIZuZp0bXFXo+ddD5S49tSUtWiegi7qWJargHgBceLPg==}
+  '@raystack/proton@0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839':
+    resolution: {integrity: sha512-YCzbMMyYaf5naOZdHYe01x5Ln0FFmABWwHDD3Oi6ANtQIZn1UmNsl8s3zcuhJ7dgQfGT87rFDeRBLm1ihxL2QQ==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -8065,7 +8065,7 @@ snapshots:
       - '@date-fns/tz'
       - date-fns
 
-  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: workspace:^
         version: link:../../sdk
       '@raystack/proton':
-        specifier: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839
-        version: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e
+        version: 0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.2.4)
@@ -1585,6 +1585,14 @@ packages:
       react-dom: ^19
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e':
+    resolution: {integrity: sha512-82QvGoJjcp5zGt/QIkdSJEn2iX8vn/g2H4jm8O3QH3YIZuZp0bXFXo+ddD5S49tSUtWiegi7qWJargHgBceLPg==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-query':
         optional: true
 
   '@raystack/proton@0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839':
@@ -8064,6 +8072,20 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - date-fns
+
+  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)
+      '@connectrpc/connect-query': 2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+    optionalDependencies:
+      '@tanstack/react-query': 5.90.21(react@19.2.4)
+    transitivePeerDependencies:
+      - '@tanstack/query-core'
+      - react
+      - react-dom
 
   '@raystack/proton@0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:

--- a/web/sdk/client/views/teams/components/add-member-menu.tsx
+++ b/web/sdk/client/views/teams/components/add-member-menu.tsx
@@ -124,7 +124,6 @@ export function AddMemberMenu({
       setGroupMemberRole(
         create(SetGroupMemberRoleRequestSchema, {
           groupId: teamId,
-          orgId: organization.id,
           principalId: userId,
           principalType: PERMISSIONS.UserPrincipal,
           roleId: memberRoleId

--- a/web/sdk/client/views/teams/components/delete-team-dialog.tsx
+++ b/web/sdk/client/views/teams/components/delete-team-dialog.tsx
@@ -39,8 +39,7 @@ export function DeleteTeamDialog({ handle, refetch }: DeleteTeamDialogProps) {
     try {
       await deleteTeam(
         create(DeleteGroupRequestSchema, {
-          id: teamId,
-          orgId: organization.id
+          id: teamId
         })
       );
       toastManager.add({ title: 'Team deleted', type: 'success' });

--- a/web/sdk/client/views/teams/components/edit-team-dialog.tsx
+++ b/web/sdk/client/views/teams/components/edit-team-dialog.tsx
@@ -98,7 +98,6 @@ function EditTeamForm({ payload, handle, refetch }: EditTeamFormProps) {
       await updateTeam(
         create(UpdateGroupRequestSchema, {
           id: payload.teamId,
-          orgId: organization.id,
           body: {
             title: data.title,
             name: payload.name

--- a/web/sdk/client/views/teams/components/remove-member-dialog.tsx
+++ b/web/sdk/client/views/teams/components/remove-member-dialog.tsx
@@ -79,7 +79,6 @@ function RemoveMemberForm({
       await removeGroupUser(
         create(RemoveGroupUserRequestSchema, {
           id: payload.teamId,
-          orgId: organization.id,
           userId: payload.memberId
         })
       );

--- a/web/sdk/client/views/teams/team-details-view.tsx
+++ b/web/sdk/client/views/teams/team-details-view.tsx
@@ -86,8 +86,7 @@ export function TeamDetailsView({
   } = useQuery(
     FrontierServiceQueries.getGroup,
     create(GetGroupRequestSchema, {
-      id: teamId || '',
-      orgId: organization?.id || ''
+      id: teamId || ''
     }),
     {
       enabled: !!organization?.id && !!teamId,
@@ -114,8 +113,7 @@ export function TeamDetailsView({
   } = useQuery(
     FrontierServiceQueries.listGroupUsers,
     create(ListGroupUsersRequestSchema, {
-      id: teamId || '',
-      orgId: organization?.id || ''
+      id: teamId || ''
     }),
     { enabled: !!organization?.id && !!teamId }
   );
@@ -214,7 +212,6 @@ export function TeamDetailsView({
         await setGroupMemberRole(
           create(SetGroupMemberRoleRequestSchema, {
             groupId: teamId,
-            orgId: organization.id,
             principalId: memberId,
             principalType: PERMISSIONS.UserPrincipal,
             roleId: role.id as string

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -101,7 +101,7 @@
     "@connectrpc/connect-query": "2.1.1",
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
-    "@raystack/proton": "0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e",
+    "@raystack/proton": "0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",


### PR DESCRIPTION
## Summary

- Bumped `@raystack/proton` to the latest (`0.1.0-f0b06e61...`) in both `web/sdk` and `web/apps/admin` so the SDK regenerates without `org_id` on the affected group RPCs.
- Removed the now-invalid `orgId` argument from `getGroup`, `updateGroup`, `listGroupUsers`, `removeGroupUser`, `deleteGroup`, and `setGroupMemberRole` calls across the team views.
- Left `ListOrganizationGroups` and `ListCurrentUserGroups` untouched — they still take `org_id`.
- Verified the full `pnpm build` (SDK + admin) passes against the regenerated SDK types with no new type errors.