### PR TITLE
chore(schema): drop dead duplicate app_organization_viewer definition

### DIFF
--- a/internal/bootstrap/schema/schema.go
+++ b/internal/bootstrap/schema/schema.go
@@ -352,14 +352,6 @@ var PredefinedRoles = []RoleDefinition{
 		},
 		Scopes: []string{OrganizationNamespace},
 	},
-	{
-		Title: "Group Viewer",
-		Name:  RoleOrganizationViewer,
-		Permissions: []string{
-			"app_organization_get",
-		},
-		Scopes: []string{OrganizationNamespace},
-	},
 	// project
 	{
 		Title: "Project Owner",


### PR DESCRIPTION
## What

Removes the second `app_organization_viewer` entry from `schema.PredefinedRoles`. The list has carried two definitions under the same name since #399 added one titled "Organization Group Viewer" (retitled "Group Viewer" in #1705):

```go
{
    Title: "Member",
    Name:  RoleOrganizationViewer,
    Permissions: []string{"app_organization_get"},
    Scopes: []string{OrganizationNamespace},
},
{
    Title: "Group Viewer",
    Name:  RoleOrganizationViewer,        // same name, same permissions, same scopes
    Permissions: []string{"app_organization_get"},
    Scopes: []string{OrganizationNamespace},
},
```

## Why it is dead code

The entry has never had any effect:

- **Boot**: `MigrateRoles` walks the list in order. The first entry creates (or matches) the role; when the second one runs, the role already exists. The reconcile path only rewrote a role when its *permissions* differed — and the two entries' permissions are identical — so the second entry never wrote anything, on any version.
- **Lookups**: every consumer that searches `PredefinedRoles` by name takes the first match.

So the role every installation actually has is the first definition ("Member"). Removing the duplicate changes no behavior on fresh boots or upgrades; it just makes the list mean what it says.

No functional changes. Existing bootstrap and schema tests pass unchanged.
