### PR TITLE
fix(spicedb): migrate batch check to the stable bulk permissions API

### DIFF
--- a/internal/store/spicedb/relation_repository.go
+++ b/internal/store/spicedb/relation_repository.go
@@ -296,9 +296,9 @@ func (r *RelationRepository) ListRelations(ctx context.Context, rel relation.Rel
 
 func (r *RelationRepository) BatchCheck(ctx context.Context, relations []relation.Relation) ([]relation.CheckPair, error) {
 	result := make([]relation.CheckPair, len(relations))
-	items := make([]*authzedpb.BulkCheckPermissionRequestItem, 0, len(relations))
+	items := make([]*authzedpb.CheckBulkPermissionsRequestItem, 0, len(relations))
 	for _, rel := range relations {
-		items = append(items, &authzedpb.BulkCheckPermissionRequestItem{
+		items = append(items, &authzedpb.CheckBulkPermissionsRequestItem{
 			Resource: &authzedpb.ObjectReference{
 				ObjectId:   rel.Object.ID,
 				ObjectType: rel.Object.Namespace,
@@ -313,12 +313,12 @@ func (r *RelationRepository) BatchCheck(ctx context.Context, relations []relatio
 			Permission: rel.RelationName,
 		})
 	}
-	request := &authzedpb.BulkCheckPermissionRequest{
+	request := &authzedpb.CheckBulkPermissionsRequest{
 		Consistency: r.getConsistencyForCheck(),
 		Items:       items,
 	}
 
-	response, err := r.spiceDB.client.BulkCheckPermission(ctx, request)
+	response, err := r.spiceDB.client.CheckBulkPermissions(ctx, request)
 	if err != nil {
 		return result, err
 	}

--- a/internal/store/spicedb/spicedb.go
+++ b/internal/store/spicedb/spicedb.go
@@ -20,7 +20,7 @@ import (
 )
 
 type SpiceDB struct {
-	client *authzed.ClientWithExperimental
+	client *authzed.Client
 }
 
 func (s *SpiceDB) Check() error {
@@ -34,7 +34,7 @@ func (s *SpiceDB) Check() error {
 
 func New(config Config, logger *slog.Logger, clientMetrics *prometheus.ClientMetrics) (*SpiceDB, error) {
 	endpoint := net.JoinHostPort(config.Host, config.Port)
-	client, err := authzed.NewClientWithExperimentalAPIs(
+	client, err := authzed.NewClient(
 		endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpcutil.WithInsecureBearerToken(config.PreSharedKey),


### PR DESCRIPTION
## Summary
Move the SpiceDB integration off the experimental API surface. The batch check migrates from the deprecated `BulkCheckPermission` to the stable `CheckBulkPermissions`, and the client no longer requests experimental APIs since nothing uses them afterwards.

## Changes
- `internal/store/spicedb/relation_repository.go` (`BatchCheck`): rename the request, item, and pair types and the client method to their stable names. Same fields, same accessors, no logic change.
- `internal/store/spicedb/spicedb.go`: construct the client with `authzed.NewClient` and hold `*authzed.Client` instead of the experimental variant. Same dial options.

## Technical Details
The stable API is available in the already-pinned `authzed-go` version; no dependency change. The stable response guarantees pairs in request order, which the result indexing relies on.

## Test Plan
- [x] Build and type checking passes
- [x] PAT e2e regression suite passes against real SpiceDB, including the batch-check mixed-results case, with the client constructed through `NewClient`
