### PR TITLE
fix(reconcile): harden the PlatformUser kind against silent access removal

### DIFF
--- a/docs/content/docs/reconcile.mdx
+++ b/docs/content/docs/reconcile.mdx
@@ -76,6 +76,15 @@ Two safety properties:
 
 Adding a user by an email that does not exist creates that user.
 
+A `ref` must be a plain email address or a uuid (a user id, or a service user id). A
+display-name email like `Alice <alice@x.com>` or a name slug is rejected, so an entry always
+resolves to exactly the principal you meant, and a non-canonical id (uppercase, `urn:uuid:`)
+still matches its principal instead of being treated as a new one.
+
+Because the file is the full list, `spec: []` removes every platform user. The bootstrap
+service account is the exception: it is never removed. Keep `app.admin.bootstrap` configured,
+since that account is the recovery path if a file ever empties the list.
+
 ## The Permission kind
 
 A permission is an identity: a `service/resource` namespace plus a verb. There is nothing

--- a/internal/api/v1beta1connect/platform.go
+++ b/internal/api/v1beta1connect/platform.go
@@ -57,7 +57,7 @@ func (h *ConnectHandler) RemovePlatformUser(ctx context.Context, req *connect.Re
 	} else if req.Msg.GetServiceuserId() != "" {
 		// The bootstrap SA can't be removed via the API. Return the generic permission
 		// error (must not reveal it's the protected SA) and log the real reason.
-		if req.Msg.GetServiceuserId() == schema.BootstrapServiceUserID {
+		if schema.IsBootstrapServiceUser(req.Msg.GetServiceuserId()) {
 			slog.WarnContext(ctx, "refused removal of the bootstrap superuser service account", "service_user_id", req.Msg.GetServiceuserId())
 			return nil, connect.NewError(connect.CodePermissionDenied, ErrUnauthorized)
 		}

--- a/internal/api/v1beta1connect/platform_test.go
+++ b/internal/api/v1beta1connect/platform_test.go
@@ -58,6 +58,20 @@ func TestHandler_RemovePlatformUser(t *testing.T) {
 		serviceUserSvc.AssertNotCalled(t, "UnSudo", mock.Anything, mock.Anything, mock.Anything)
 	})
 
+	t.Run("refuses the bootstrap SA in a non-canonical uuid form", func(t *testing.T) {
+		serviceUserSvc := mocks.NewServiceUserService(t)
+		// the uuid column treats an uppercased id as equal, so the guard must match
+		// it too rather than fall through to UnSudo on the protected SA.
+		h := &ConnectHandler{serviceUserService: serviceUserSvc}
+		resp, err := h.RemovePlatformUser(context.Background(), connect.NewRequest(&frontierv1beta1.RemovePlatformUserRequest{
+			ServiceuserId: "urn:uuid:" + schema.BootstrapServiceUserID,
+		}))
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		serviceUserSvc.AssertNotCalled(t, "UnSudo", mock.Anything, mock.Anything, mock.Anything)
+	})
+
 	t.Run("removes only the specified relation when relation is set", func(t *testing.T) {
 		userSvc := mocks.NewUserService(t)
 		// only the admin relation is stripped; an UnSudo for member would be an

--- a/internal/bootstrap/schema/schema.go
+++ b/internal/bootstrap/schema/schema.go
@@ -99,6 +99,20 @@ var (
 	PlatformOrgID = uuid.Nil
 )
 
+// bootstrapServiceUserUUID is BootstrapServiceUserID parsed once, so the identity
+// check compares 128-bit values instead of strings.
+var bootstrapServiceUserUUID = uuid.MustParse(BootstrapServiceUserID)
+
+// IsBootstrapServiceUser reports whether id is the config bootstrap service
+// account's id. It compares parsed UUID values, so any accepted spelling of the
+// id (uppercase, urn:uuid, braces, no dashes) matches and a non-uuid never does.
+// The bootstrap id lives in the service-user id space, so callers should apply
+// this only to a service-user id, never a user id.
+func IsBootstrapServiceUser(id string) bool {
+	parsed, err := uuid.Parse(strings.TrimSpace(id))
+	return err == nil && parsed == bootstrapServiceUserUUID
+}
+
 //go:embed base_schema.zed
 var BaseSchemaZed string
 

--- a/internal/bootstrap/schema/schema_test.go
+++ b/internal/bootstrap/schema/schema_test.go
@@ -49,3 +49,27 @@ func TestFQPermissionNameFromNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBootstrapServiceUser(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"canonical id", schema.BootstrapServiceUserID, true},
+		{"braces form", "{00000000-0000-0000-0000-000000000001}", true},
+		{"urn form", "urn:uuid:00000000-0000-0000-0000-000000000001", true},
+		{"no dashes", "00000000000000000000000000000001", true},
+		{"surrounding space", "  00000000-0000-0000-0000-000000000001  ", true},
+		{"different uuid", "00000000-0000-0000-0000-000000000002", false},
+		{"not a uuid", "alice@x.com", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := schema.IsBootstrapServiceUser(tt.id); got != tt.want {
+				t.Errorf("IsBootstrapServiceUser(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reconcile/platformuser.go
+++ b/internal/reconcile/platformuser.go
@@ -2,8 +2,10 @@ package reconcile
 
 import (
 	"fmt"
+	"net/mail"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 )
 
@@ -76,14 +78,51 @@ func validateSpec(s PlatformUserSpec) error {
 	default:
 		return fmt.Errorf("invalid relation %q (want %q or %q)", s.Relation, schema.AdminRelationName, schema.MemberRelationName)
 	}
-	if strings.TrimSpace(s.Ref) == "" {
+	ref := strings.TrimSpace(s.Ref)
+	if ref == "" {
 		return fmt.Errorf("empty ref")
 	}
+	// The ref must be a form the server resolves to exactly one principal, so the
+	// diff can match it to a live principal. A user is an id or a plain email; a
+	// service user is an id. A slug or a display-name email would resolve on the
+	// server but not match here, silently planning a remove of access meant to stay.
+	if s.Type == principalTypeUser {
+		if !isUUID(ref) && !isBareEmail(ref) {
+			return fmt.Errorf("ref %q must be a user id (uuid) or a plain email address", s.Ref)
+		}
+	} else if !isUUID(ref) {
+		return fmt.Errorf("ref %q must be a service user id (uuid)", s.Ref)
+	}
 	// The bootstrap SA is server-managed; reject it here too, not just skip it on the current side.
-	if s.Type == principalTypeServiceUser && strings.TrimSpace(s.Ref) == schema.BootstrapServiceUserID {
+	if s.Type == principalTypeServiceUser && ref == schema.BootstrapServiceUserID {
 		return fmt.Errorf("ref %q is the bootstrap service account, which the server manages and cannot be reconciled", s.Ref)
 	}
 	return nil
+}
+
+// isUUID reports whether s parses as a UUID in any form uuid.Parse accepts
+// (canonical, uppercase, urn:uuid, braces, or no dashes).
+func isUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
+}
+
+// isBareEmail reports whether s is a plain email address with no display name,
+// so it matches the address the server stores. "Alice <a@x.com>" is rejected.
+func isBareEmail(s string) bool {
+	addr, err := mail.ParseAddress(s)
+	return err == nil && addr.Name == "" && addr.Address == s
+}
+
+// canonicalRef normalizes a ref to the form the server stores. A UUID in any
+// accepted form becomes the canonical lowercase id; anything else (an email) is
+// only trimmed and still matches case-insensitively against the stored address.
+func canonicalRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if u, err := uuid.Parse(ref); err == nil {
+		return u.String()
+	}
+	return ref
 }
 
 // specMatchesPrincipal reports whether a desired spec refers to a current
@@ -103,11 +142,18 @@ var platformRelationOrder = []string{schema.AdminRelationName, schema.MemberRela
 // diffPlatformUsers returns the ops that make the current platform principals
 // match the desired spec, per (principal, relation). Order is stable.
 func diffPlatformUsers(desired []PlatformUserSpec, current []platformPrincipal) ([]Op, error) {
-	for _, s := range desired {
+	// Validate every entry, then canonicalize its ref so a valid-but-non-canonical
+	// id (uppercase, urn:uuid, braces, no dashes) matches the principal's stored id
+	// instead of planning a spurious remove of the access it means to keep.
+	canonical := make([]PlatformUserSpec, len(desired))
+	for i, s := range desired {
 		if err := validateSpec(s); err != nil {
 			return nil, fmt.Errorf("invalid platform-user spec %+v: %w", s, err)
 		}
+		s.Ref = canonicalRef(s.Ref)
+		canonical[i] = s
 	}
+	desired = canonical
 
 	// Emit adds before removes so a relation change (admin -> member) never drops
 	// all access if a later op fails.

--- a/internal/reconcile/platformuser.go
+++ b/internal/reconcile/platformuser.go
@@ -93,8 +93,12 @@ func validateSpec(s PlatformUserSpec) error {
 	} else if !isUUID(ref) {
 		return fmt.Errorf("ref %q must be a service user id (uuid)", s.Ref)
 	}
-	// The bootstrap SA is server-managed; reject it here too, not just skip it on the current side.
-	if s.Type == principalTypeServiceUser && ref == schema.BootstrapServiceUserID {
+	// The bootstrap SA is server-managed; reject it here too, not just skip it on
+	// the current side. It is a service-user id, and users are a separate id space
+	// (the server's own guard checks only the service-user id), so this is scoped
+	// to serviceuser entries. IsBootstrapServiceUser matches the id in any UUID
+	// form, so a non-canonical spelling cannot slip past the guard.
+	if s.Type == principalTypeServiceUser && schema.IsBootstrapServiceUser(ref) {
 		return fmt.Errorf("ref %q is the bootstrap service account, which the server manages and cannot be reconciled", s.Ref)
 	}
 	return nil

--- a/internal/reconcile/platformuser_reconciler.go
+++ b/internal/reconcile/platformuser_reconciler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/raystack/frontier/internal/bootstrap/schema"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"google.golang.org/protobuf/types/known/structpb"
-	"gopkg.in/yaml.v3"
 )
 
 // PlatformUserAPI is the subset of the admin API the platform-user reconciler needs.
@@ -35,7 +34,7 @@ func (r *PlatformUserReconciler) Kind() string { return KindPlatformUser }
 
 func (r *PlatformUserReconciler) Reconcile(ctx context.Context, spec []byte, dryRun bool) (Report, error) {
 	var specs []PlatformUserSpec
-	if err := yaml.Unmarshal(spec, &specs); err != nil {
+	if err := decodeSpec(spec, &specs); err != nil {
 		return Report{}, fmt.Errorf("parse %s spec: %w", KindPlatformUser, err)
 	}
 

--- a/internal/reconcile/platformuser_reconciler.go
+++ b/internal/reconcile/platformuser_reconciler.go
@@ -113,7 +113,7 @@ func (r *PlatformUserReconciler) fetchCurrent(ctx context.Context) ([]platformPr
 	}
 	for _, su := range resp.Msg.GetServiceusers() {
 		// Never reconcile the bootstrap SA — it is server-managed and removal-blocked.
-		if su.GetId() == schema.BootstrapServiceUserID {
+		if schema.IsBootstrapServiceUser(su.GetId()) {
 			continue
 		}
 		current = append(current, platformPrincipal{

--- a/internal/reconcile/platformuser_reconciler_test.go
+++ b/internal/reconcile/platformuser_reconciler_test.go
@@ -160,13 +160,15 @@ func TestPlatformUserReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("reconciling an exported document plans no changes", func(t *testing.T) {
+		// A user without an email and a service user both export by id, so their ids
+		// must be real uuids for the exported document to pass reconcile validation.
 		api := &fakePlatformUserAPI{
 			users: []*frontierv1beta1.User{
 				platformUserPBRelations(t, "alice-id", "alice@x.com", schema.AdminRelationName, schema.MemberRelationName),
-				platformUserPBRelations(t, "noemail-id", "", schema.MemberRelationName),
+				platformUserPBRelations(t, "33333333-3333-3333-3333-333333333333", "", schema.MemberRelationName),
 			},
 			sus: []*frontierv1beta1.ServiceUser{
-				serviceUserPBRelations(t, "sa-id", schema.MemberRelationName, schema.AdminRelationName),
+				serviceUserPBRelations(t, "44444444-4444-4444-4444-444444444444", schema.MemberRelationName, schema.AdminRelationName),
 			},
 		}
 		registry := map[string]Reconciler{KindPlatformUser: NewPlatformUserReconciler(api, "")}

--- a/internal/reconcile/platformuser_reconciler_test.go
+++ b/internal/reconcile/platformuser_reconciler_test.go
@@ -91,6 +91,15 @@ func TestPlatformUserReconciler_Reconcile(t *testing.T) {
 		}
 	})
 
+	t.Run("an unknown field in the spec fails the plan", func(t *testing.T) {
+		api := &fakePlatformUserAPI{}
+		// `relatio` instead of `relation`: must fail, not be silently ignored
+		spec := []byte("- {type: user, ref: a@x.com, relatio: admin}\n")
+		_, err := NewPlatformUserReconciler(api, "").Reconcile(context.Background(), spec, true)
+		assert.ErrorContains(t, err, "parse PlatformUser spec")
+		assert.Empty(t, api.added)
+	})
+
 	t.Run("dry-run plans without applying", func(t *testing.T) {
 		api := &fakePlatformUserAPI{users: []*frontierv1beta1.User{
 			platformUserPB(t, "drop-id", "drop@x.com", schema.AdminRelationName),

--- a/internal/reconcile/platformuser_test.go
+++ b/internal/reconcile/platformuser_test.go
@@ -36,11 +36,11 @@ func TestDiffPlatformUsers(t *testing.T) {
 
 	t.Run("new service user is added", func(t *testing.T) {
 		ops, err := diffPlatformUsers(
-			[]PlatformUserSpec{{Type: "serviceuser", Ref: "su-1", Relation: member}},
+			[]PlatformUserSpec{{Type: "serviceuser", Ref: "11111111-1111-1111-1111-111111111111", Relation: member}},
 			nil,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, []Op{{Action: opAdd, Type: "serviceuser", Ref: "su-1", Relation: member}}, ops)
+		assert.Equal(t, []Op{{Action: opAdd, Type: "serviceuser", Ref: "11111111-1111-1111-1111-111111111111", Relation: member}}, ops)
 	})
 
 	t.Run("already-correct principal makes no change (matched by email)", func(t *testing.T) {
@@ -134,6 +134,33 @@ func TestDiffPlatformUsers(t *testing.T) {
 			[]PlatformUserSpec{{Type: "serviceuser", Ref: schema.BootstrapServiceUserID, Relation: admin}}, nil)
 		assert.Error(t, err)
 	})
+
+	t.Run("a non-canonical uuid ref matches the stored principal, no spurious remove", func(t *testing.T) {
+		// The file lists the same id the server stored, but uppercased. Without
+		// canonicalization this fails to match and plans an add + a remove that
+		// silently strips the principal's access.
+		ops, err := diffPlatformUsers(
+			[]PlatformUserSpec{{Type: "user", Ref: "AAAAAAAA-1111-1111-1111-111111111111", Relation: admin}},
+			[]platformPrincipal{principal("user", "aaaaaaaa-1111-1111-1111-111111111111", "alice@x.com", admin)},
+		)
+		assert.NoError(t, err)
+		assert.Empty(t, ops)
+	})
+
+	t.Run("rejects a user ref that is neither a uuid nor a plain email", func(t *testing.T) {
+		_, err := diffPlatformUsers([]PlatformUserSpec{{Type: "user", Ref: "alice-slug", Relation: admin}}, nil)
+		assert.ErrorContains(t, err, "must be a user id (uuid) or a plain email address")
+	})
+
+	t.Run("rejects a display-name email ref", func(t *testing.T) {
+		_, err := diffPlatformUsers([]PlatformUserSpec{{Type: "user", Ref: "Alice <alice@x.com>", Relation: admin}}, nil)
+		assert.ErrorContains(t, err, "must be a user id (uuid) or a plain email address")
+	})
+
+	t.Run("rejects a service user ref that is not a uuid", func(t *testing.T) {
+		_, err := diffPlatformUsers([]PlatformUserSpec{{Type: "serviceuser", Ref: "not-a-uuid", Relation: admin}}, nil)
+		assert.ErrorContains(t, err, "must be a service user id (uuid)")
+	})
 }
 
 // TestSpecRefMatching covers the accepted `ref` forms: a user may be referenced by
@@ -168,12 +195,12 @@ func TestSpecRefMatching(t *testing.T) {
 	t.Run("diff makes no change: user by id + serviceuser by id already correct", func(t *testing.T) {
 		ops, err := diffPlatformUsers(
 			[]PlatformUserSpec{
-				{Type: "user", Ref: "user-uuid-1", Relation: admin},
-				{Type: "serviceuser", Ref: "su-uuid-1", Relation: admin},
+				{Type: "user", Ref: "11111111-1111-1111-1111-111111111111", Relation: admin},
+				{Type: "serviceuser", Ref: "22222222-2222-2222-2222-222222222222", Relation: admin},
 			},
 			[]platformPrincipal{
-				principal("user", "user-uuid-1", "alice@x.com", admin),
-				principal("serviceuser", "su-uuid-1", "", admin),
+				principal("user", "11111111-1111-1111-1111-111111111111", "alice@x.com", admin),
+				principal("serviceuser", "22222222-2222-2222-2222-222222222222", "", admin),
 			},
 		)
 		assert.NoError(t, err)

--- a/internal/reconcile/platformuser_test.go
+++ b/internal/reconcile/platformuser_test.go
@@ -135,6 +135,23 @@ func TestDiffPlatformUsers(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("rejects the bootstrap service account in a non-canonical uuid form", func(t *testing.T) {
+		_, err := diffPlatformUsers(
+			[]PlatformUserSpec{{Type: "serviceuser", Ref: "urn:uuid:" + schema.BootstrapServiceUserID, Relation: admin}}, nil)
+		assert.ErrorContains(t, err, "bootstrap service account")
+	})
+
+	t.Run("a user that happens to share the bootstrap uuid is a different principal, not rejected", func(t *testing.T) {
+		// The bootstrap id is a service-user id; users are a separate id space, so a
+		// user entry with that id is not the bootstrap SA and must not be rejected.
+		ops, err := diffPlatformUsers(
+			[]PlatformUserSpec{{Type: "user", Ref: schema.BootstrapServiceUserID, Relation: admin}},
+			[]platformPrincipal{principal("user", schema.BootstrapServiceUserID, "", admin)},
+		)
+		assert.NoError(t, err)
+		assert.Empty(t, ops)
+	})
+
 	t.Run("a non-canonical uuid ref matches the stored principal, no spurious remove", func(t *testing.T) {
 		// The file lists the same id the server stored, but uppercased. Without
 		// canonicalization this fails to match and plans an add + a remove that


### PR DESCRIPTION
## What

Hardening fixes for the `PlatformUser` reconcile kind, found by an independent review. Each
commit is one finding, most-severe first. The headline fix (M1) is security-relevant: it
closes a path where a hand-authored file could silently remove a superuser's access. One fix
(m2) also touches the server: it moves the bootstrap-account identity check into a shared
helper so the server's removal guard matches the id in any uuid form, not just the exact
string.

## The fixes

**M1 (major): validate and canonicalize refs to prevent silent access removal.** The diff
matched a file entry to a live principal with a raw string compare, but the server resolves
refs loosely (an uppercase or `urn:uuid:` id, a name slug, or a display-name email). So an
entry meant to keep `alice-id`, written as `ALICE-ID` or a slug, failed to match, and because
adds run before removes the run quietly stripped the access it meant to keep and never
converged. Now a user ref must be a plain email or a uuid and a service user ref must be a
uuid (a slug or `Alice <a@x.com>` is rejected at plan time), and a uuid ref is canonicalized
so a non-canonical id matches its stored principal.

**m1: reject unknown fields in PlatformUser specs.** This kind decoded with plain
`yaml.Unmarshal`, so a mistyped field was silently ignored. It now uses the framework's strict
`decodeSpec`, matching every other kind.

**m2: guard the bootstrap service account by uuid value, on the reconciler and the server.**
The check now lives in one place, `schema.IsBootstrapServiceUser`, which parses both ids and
compares the 128-bit uuid values, so any spelling (uppercase, `urn:uuid:`, braces, no dashes)
matches. Two call sites use it: the reconciler rejects a `serviceuser` entry that names the
bootstrap id, and the server's `RemovePlatformUser` refuses to remove it. The server guard used
an exact string compare before, so a non-canonical spelling could slip past it and reach
`UnSudo` on the protected account even though the uuid column treats the ids as equal. The
guard is scoped to service-user ids on purpose: the bootstrap id is a service-user id, users
are a separate id space, so a user that happens to share that uuid is a different principal and
must not be rejected.

**m5 (docs): warn about the empty-file lock-out.** Documents that `spec: []` removes every
platform user except the bootstrap account, so `app.admin.bootstrap` must stay configured as
the recovery path.

## Not in this PR (need server-side changes)

- **m3:** the report over-counts `Applied` when the server no-ops an add (for example a uuid
  user ref that does not exist). The admin API does not tell the client whether a call changed
  anything, so this needs a server signal to fix cleanly.
- **m4:** a non-existent user ref is a silent no-op while a non-existent service user id fails
  loudly. The user path swallows `ErrNotExist` server-side; aligning them is a server change.
- **n1 (dropped):** an earlier commit failed fast on a malformed `--header`. It was removed
  because passing the token via the `-H` flag is interim; the auth mechanism will change, so
  validating that flag is not worth carrying.
- **n2 (dropped):** an earlier commit also skipped the bootstrap id in the *users* list as
  "defense in depth". That was the same conflation: the bootstrap id is a service-user id, so a
  user that happens to share that uuid is a different principal and should still be reconciled,
  not hidden.

## Testing

- New tests: non-canonical uuid matches without a spurious remove; slug and display-name refs
  rejected; service user ref must be a uuid; unknown field fails the plan; the bootstrap
  account rejected in a non-canonical uuid form; a user that shares the bootstrap uuid is not
  rejected; the server refuses to remove the bootstrap account in a non-canonical form; and a
  table test for `schema.IsBootstrapServiceUser` across uuid forms.
- `go build`, `go test ./cmd/... ./internal/reconcile/...`, `go vet`, `gofmt`, and
  `golangci-lint` all pass.
