### PR TITLE
chore(lint): enable errcheck and staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ output:
 linters:
   default: none
   enable:
+    - errcheck
     - forbidigo
     - gosec
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - misspell
     - protogetter
     - revive
+    - staticcheck
     - thelper
     - unconvert
     - unused
@@ -23,6 +24,20 @@ linters:
   settings:
     revive:
       severity: warning
+    staticcheck:
+      # The golangci-lint default check set, minus the QF family: QF checks
+      # are editor refactoring suggestions, not problems.
+      checks:
+        [
+          "all",
+          "-ST1000",
+          "-ST1003",
+          "-ST1016",
+          "-ST1020",
+          "-ST1021",
+          "-ST1022",
+          "-QF*",
+        ]
     gosec:
       # Only run SQL-injection rules. Revisit if specific risks emerge.
       includes:

--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -377,7 +377,7 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 		var subsItems []*stripe.CheckoutSessionLineItemParams
 		var minQ int64 = MinimumProductQuantity
 		var maxQ int64 = MaximumProductQuantity
-		var adjustableQuantity bool = true
+		var adjustableQuantity = true
 		if chProduct.Config.MinQuantity > 0 {
 			minQ = chProduct.Config.MinQuantity
 		}

--- a/internal/api/v1beta1connect/authenticate_test.go
+++ b/internal/api/v1beta1connect/authenticate_test.go
@@ -16,6 +16,7 @@ import (
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnectHandler_AuthToken_ServiceUser(t *testing.T) {
@@ -176,9 +177,9 @@ func TestConnectHandler_GetJWKs(t *testing.T) {
 				// Create a test key set
 				testKeySet := jwk.NewSet()
 				testKey, _ := jwk.FromRaw([]byte("test-key-data"))
-				testKey.Set(jwk.KeyIDKey, "test-key-id")
-				testKey.Set(jwk.KeyTypeKey, "oct")
-				testKeySet.AddKey(testKey)
+				_ = testKey.Set(jwk.KeyIDKey, "test-key-id")
+				_ = testKey.Set(jwk.KeyTypeKey, "oct")
+				_ = testKeySet.AddKey(testKey)
 
 				authn.EXPECT().JWKs(mock.Anything).Return(testKeySet)
 			},
@@ -214,15 +215,15 @@ func TestConnectHandler_GetJWKs(t *testing.T) {
 
 				// First key
 				testKey1, _ := jwk.FromRaw([]byte("test-key-data-1"))
-				testKey1.Set(jwk.KeyIDKey, "test-key-id-1")
-				testKey1.Set(jwk.KeyTypeKey, "oct")
-				testKeySet.AddKey(testKey1)
+				_ = testKey1.Set(jwk.KeyIDKey, "test-key-id-1")
+				_ = testKey1.Set(jwk.KeyTypeKey, "oct")
+				_ = testKeySet.AddKey(testKey1)
 
 				// Second key
 				testKey2, _ := jwk.FromRaw([]byte("test-key-data-2"))
-				testKey2.Set(jwk.KeyIDKey, "test-key-id-2")
-				testKey2.Set(jwk.KeyTypeKey, "oct")
-				testKeySet.AddKey(testKey2)
+				_ = testKey2.Set(jwk.KeyIDKey, "test-key-id-2")
+				_ = testKey2.Set(jwk.KeyTypeKey, "oct")
+				_ = testKeySet.AddKey(testKey2)
 
 				authn.EXPECT().JWKs(mock.Anything).Return(testKeySet)
 			},
@@ -297,9 +298,9 @@ func TestToJSONWebKey(t *testing.T) {
 			keySet: func() jwk.Set {
 				keySet := jwk.NewSet()
 				testKey, _ := jwk.FromRaw([]byte("test-key-data"))
-				testKey.Set(jwk.KeyIDKey, "test-key-id")
-				testKey.Set(jwk.KeyTypeKey, "oct")
-				keySet.AddKey(testKey)
+				_ = testKey.Set(jwk.KeyIDKey, "test-key-id")
+				_ = testKey.Set(jwk.KeyTypeKey, "oct")
+				_ = keySet.AddKey(testKey)
 				return keySet
 			}(),
 			expectError: false,
@@ -326,7 +327,7 @@ func TestToJSONWebKey(t *testing.T) {
 				// Verify the structure is correct
 				keySetJson, _ := json.Marshal(tt.keySet)
 				var expectedJWKS JsonWebKeySet
-				json.Unmarshal(keySetJson, &expectedJWKS)
+				require.NoError(t, json.Unmarshal(keySetJson, &expectedJWKS))
 				assert.Equal(t, len(expectedJWKS.Keys), len(result.Keys))
 			}
 		})

--- a/internal/store/postgres/prospect_repository_test.go
+++ b/internal/store/postgres/prospect_repository_test.go
@@ -528,7 +528,7 @@ func (s *ProspectRepositoryTestSuite) TestDelete() {
 	for _, tc := range testCases {
 		s.Run(tc.Description, func() {
 			// Reset the test data for each test case
-			s.cleanup()
+			s.Require().NoError(s.cleanup())
 			s.SetupTest()
 
 			if tc.SetupFn != nil {

--- a/pkg/server/webhook_bridge_test.go
+++ b/pkg/server/webhook_bridge_test.go
@@ -18,7 +18,7 @@ type mockHandler struct {
 
 func (m *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(m.statusCode)
-	w.Write(m.response)
+	_, _ = w.Write(m.response)
 }
 
 func TestWebhookBridgeHandler_HTTPMethods(t *testing.T) {
@@ -158,7 +158,7 @@ func TestWebhookBridgeHandler_SuccessfulRequest(t *testing.T) {
 		// Return success
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 
 	req := httptest.NewRequest("POST", "/billing/webhooks/callback/stripe", bytes.NewReader([]byte(`{"event":"test"}`)))

--- a/test/e2e/regression/authentication_test.go
+++ b/test/e2e/regression/authentication_test.go
@@ -171,7 +171,7 @@ func (s *AuthenticationRegressionTestSuite) TestUserSession() {
 			Handler: callbackMux,
 		}
 		// clean up callback server
-		defer srv.Shutdown(ctx)
+		defer srv.Shutdown(ctx) // nolint
 		go func() {
 			if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 				s.Assert().NoError(err)

--- a/test/e2e/regression/authentication_test.go
+++ b/test/e2e/regression/authentication_test.go
@@ -171,7 +171,7 @@ func (s *AuthenticationRegressionTestSuite) TestUserSession() {
 			Handler: callbackMux,
 		}
 		// clean up callback server
-		defer srv.Shutdown(ctx) // nolint
+		defer srv.Shutdown(ctx) //nolint:errcheck
 		go func() {
 			if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 				s.Assert().NoError(err)


### PR DESCRIPTION
## Summary
Enable the `errcheck` and `staticcheck` linters. All findings were fixed in the preceding PRs; this turns the gates on.

## Changes
- Add `errcheck` to `linters.enable`, plus the seventeen findings that lived in test files:
  - `internal/api/v1beta1connect/authenticate_test.go`: `_ =` on 12 JWK fixture calls (no `t` in scope inside the fixture closures); `require.NoError` on the `json.Unmarshal` that builds an expected value
  - `internal/store/postgres/prospect_repository_test.go`: assert the between-case `s.cleanup()` so a failed cleanup stops the suite at the real problem
  - `pkg/server/webhook_bridge_test.go`: `_, _ =` on two stub-handler writes
  - `test/e2e/regression/authentication_test.go`: `nolint` on the callback server shutdown defer
- Add `staticcheck` to `linters.enable` with the golangci-lint default check set spelled out, minus the QF family (editor refactoring suggestions, not problems)
- `billing/checkout/service.go`: drop an inferable type from a var declaration — the one outstanding staticcheck finding

## Test Plan
- [x] `golangci-lint run` with both linters enabled and issue caps disabled reports zero findings
- [x] Build passes; affected test packages pass
