### PR TITLE
docs(reconcile): show scopes in the Role example

### DIFF
--- a/docs/content/docs/reconcile.mdx
+++ b/docs/content/docs/reconcile.mdx
@@ -116,10 +116,14 @@ spec:
     permissions:
       - compute_order_get
       - compute_order_update
+    scopes:                          # resource types this role can attach to
+      - compute/order
   - name: app_project_viewer         # predefined role: override only the fields you list
     permissions:
       - app_project_get
       - resource_aoi_get
+    scopes:                          # override the scope too, if you need to
+      - app/project
   - name: old_role
     delete: true
 ```
@@ -149,6 +153,13 @@ takes those permissions away on the next apply.
 
 Permission references accept any form the server knows: the slug (`compute_order_get`),
 `service/resource:verb`, or `service.resource.verb`.
+
+`scopes` is the list of resource types a role can attach to (`app/organization`,
+`app/project`, `compute/order`, and so on). Note how it shows up in an export: a custom
+role lists its scopes in full, but a predefined role lists `scopes` only when they differ
+from the shipped default. So a predefined role whose scope already matches the default
+won't show a `scopes` line — the scope is still enforced, it just isn't repeated. The same
+goes for `title`: it appears only when you have changed it.
 
 ## The Preference kind
 


### PR DESCRIPTION
## What

Adds `scopes` to the Role example in the reconcile guide and explains why an exported file
may not show it.

- The Role YAML example now includes a `scopes:` line on both a custom role and a
  predefined override, with a short inline note ("resource types this role can attach to").
- A new paragraph explains the export behavior: a custom role lists its scopes in full, but
  a predefined role lists `scopes` only when they differ from the shipped default — so a
  role whose scope already matches the default won't show a `scopes` line, even though the
  scope is still enforced. Same for `title`.

## Why

`scopes` was already a managed field (and mentioned in the prose), but the example didn't
show it, which led to "is there a way to set a role's scope?" and "why is `scopes` missing
from the exported files?". The exports omit it for predefined roles whose scope matches the
default — this makes that explicit.

Docs only; no code change.
