### PR TITLE
fix(store): surface prospect metadata errors and revive the policy list assertion

### DIFF
--- a/internal/store/postgres/policy_repository_test.go
+++ b/internal/store/postgres/policy_repository_test.go
@@ -226,16 +226,18 @@ func (s *PolicyRepositoryTestSuite) TestList() {
 			Description: "should get all policies",
 			ExpectedPolicys: []policy.Policy{
 				{
-					RoleID:       s.roles[0].ID,
-					PrincipalID:  s.userID,
-					ResourceID:   s.orgID,
-					ResourceType: "ns1",
+					RoleID:        s.roles[0].ID,
+					PrincipalID:   s.userID,
+					PrincipalType: schema.UserPrincipal,
+					ResourceID:    s.orgID,
+					ResourceType:  "ns1",
 				},
 				{
-					RoleID:       s.roles[0].ID,
-					PrincipalID:  s.userID,
-					ResourceID:   s.orgID,
-					ResourceType: "ns2",
+					RoleID:        s.roles[0].ID,
+					PrincipalID:   s.userID,
+					PrincipalType: schema.UserPrincipal,
+					ResourceID:    s.orgID,
+					ResourceType:  "ns2",
 				},
 			},
 		},
@@ -266,8 +268,11 @@ func (s *PolicyRepositoryTestSuite) TestList() {
 			if len(got) != len(tc.ExpectedPolicys) {
 				s.T().Fatalf("got result %+v, expected was %+v", got, tc.ExpectedPolicys)
 			}
-			if !cmp.Equal(got, tc.ExpectedPolicys, cmpopts.IgnoreFields(policy.Policy{},
-				"ID", "CreatedAt", "UpdatedAt")) {
+			if diff := cmp.Diff(tc.ExpectedPolicys, got,
+				cmpopts.IgnoreFields(policy.Policy{}, "ID", "CreatedAt", "UpdatedAt"),
+				cmpopts.SortSlices(func(a, b policy.Policy) bool { return a.ResourceType < b.ResourceType }),
+			); diff != "" {
+				s.T().Fatalf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/store/postgres/prospect.go
+++ b/internal/store/postgres/prospect.go
@@ -28,6 +28,7 @@ func (a *Prospect) transformToProspect() (prospect.Prospect, error) {
 	var unmarshalledMetadata map[string]any
 	if len(a.Metadata) > 0 {
 		if err := json.Unmarshal(a.Metadata, &unmarshalledMetadata); err != nil {
+			return prospect.Prospect{}, err
 		}
 	}
 	return prospect.Prospect{

--- a/internal/store/postgres/prospect_repository_test.go
+++ b/internal/store/postgres/prospect_repository_test.go
@@ -233,6 +233,15 @@ func (s *ProspectRepositoryTestSuite) TestGet() {
 			}
 		})
 	}
+
+	s.Run("should return error when stored metadata cannot be parsed", func() {
+		// a top-level JSON array is valid JSONB but does not fit the metadata map
+		query := fmt.Sprintf("UPDATE %s SET metadata = '[1,2,3]'::jsonb WHERE id = '%s'", postgres.TABLE_PROSPECTS, s.prospects[0].ID)
+		s.Require().NoError(execQueries(s.ctx, s.client, []string{query}))
+
+		_, err := s.repository.Get(s.ctx, s.prospects[0].ID)
+		s.Assert().Error(err)
+	})
 }
 
 func (s *ProspectRepositoryTestSuite) TestList() {


### PR DESCRIPTION
## Summary
Two error checks existed but did nothing. The prospect transform caught the metadata unmarshal error and dropped it; the policy list test computed the content comparison and discarded the result.

## Changes
- `internal/store/postgres/prospect.go`: return the metadata unmarshal error, matching the organization and group transforms. A JSONB value of the wrong shape (for example a top-level array) now surfaces as an error instead of a prospect with silently empty metadata.
- `internal/store/postgres/prospect_repository_test.go`: new `TestGet` case that stores a top-level JSON array as metadata and asserts `Get` returns an error.
- `internal/store/postgres/policy_repository_test.go`: the list comparison now fails the test with a `cmp.Diff` output. The expected fixtures gain `PrincipalType` (the repository returns it, and the dead assertion had been hiding the gap), and the comparison sorts by resource type because the list query has no ORDER BY.

## Test Plan
- [x] Policy and prospect suites pass
- [x] Both fixes verified red on the old code: the new prospect case fails without the transform fix; the revived assertion fails against the old expected fixtures with a `PrincipalType` diff

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
- [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
- [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
- [x] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.
