### PR TITLE
feat(reconcile): unify custom and predefined role handling under one field model

### DIFF
--- a/internal/reconcile/role.go
+++ b/internal/reconcile/role.go
@@ -17,7 +17,7 @@ const opUpdate opAction = "update"
 // RoleSpec is one desired platform-level role. Name is the identity and never
 // changes. Every other field uses presence tracking: a pointer is nil when the
 // field is omitted, and non-nil when the file lists it (including an explicit
-// empty value like `title: ""` or `permissions: []`).
+// empty value like `title: ""` or `scopes: []`).
 //
 // A present field is the whole desired value for that field. An omitted field
 // takes the role's default: empty for a custom role, and the shipped
@@ -180,14 +180,25 @@ func stringSetsEqual(a, b []string) bool {
 }
 
 // validateRoleSpec rejects entries the flow cannot manage: an entry needs a
-// name, and a predefined role cannot be deleted because bootstrap recreates it
-// on the next boot.
+// name, a predefined role cannot be deleted because bootstrap recreates it on
+// the next boot, and a role must resolve to at least one permission.
 func validateRoleSpec(s RoleSpec, isPredefined bool) error {
 	if strings.TrimSpace(s.Name) == "" {
 		return fmt.Errorf("name is required")
 	}
 	if s.Delete && isPredefined {
 		return fmt.Errorf("cannot delete a predefined role; bootstrap recreates it on the next boot")
+	}
+	// The server rejects a role with no permissions, so a spec that resolves to an
+	// empty permission set is a plan that can never apply. Fail here with a clear
+	// message instead of late at the API. A custom role defaults to empty, so
+	// omitting its permissions resolves to empty; writing `permissions: []` on any
+	// role resolves to empty too.
+	if !s.Delete {
+		def, _ := roleDefault(s.Name)
+		if len(s.resolve(def).Permissions) == 0 {
+			return fmt.Errorf("must list at least one permission; a role with no permissions cannot be applied")
+		}
 	}
 	return nil
 }

--- a/internal/reconcile/role.go
+++ b/internal/reconcile/role.go
@@ -15,20 +15,32 @@ const KindRole = "Role"
 const opUpdate opAction = "update"
 
 // RoleSpec is one desired platform-level role. Name is the identity and never
-// changes. For custom roles, a field that is present is managed and a field
-// that is omitted keeps its server value; permissions must be listed.
-// Predefined roles converge to their shipped definition instead: an entry
-// overrides the fields it lists, an omitted field takes the definition's
-// value, and a predefined role absent from the file resets to the definition.
-// Predefined roles cannot be deleted — bootstrap recreates a missing one on
-// the next boot.
+// changes. Every other field uses presence tracking: a pointer is nil when the
+// field is omitted, and non-nil when the file lists it (including an explicit
+// empty value like `title: ""` or `permissions: []`).
+//
+// A present field is the whole desired value for that field. An omitted field
+// takes the role's default: empty for a custom role, and the shipped
+// definition's value for a predefined role. So custom and predefined roles run
+// through the same rule; they differ only in their defaults and in that a
+// predefined role is never created or deleted by this flow.
 type RoleSpec struct {
-	Name        string   `yaml:"name"`
-	Title       string   `yaml:"title,omitempty"`
-	Description string   `yaml:"description,omitempty"`
-	Permissions []string `yaml:"permissions,omitempty"`
-	Scopes      []string `yaml:"scopes,omitempty"`
-	Delete      bool     `yaml:"delete,omitempty"`
+	Name        string    `yaml:"name"`
+	Title       *string   `yaml:"title,omitempty"`
+	Description *string   `yaml:"description,omitempty"`
+	Permissions *[]string `yaml:"permissions,omitempty"`
+	Scopes      *[]string `yaml:"scopes,omitempty"`
+	Delete      bool      `yaml:"delete,omitempty"`
+}
+
+// roleFields are a role's managed values in normalized form: permissions as
+// sorted, deduped slugs and scopes sorted. currentRole, the spec defaults, and
+// the desired result all reduce to this one shape, so they compare directly.
+type roleFields struct {
+	Title       string
+	Description string
+	Permissions []string // sorted slugs
+	Scopes      []string // sorted
 }
 
 // currentRole is one platform role as returned by ListRoles. Description is a
@@ -45,12 +57,23 @@ type currentRole struct {
 	Metadata    map[string]any
 }
 
-// roleOp is a single planned change. For adds and updates, spec carries the
-// final values to send (desired fields merged over current ones). baseMetadata
-// is the role's current metadata for an update, so managed keys merge over it.
+// fields reduces a server role to its normalized managed values.
+func (c currentRole) fields() roleFields {
+	return roleFields{
+		Title:       c.Title,
+		Description: c.Description,
+		Permissions: normalizePermissions(c.Permissions),
+		Scopes:      sortedCopy(c.Scopes),
+	}
+}
+
+// roleOp is a single planned change. For adds and updates, fields carries the
+// resolved values to send. baseMetadata is the role's current metadata for an
+// update, so managed keys merge over it.
 type roleOp struct {
 	action       opAction
-	spec         RoleSpec
+	name         string
+	fields       roleFields
 	id           string         // server role id, set for updates and deletes
 	detail       string         // which fields change, for the plan output
 	baseMetadata map[string]any // current metadata to merge onto, set for updates
@@ -59,22 +82,67 @@ type roleOp struct {
 func (o roleOp) String() string {
 	switch o.action {
 	case opRemove:
-		return fmt.Sprintf("delete role %s", o.spec.Name)
+		return fmt.Sprintf("delete role %s", o.name)
 	case opUpdate:
-		return fmt.Sprintf("update role %s (%s)", o.spec.Name, o.detail)
+		return fmt.Sprintf("update role %s (%s)", o.name, o.detail)
 	default:
-		return fmt.Sprintf("add role %s", o.spec.Name)
+		return fmt.Sprintf("add role %s", o.name)
 	}
 }
 
-// predefinedRole returns the shipped definition of a predefined role name.
-func predefinedRole(name string) (schema.RoleDefinition, bool) {
+// roleDefault returns the default fields for a role name. A predefined role
+// defaults to its shipped definition; any other name defaults to empty fields.
+// The bool reports whether the name is predefined.
+func roleDefault(name string) (roleFields, bool) {
 	for _, def := range schema.PredefinedRoles {
 		if def.Name == name {
-			return def, true
+			return roleFields{
+				Title:       def.Title,
+				Description: def.Description,
+				Permissions: normalizePermissions(def.Permissions),
+				Scopes:      sortedCopy(def.Scopes),
+			}, true
 		}
 	}
-	return schema.RoleDefinition{}, false
+	return roleFields{}, false
+}
+
+// resolve lays the spec's present fields over the default. An omitted field
+// keeps the default; a present field replaces it, even when it is empty.
+func (s RoleSpec) resolve(def roleFields) roleFields {
+	want := def
+	if s.Title != nil {
+		want.Title = *s.Title
+	}
+	if s.Description != nil {
+		want.Description = *s.Description
+	}
+	if s.Permissions != nil {
+		want.Permissions = normalizePermissions(*s.Permissions)
+	}
+	if s.Scopes != nil {
+		want.Scopes = sortedCopy(*s.Scopes)
+	}
+	return want
+}
+
+// diffFields returns the names of the fields that differ between want and have,
+// in a stable order. An empty result means the two are already equal.
+func diffFields(want, have roleFields) []string {
+	var changes []string
+	if want.Title != have.Title {
+		changes = append(changes, "title")
+	}
+	if want.Description != have.Description {
+		changes = append(changes, "description")
+	}
+	if !stringSetsEqual(want.Permissions, have.Permissions) {
+		changes = append(changes, "permissions")
+	}
+	if !stringSetsEqual(want.Scopes, have.Scopes) {
+		changes = append(changes, "scopes")
+	}
+	return changes
 }
 
 // normalizePermissions maps permission references in any accepted form
@@ -111,210 +179,94 @@ func stringSetsEqual(a, b []string) bool {
 	return true
 }
 
-// validateRoleSpec rejects entries the flow cannot manage. A managed-empty
-// permission list is rejected for both role types: an exported file cannot
-// represent it (empty lists are omitted), so it would not survive a round trip.
+// validateRoleSpec rejects entries the flow cannot manage: an entry needs a
+// name, and a predefined role cannot be deleted because bootstrap recreates it
+// on the next boot.
 func validateRoleSpec(s RoleSpec, isPredefined bool) error {
 	if strings.TrimSpace(s.Name) == "" {
 		return fmt.Errorf("name is required")
 	}
-	if s.Delete {
-		if isPredefined {
-			return fmt.Errorf("cannot delete a predefined role; bootstrap recreates it on the next boot")
-		}
-		return nil
-	}
-	if isPredefined {
-		if s.Permissions != nil && len(s.Permissions) == 0 {
-			return fmt.Errorf("cannot set a predefined role's permissions to an empty list")
-		}
-		if s.Scopes != nil && len(s.Scopes) == 0 {
-			return fmt.Errorf("cannot set a predefined role's scopes to an empty list")
-		}
-		return nil
-	}
-	if len(s.Permissions) == 0 {
-		return fmt.Errorf("a custom role must list at least one permission")
+	if s.Delete && isPredefined {
+		return fmt.Errorf("cannot delete a predefined role; bootstrap recreates it on the next boot")
 	}
 	return nil
 }
 
 // diffRoles returns the ops that make the current platform roles match the
-// desired spec. Custom roles are authoritative: every one on the server must
-// appear in the spec — kept, or marked delete — so nothing is removed by
-// omission. Predefined roles on the server converge to their shipped
-// definition with the file entry, if any, laid over it; boot owns creating
-// missing ones, so a predefined role absent from the server is not created
-// here (and cannot be represented by an export anyway).
+// desired spec. Each listed role's desired fields are its own present fields
+// laid over its default (empty for custom, the shipped definition for
+// predefined). A custom role missing from the server is created; a predefined
+// one missing there is an error, since bootstrap owns creating it. A custom
+// role can be deleted; a predefined one cannot. Every server role not in the
+// file must be accounted for: a predefined one converges back to its
+// definition, and a custom one fails the plan so nothing is removed by omission.
 func diffRoles(desired []RoleSpec, current []currentRole) ([]roleOp, error) {
 	byName := make(map[string]currentRole, len(current))
 	for _, c := range current {
 		byName[c.Name] = c
 	}
 
-	seen := map[string]struct{}{}
-	overrides := map[string]RoleSpec{}
-	var customs []RoleSpec
+	var adds, updates, removes []roleOp
+	listed := map[string]struct{}{}
 	for _, s := range desired {
-		_, isPredefined := predefinedRole(s.Name)
+		def, isPredefined := roleDefault(s.Name)
 		if err := validateRoleSpec(s, isPredefined); err != nil {
 			return nil, fmt.Errorf("invalid role spec %q: %w", s.Name, err)
 		}
-		if _, dup := seen[s.Name]; dup {
+		if _, dup := listed[s.Name]; dup {
 			return nil, fmt.Errorf("role %q is listed more than once", s.Name)
 		}
-		seen[s.Name] = struct{}{}
-		if isPredefined {
-			overrides[s.Name] = s
-		} else {
-			customs = append(customs, s)
-		}
-	}
+		listed[s.Name] = struct{}{}
 
-	var adds, updates, removes []roleOp
-
-	// Predefined roles, in definition order. A duplicate definition keeps the
-	// first one, matching what boot creates.
-	seeded := map[string]struct{}{}
-	for _, def := range schema.PredefinedRoles {
-		if _, dup := seeded[def.Name]; dup {
-			continue
-		}
-		seeded[def.Name] = struct{}{}
-		cur, exists := byName[def.Name]
-		s, listed := overrides[def.Name]
-		if !exists {
-			if listed {
-				return nil, fmt.Errorf("predefined role %q not found on the server; bootstrap creates it at boot", def.Name)
-			}
-			continue
-		}
-		var entry *RoleSpec
-		if listed {
-			entry = &s
-		}
-		if op, changed := diffPredefinedRole(def, entry, cur); changed {
-			updates = append(updates, op)
-		}
-	}
-
-	for _, s := range customs {
 		cur, exists := byName[s.Name]
 		if s.Delete {
 			if exists {
-				removes = append(removes, roleOp{action: opRemove, spec: s, id: cur.ID})
+				removes = append(removes, roleOp{action: opRemove, name: s.Name, id: cur.ID})
 			}
 			continue
 		}
-		desiredPerms := normalizePermissions(s.Permissions)
+
+		want := s.resolve(def)
 		if !exists {
-			adds = append(adds, roleOp{action: opAdd, spec: RoleSpec{
-				Name:        s.Name,
-				Title:       s.Title,
-				Description: s.Description,
-				Permissions: desiredPerms,
-				Scopes:      sortedCopy(s.Scopes),
-			}})
+			if isPredefined {
+				return nil, fmt.Errorf("predefined role %q not found on the server; bootstrap creates it at boot", s.Name)
+			}
+			adds = append(adds, roleOp{action: opAdd, name: s.Name, fields: want})
 			continue
 		}
-		var changes []string
-		merged := RoleSpec{Name: s.Name, Title: cur.Title, Description: cur.Description, Permissions: sortedCopy(cur.Permissions), Scopes: sortedCopy(cur.Scopes)}
-		if s.Title != "" && s.Title != cur.Title {
-			merged.Title = s.Title
-			changes = append(changes, "title")
-		}
-		if s.Description != "" && s.Description != cur.Description {
-			merged.Description = s.Description
-			changes = append(changes, "description")
-		}
-		if !stringSetsEqual(desiredPerms, sortedCopy(cur.Permissions)) {
-			merged.Permissions = desiredPerms
-			changes = append(changes, "permissions")
-		}
-		if s.Scopes != nil && !stringSetsEqual(sortedCopy(s.Scopes), sortedCopy(cur.Scopes)) {
-			merged.Scopes = sortedCopy(s.Scopes)
-			changes = append(changes, "scopes")
-		}
-		if len(changes) > 0 {
-			updates = append(updates, roleOp{action: opUpdate, spec: merged, id: cur.ID, detail: strings.Join(changes, ", "), baseMetadata: cur.Metadata})
+		if changes := diffFields(want, cur.fields()); len(changes) > 0 {
+			updates = append(updates, roleOp{action: opUpdate, name: s.Name, fields: want, id: cur.ID,
+				detail: strings.Join(changes, ", "), baseMetadata: cur.Metadata})
 		}
 	}
 
-	var unaccounted []string
+	// Every server role not in the file. Predefined roles converge back to their
+	// definition; custom roles are unaccounted for and fail the plan.
+	var names []string
 	for name := range byName {
-		if _, ok := seen[name]; ok {
+		if _, ok := listed[name]; !ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	var unaccounted []string
+	for _, name := range names {
+		cur := byName[name]
+		def, isPredefined := roleDefault(name)
+		if !isPredefined {
+			unaccounted = append(unaccounted, name)
 			continue
 		}
-		if _, isPredefined := predefinedRole(name); isPredefined {
-			continue
+		if changes := diffFields(def, cur.fields()); len(changes) > 0 {
+			updates = append(updates, roleOp{action: opUpdate, name: name, fields: def, id: cur.ID,
+				detail: strings.Join(changes, ", ") + "; not in file, reset to default", baseMetadata: cur.Metadata})
 		}
-		unaccounted = append(unaccounted, name)
 	}
 	if len(unaccounted) > 0 {
-		sort.Strings(unaccounted)
 		return nil, fmt.Errorf("roles exist on the server but are not in the file: %s; keep them or mark them 'delete: true'", strings.Join(unaccounted, ", "))
 	}
 
 	ops := append(adds, updates...)
 	return append(ops, removes...), nil
-}
-
-// diffPredefinedRole compares one predefined role on the server against its
-// shipped definition with the file entry, if any, laid over it. An omitted
-// field converges to the definition, not the server value. A field whose
-// server value is empty converges only when the entry lists it: an empty
-// value cannot be written to or read back from a file, so converging it
-// unlisted would break the export round trip.
-func diffPredefinedRole(def schema.RoleDefinition, s *RoleSpec, cur currentRole) (roleOp, bool) {
-	merged := RoleSpec{Name: def.Name, Title: cur.Title, Description: cur.Description, Permissions: sortedCopy(cur.Permissions), Scopes: sortedCopy(cur.Scopes)}
-	var changes []string
-
-	title := def.Title
-	titleListed := s != nil && s.Title != ""
-	if titleListed {
-		title = s.Title
-	}
-	if title != cur.Title && (titleListed || cur.Title != "") {
-		merged.Title = title
-		changes = append(changes, "title")
-	}
-
-	description := def.Description
-	descriptionListed := s != nil && s.Description != ""
-	if descriptionListed {
-		description = s.Description
-	}
-	if description != cur.Description && (descriptionListed || cur.Description != "") {
-		merged.Description = description
-		changes = append(changes, "description")
-	}
-
-	perms := normalizePermissions(def.Permissions)
-	permsListed := s != nil && s.Permissions != nil
-	if permsListed {
-		perms = normalizePermissions(s.Permissions)
-	}
-	if !stringSetsEqual(perms, sortedCopy(cur.Permissions)) && (permsListed || len(cur.Permissions) > 0) {
-		merged.Permissions = perms
-		changes = append(changes, "permissions")
-	}
-
-	scopes := sortedCopy(def.Scopes)
-	scopesListed := s != nil && s.Scopes != nil
-	if scopesListed {
-		scopes = sortedCopy(s.Scopes)
-	}
-	if !stringSetsEqual(scopes, sortedCopy(cur.Scopes)) && (scopesListed || len(cur.Scopes) > 0) {
-		merged.Scopes = scopes
-		changes = append(changes, "scopes")
-	}
-
-	if len(changes) == 0 {
-		return roleOp{}, false
-	}
-	detail := strings.Join(changes, ", ")
-	if s == nil {
-		detail += "; not in file, reset to default"
-	}
-	return roleOp{action: opUpdate, spec: merged, id: cur.ID, detail: detail, baseMetadata: cur.Metadata}, true
 }

--- a/internal/reconcile/role_reconciler.go
+++ b/internal/reconcile/role_reconciler.go
@@ -50,7 +50,7 @@ func (r *RoleReconciler) Validate(spec []byte) error {
 	}
 	seen := map[string]struct{}{}
 	for _, s := range specs {
-		_, isPredefined := predefinedRole(s.Name)
+		_, isPredefined := roleDefault(s.Name)
 		if err := validateRoleSpec(s, isPredefined); err != nil {
 			return fmt.Errorf("invalid role spec %q: %w", s.Name, err)
 		}
@@ -94,13 +94,14 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, spec []byte, dryRun bool
 	return rep, nil
 }
 
-// Export returns the current platform roles as a desired-state spec. Custom
-// roles are exported in full. Predefined roles are exported only when they
-// differ from their shipped definition (title, permissions, or scopes), and
-// only with the differing fields, so converged ones stay out of the file.
-// The comparisons mirror diffPredefinedRole exactly — including skipping
-// fields that are empty on the server, which a file cannot represent — so
-// reconciling an export's output always plans no changes.
+// Export returns the current platform roles as a desired-state spec. Each
+// server role is compared to its default (empty for a custom role, the shipped
+// definition for a predefined one) and only the fields that differ are emitted.
+// A custom role always emits an entry, because a custom role must appear in the
+// file to be kept; a predefined role emits an entry only when some field
+// differs, so converged ones stay out. An empty server value that differs from
+// the default is written as an explicit empty (`title: ""`, `scopes: []`), so
+// the value round-trips exactly and reconciling an export plans no changes.
 func (r *RoleReconciler) Export(ctx context.Context) (any, error) {
 	current, err := r.fetchCurrent(ctx)
 	if err != nil {
@@ -110,41 +111,33 @@ func (r *RoleReconciler) Export(ctx context.Context) (any, error) {
 
 	specs := make([]RoleSpec, 0, len(current))
 	for _, c := range current {
-		def, isPredefined := predefinedRole(c.Name)
-		if !isPredefined {
-			specs = append(specs, RoleSpec{
-				Name:        c.Name,
-				Title:       c.Title,
-				Description: c.Description,
-				Permissions: sortedCopy(c.Permissions),
-				Scopes:      sortedCopy(c.Scopes),
-			})
+		def, isPredefined := roleDefault(c.Name)
+		have := c.fields()
+		changes := diffFields(have, def)
+		if isPredefined && len(changes) == 0 {
 			continue
 		}
 		entry := RoleSpec{Name: c.Name}
-		changed := false
-		if c.Title != "" && c.Title != def.Title {
-			entry.Title = c.Title
-			changed = true
+		for _, field := range changes {
+			switch field {
+			case "title":
+				entry.Title = strPtr(have.Title)
+			case "description":
+				entry.Description = strPtr(have.Description)
+			case "permissions":
+				entry.Permissions = slicePtr(have.Permissions)
+			case "scopes":
+				entry.Scopes = slicePtr(have.Scopes)
+			}
 		}
-		if c.Description != "" && c.Description != def.Description {
-			entry.Description = c.Description
-			changed = true
-		}
-		if len(c.Permissions) > 0 && !stringSetsEqual(normalizePermissions(c.Permissions), normalizePermissions(def.Permissions)) {
-			entry.Permissions = sortedCopy(c.Permissions)
-			changed = true
-		}
-		if len(c.Scopes) > 0 && !stringSetsEqual(sortedCopy(c.Scopes), sortedCopy(def.Scopes)) {
-			entry.Scopes = sortedCopy(c.Scopes)
-			changed = true
-		}
-		if changed {
-			specs = append(specs, entry)
-		}
+		specs = append(specs, entry)
 	}
 	return specs, nil
 }
+
+func strPtr(s string) *string { return &s }
+
+func slicePtr(s []string) *[]string { return &s }
 
 func (r *RoleReconciler) fetchCurrent(ctx context.Context) ([]currentRole, error) {
 	resp, err := r.client.ListRoles(ctx, authReq(&frontierv1beta1.ListRolesRequest{}, r.header))
@@ -184,14 +177,14 @@ func metadataString(md *structpb.Struct, key string) string {
 func (r *RoleReconciler) apply(ctx context.Context, op roleOp) error {
 	switch op.action {
 	case opAdd:
-		body, err := roleBody(op.spec, op.baseMetadata)
+		body, err := roleBody(op.name, op.fields, op.baseMetadata)
 		if err != nil {
 			return err
 		}
 		_, err = r.client.CreateRole(ctx, authReq(&frontierv1beta1.CreateRoleRequest{Body: body}, r.header))
 		return err
 	case opUpdate:
-		body, err := roleBody(op.spec, op.baseMetadata)
+		body, err := roleBody(op.name, op.fields, op.baseMetadata)
 		if err != nil {
 			return err
 		}
@@ -209,14 +202,14 @@ func (r *RoleReconciler) apply(ctx context.Context, op roleOp) error {
 // current metadata (nil for a new role); the reconciler-managed keys are merged
 // over a copy of it, so other metadata keys an operator set are kept, not
 // dropped. An empty managed description clears the key, matching a reset.
-func roleBody(spec RoleSpec, base map[string]any) (*frontierv1beta1.RoleRequestBody, error) {
+func roleBody(name string, want roleFields, base map[string]any) (*frontierv1beta1.RoleRequestBody, error) {
 	fields := map[string]any{}
 	for k, v := range base {
 		fields[k] = v
 	}
 	fields[managedByKey] = managedByValue
-	if spec.Description != "" {
-		fields[descriptionKey] = spec.Description
+	if want.Description != "" {
+		fields[descriptionKey] = want.Description
 	} else {
 		delete(fields, descriptionKey)
 	}
@@ -225,10 +218,10 @@ func roleBody(spec RoleSpec, base map[string]any) (*frontierv1beta1.RoleRequestB
 		return nil, fmt.Errorf("build role metadata: %w", err)
 	}
 	return &frontierv1beta1.RoleRequestBody{
-		Name:        spec.Name,
-		Title:       spec.Title,
-		Permissions: spec.Permissions,
-		Scopes:      spec.Scopes,
+		Name:        name,
+		Title:       want.Title,
+		Permissions: want.Permissions,
+		Scopes:      want.Scopes,
 		Metadata:    md,
 	}, nil
 }

--- a/internal/reconcile/role_reconciler_test.go
+++ b/internal/reconcile/role_reconciler_test.go
@@ -102,8 +102,9 @@ func TestRoleReconciler(t *testing.T) {
 		role := rolePB("r1", "compute_manager", "Compute Manager", []string{"compute_order_get"})
 		role.Metadata = md
 		api := &fakeRoleAPI{roles: []*frontierv1beta1.Role{ownerDefaultPB(), role}}
-		// only permissions change; team must survive the update
-		spec := []byte("- {name: compute_manager, permissions: [compute_order_get, compute_order_update]}\n")
+		// only permissions change; the file lists the fields it keeps, and the
+		// unmanaged team key must survive the update either way.
+		spec := []byte("- {name: compute_manager, title: Compute Manager, description: old, permissions: [compute_order_get, compute_order_update]}\n")
 
 		rep, err := NewRoleReconciler(api, "").Reconcile(context.Background(), spec, false)
 
@@ -113,7 +114,7 @@ func TestRoleReconciler(t *testing.T) {
 			f := body.GetMetadata().GetFields()
 			assert.Equal(t, "compute", f["team"].GetStringValue())            // preserved, not dropped
 			assert.Equal(t, managedByValue, f[managedByKey].GetStringValue()) // still stamped
-			assert.Equal(t, "old", f[descriptionKey].GetStringValue())        // kept
+			assert.Equal(t, "old", f[descriptionKey].GetStringValue())        // kept because the file lists it
 		}
 	})
 
@@ -165,10 +166,11 @@ func TestRoleReconciler(t *testing.T) {
 		}
 	})
 
-	t.Run("a predefined role with empty legacy fields round-trips as converged", func(t *testing.T) {
-		// A row from before the scopes column: empty on the server, non-empty in
-		// the definition. A file cannot hold an empty value, so export omits the
-		// role and reconcile leaves the field alone instead of fighting forever.
+	t.Run("a predefined role with an empty legacy field round-trips", func(t *testing.T) {
+		// A row from before the scopes column: empty scopes on the server, non-empty
+		// in the definition. Presence-tracking pointers let a file hold an empty
+		// value, so export writes `scopes: []` and reconcile keeps it as-is instead
+		// of fighting the definition forever.
 		api := &fakeRoleAPI{roles: []*frontierv1beta1.Role{
 			rolePB("r-owner", schema.RoleOrganizationOwner, "Owner", []string{"app_organization_administer"}),
 		}}
@@ -176,7 +178,27 @@ func TestRoleReconciler(t *testing.T) {
 
 		out, err := Export(context.Background(), registry, KindRole)
 		assert.NoError(t, err)
-		assert.Contains(t, string(out), "spec: []")
+		assert.Contains(t, string(out), "scopes: []") // the empty value written explicitly
+
+		reports, err := Run(context.Background(), registry, out, true)
+		assert.NoError(t, err)
+		if assert.Len(t, reports, 1) {
+			assert.Empty(t, reports[0].Planned)
+		}
+	})
+
+	t.Run("a custom role with no permissions round-trips", func(t *testing.T) {
+		// A custom role whose permissions were emptied. Export writes an entry so
+		// the role is kept, and reconciling that entry plans no changes.
+		api := &fakeRoleAPI{roles: []*frontierv1beta1.Role{
+			ownerDefaultPB(),
+			rolePB("r1", "compute_manager", "Compute Manager", nil), // no permissions
+		}}
+		registry := map[string]Reconciler{KindRole: NewRoleReconciler(api, "")}
+
+		out, err := Export(context.Background(), registry, KindRole)
+		assert.NoError(t, err)
+		assert.Contains(t, string(out), "compute_manager") // the custom role is kept in the file
 
 		reports, err := Run(context.Background(), registry, out, true)
 		assert.NoError(t, err)
@@ -269,7 +291,7 @@ func TestRoleReconciler(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, []RoleSpec{{
 			Name:        schema.RoleOrganizationOwner,
-			Permissions: []string{"app_organization_get", "app_organization_policymanage", "app_organization_update"},
+			Permissions: ptr([]string{"app_organization_get", "app_organization_policymanage", "app_organization_update"}),
 		}}, spec)
 
 		out, err := Export(context.Background(), registry, KindRole)
@@ -292,7 +314,7 @@ func TestRoleReconciler(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, []RoleSpec{{
 			Name:   schema.RoleOrganizationOwner,
-			Scopes: []string{schema.OrganizationNamespace, "compute/order"},
+			Scopes: ptr([]string{schema.OrganizationNamespace, "compute/order"}),
 		}}, spec)
 
 		out, err := Export(context.Background(), registry, KindRole)

--- a/internal/reconcile/role_reconciler_test.go
+++ b/internal/reconcile/role_reconciler_test.go
@@ -187,26 +187,6 @@ func TestRoleReconciler(t *testing.T) {
 		}
 	})
 
-	t.Run("a custom role with no permissions round-trips", func(t *testing.T) {
-		// A custom role whose permissions were emptied. Export writes an entry so
-		// the role is kept, and reconciling that entry plans no changes.
-		api := &fakeRoleAPI{roles: []*frontierv1beta1.Role{
-			ownerDefaultPB(),
-			rolePB("r1", "compute_manager", "Compute Manager", nil), // no permissions
-		}}
-		registry := map[string]Reconciler{KindRole: NewRoleReconciler(api, "")}
-
-		out, err := Export(context.Background(), registry, KindRole)
-		assert.NoError(t, err)
-		assert.Contains(t, string(out), "compute_manager") // the custom role is kept in the file
-
-		reports, err := Run(context.Background(), registry, out, true)
-		assert.NoError(t, err)
-		if assert.Len(t, reports, 1) {
-			assert.Empty(t, reports[0].Planned)
-		}
-	})
-
 	t.Run("applying a role with a description writes it to metadata", func(t *testing.T) {
 		api := &fakeRoleAPI{}
 		spec := []byte("- {name: new_role, description: Runs compute orders, permissions: [compute_order_get]}\n")

--- a/internal/reconcile/role_test.go
+++ b/internal/reconcile/role_test.go
@@ -249,23 +249,6 @@ func TestDiffRoles(t *testing.T) {
 		assert.ErrorContains(t, err, "delete: true")
 	})
 
-	t.Run("a custom role with no permissions is allowed", func(t *testing.T) {
-		// The old "must list at least one permission" rule is gone. A custom role
-		// with an omitted or empty permission list is a valid desired state.
-		withEmpty := []currentRole{
-			{ID: "r1", Name: "compute_manager", Title: "Compute Manager",
-				Permissions: []string{"compute_order_get", "compute_order_update"}, Scopes: []string{"compute/order"}},
-			{ID: "r2", Name: "old_role", Title: "Old"}, // no permissions on the server
-		}
-		ops, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Title: ptr("Compute Manager"),
-				Permissions: ptr([]string{"compute_order_get", "compute_order_update"}), Scopes: ptr([]string{"compute/order"})},
-			{Name: "old_role", Title: ptr("Old")}, // omitted permissions default to empty for a custom role
-		}, withEmpty)
-		assert.NoError(t, err)
-		assert.Empty(t, ops)
-	})
-
 	t.Run("an omitted custom title clears it", func(t *testing.T) {
 		// A custom role defaults to empty fields, so omitting the title means the
 		// desired title is empty. A server role that still has a title drifts and
@@ -293,6 +276,24 @@ func TestDiffRoles(t *testing.T) {
 		ops, err := diffRoles(append(keepCustom, RoleSpec{Name: "already_gone", Delete: true}), current)
 		assert.NoError(t, err)
 		assert.Empty(t, ops)
+	})
+
+	t.Run("a custom role that resolves to no permissions fails the plan", func(t *testing.T) {
+		// The server rejects a role with no permissions, so a spec resolving to an
+		// empty set is a plan that can never apply. It must fail at plan time. A
+		// custom role defaults to empty, so both omitting permissions and writing
+		// an explicit empty list resolve to empty.
+		_, omitted := diffRoles([]RoleSpec{{Name: "empty_custom"}}, nil)
+		assert.ErrorContains(t, omitted, "at least one permission")
+
+		_, explicit := diffRoles([]RoleSpec{{Name: "empty_custom", Permissions: ptr([]string{})}}, nil)
+		assert.ErrorContains(t, explicit, "at least one permission")
+	})
+
+	t.Run("a predefined role set to empty permissions fails the plan", func(t *testing.T) {
+		cur := []currentRole{{ID: "r1", Name: schema.RoleOrganizationViewer, Permissions: []string{"app_organization_get"}}}
+		_, err := diffRoles([]RoleSpec{{Name: schema.RoleOrganizationViewer, Permissions: ptr([]string{})}}, cur)
+		assert.ErrorContains(t, err, "at least one permission")
 	})
 }
 

--- a/internal/reconcile/role_test.go
+++ b/internal/reconcile/role_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// ptr and slicePtr build the presence-tracking pointers a RoleSpec now uses:
+// a nil pointer is an omitted field, a non-nil one is a listed value.
+func ptr[T any](v T) *T { return &v }
+
 func TestDiffRoles(t *testing.T) {
 	current := []currentRole{
 		{ID: "r1", Name: "compute_manager", Title: "Compute Manager",
@@ -19,9 +23,13 @@ func TestDiffRoles(t *testing.T) {
 			Scopes:      []string{schema.OrganizationNamespace}},
 	}
 
+	// keepCustom lists every non-empty field of the two custom roles, since the
+	// file is the whole desired state: an omitted field defaults to empty and
+	// would clear the server value. This is what an export writes.
 	keepCustom := []RoleSpec{
-		{Name: "compute_manager", Permissions: []string{"compute_order_get", "compute_order_update"}},
-		{Name: "old_role", Permissions: []string{"compute_order_get"}},
+		{Name: "compute_manager", Title: ptr("Compute Manager"),
+			Permissions: ptr([]string{"compute_order_get", "compute_order_update"}), Scopes: ptr([]string{"compute/order"})},
+		{Name: "old_role", Title: ptr("Old"), Permissions: ptr([]string{"compute_order_get"})},
 	}
 
 	t.Run("no changes when converged, unlisted predefined roles at defaults", func(t *testing.T) {
@@ -42,8 +50,8 @@ func TestDiffRoles(t *testing.T) {
 		if assert.Len(t, ops, 1) {
 			assert.Equal(t, "update role app_organization_owner (title, permissions; not in file, reset to default)", ops[0].String())
 			assert.Equal(t, "r3", ops[0].id)
-			assert.Equal(t, "Owner", ops[0].spec.Title)
-			assert.Equal(t, []string{"app_organization_administer"}, ops[0].spec.Permissions)
+			assert.Equal(t, "Owner", ops[0].fields.Title)
+			assert.Equal(t, []string{"app_organization_administer"}, ops[0].fields.Permissions)
 		}
 	})
 
@@ -55,28 +63,42 @@ func TestDiffRoles(t *testing.T) {
 
 		ops, err := diffRoles(append(keepCustom, RoleSpec{
 			Name:        schema.RoleOrganizationOwner,
-			Permissions: []string{"app_organization_administer", "app_organization_get"},
+			Permissions: ptr([]string{"app_organization_administer", "app_organization_get"}),
 		}), drifted)
 
 		assert.NoError(t, err)
 		if assert.Len(t, ops, 1) {
 			assert.Equal(t, "update role app_organization_owner (title, permissions)", ops[0].String())
-			assert.Equal(t, "Owner", ops[0].spec.Title) // omitted in the entry: back to the definition, not the server value
-			assert.ElementsMatch(t, []string{"app_organization_administer", "app_organization_get"}, ops[0].spec.Permissions)
+			assert.Equal(t, "Owner", ops[0].fields.Title) // omitted in the entry: back to the definition, not the server value
+			assert.ElementsMatch(t, []string{"app_organization_administer", "app_organization_get"}, ops[0].fields.Permissions)
 		}
 	})
 
-	t.Run("empty server values converge only when listed", func(t *testing.T) {
+	t.Run("an unlisted predefined role with an empty legacy field resets to the definition", func(t *testing.T) {
+		// A row from before the scopes column: empty scopes on the server, non-empty
+		// in the definition. Unlisted, it now converges to the definition like any
+		// other drift, instead of being left alone forever. Export writes the empty
+		// value explicitly (see the reconciler round-trip tests), so a role that
+		// should keep an empty field stays listed and never reaches this branch.
 		legacy := append([]currentRole{}, current[:2]...)
 		legacy = append(legacy, currentRole{ID: "r3", Name: schema.RoleOrganizationOwner, Title: "Owner",
 			Permissions: []string{"app_organization_administer"}}) // scopes never recorded on this row
 
 		ops, err := diffRoles(keepCustom, legacy)
 		assert.NoError(t, err)
-		assert.Empty(t, ops) // unlisted: an empty value cannot round-trip through a file, so it is settled
+		if assert.Len(t, ops, 1) {
+			assert.Equal(t, "update role app_organization_owner (scopes; not in file, reset to default)", ops[0].String())
+			assert.Equal(t, []string{schema.OrganizationNamespace}, ops[0].fields.Scopes)
+		}
+	})
 
-		ops, err = diffRoles(append(keepCustom, RoleSpec{
-			Name: schema.RoleOrganizationOwner, Scopes: []string{schema.OrganizationNamespace},
+	t.Run("a listed predefined role sets an empty server field", func(t *testing.T) {
+		legacy := append([]currentRole{}, current[:2]...)
+		legacy = append(legacy, currentRole{ID: "r3", Name: schema.RoleOrganizationOwner, Title: "Owner",
+			Permissions: []string{"app_organization_administer"}}) // empty scopes
+
+		ops, err := diffRoles(append(keepCustom, RoleSpec{
+			Name: schema.RoleOrganizationOwner, Scopes: ptr([]string{schema.OrganizationNamespace}),
 		}), legacy)
 		assert.NoError(t, err)
 		if assert.Len(t, ops, 1) {
@@ -84,10 +106,24 @@ func TestDiffRoles(t *testing.T) {
 		}
 	})
 
+	t.Run("an explicit empty list clears a field", func(t *testing.T) {
+		// `scopes: []` in the file is a listed value, not an omission, so it
+		// overrides the definition's scopes with an empty set.
+		ops, err := diffRoles(append(keepCustom, RoleSpec{
+			Name: schema.RoleOrganizationOwner, Scopes: ptr([]string{}),
+		}), current)
+		assert.NoError(t, err)
+		if assert.Len(t, ops, 1) {
+			assert.Equal(t, "update role app_organization_owner (scopes)", ops[0].String())
+			assert.Empty(t, ops[0].fields.Scopes)
+		}
+	})
+
 	t.Run("permission references in any form match slugs", func(t *testing.T) {
 		ops, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Permissions: []string{"compute/order:get", "compute.order.update"}},
-			{Name: "old_role", Permissions: []string{"compute_order_get"}},
+			{Name: "compute_manager", Title: ptr("Compute Manager"),
+				Permissions: ptr([]string{"compute/order:get", "compute.order.update"}), Scopes: ptr([]string{"compute/order"})},
+			{Name: "old_role", Title: ptr("Old"), Permissions: ptr([]string{"compute_order_get"})},
 		}, current)
 		assert.NoError(t, err)
 		assert.Empty(t, ops)
@@ -95,10 +131,10 @@ func TestDiffRoles(t *testing.T) {
 
 	t.Run("adds, updates, and deletes in that order", func(t *testing.T) {
 		ops, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Title: "Compute Admin",
-				Permissions: []string{"compute_order_get", "compute_order_update"}},
+			{Name: "compute_manager", Title: ptr("Compute Admin"),
+				Permissions: ptr([]string{"compute_order_get", "compute_order_update"}), Scopes: ptr([]string{"compute/order"})},
 			{Name: "old_role", Delete: true},
-			{Name: "new_role", Title: "New", Permissions: []string{"compute_order_get"}},
+			{Name: "new_role", Title: ptr("New"), Permissions: ptr([]string{"compute_order_get"})},
 		}, current)
 
 		assert.NoError(t, err)
@@ -110,34 +146,57 @@ func TestDiffRoles(t *testing.T) {
 		}
 	})
 
-	t.Run("update merges managed fields over current values", func(t *testing.T) {
+	t.Run("a listed field is the whole desired value; omitted custom fields clear", func(t *testing.T) {
+		// Under one field model, a custom role's omitted fields default to empty,
+		// they are not kept from the server. So listing only permissions here also
+		// clears the title and scopes, because the file is the whole desired state.
 		ops, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Permissions: []string{"compute_order_get"}}, // narrow the set, no title in spec
-			{Name: "old_role", Permissions: []string{"compute_order_get"}},
+			{Name: "compute_manager", Permissions: ptr([]string{"compute_order_get"})}, // narrow perms, title and scopes omitted
+			{Name: "old_role", Title: ptr("Old"), Permissions: ptr([]string{"compute_order_get"})},
 		}, current)
 
 		assert.NoError(t, err)
 		if assert.Len(t, ops, 1) {
 			op := ops[0]
 			assert.Equal(t, opUpdate, op.action)
-			assert.Equal(t, "permissions", op.detail)
-			assert.Equal(t, "Compute Manager", op.spec.Title) // kept from server
-			assert.Equal(t, []string{"compute_order_get"}, op.spec.Permissions)
-			assert.Equal(t, []string{"compute/order"}, op.spec.Scopes) // kept from server
+			assert.Equal(t, "title, permissions, scopes", op.detail)
+			assert.Equal(t, "", op.fields.Title) // omitted: custom default is empty
+			assert.Equal(t, []string{"compute_order_get"}, op.fields.Permissions)
+			assert.Empty(t, op.fields.Scopes) // omitted: custom default is empty
+		}
+	})
+
+	t.Run("a custom role keeps its fields when the file lists them", func(t *testing.T) {
+		// To keep a custom role's title and scopes, the file lists them, since the
+		// file is the whole desired state. Export writes them all out for exactly
+		// this reason.
+		ops, err := diffRoles([]RoleSpec{
+			{Name: "compute_manager", Title: ptr("Compute Manager"),
+				Permissions: ptr([]string{"compute_order_get"}), Scopes: ptr([]string{"compute/order"})},
+			{Name: "old_role", Title: ptr("Old"), Permissions: ptr([]string{"compute_order_get"})},
+		}, current)
+
+		assert.NoError(t, err)
+		if assert.Len(t, ops, 1) {
+			op := ops[0]
+			assert.Equal(t, "permissions", op.detail) // only the narrowed set changed
+			assert.Equal(t, "Compute Manager", op.fields.Title)
+			assert.Equal(t, []string{"compute_order_get"}, op.fields.Permissions)
+			assert.Equal(t, []string{"compute/order"}, op.fields.Scopes)
 		}
 	})
 
 	t.Run("a custom role's description is managed like its title", func(t *testing.T) {
 		ops, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Description: "Runs compute orders",
-				Permissions: []string{"compute_order_get", "compute_order_update"}},
-			{Name: "old_role", Permissions: []string{"compute_order_get"}},
+			{Name: "compute_manager", Title: ptr("Compute Manager"), Description: ptr("Runs compute orders"),
+				Permissions: ptr([]string{"compute_order_get", "compute_order_update"}), Scopes: ptr([]string{"compute/order"})},
+			{Name: "old_role", Title: ptr("Old"), Permissions: ptr([]string{"compute_order_get"})},
 		}, current)
 
 		assert.NoError(t, err)
 		if assert.Len(t, ops, 1) {
 			assert.Equal(t, "update role compute_manager (description)", ops[0].String())
-			assert.Equal(t, "Runs compute orders", ops[0].spec.Description)
+			assert.Equal(t, "Runs compute orders", ops[0].fields.Description)
 		}
 	})
 
@@ -153,15 +212,15 @@ func TestDiffRoles(t *testing.T) {
 		assert.NoError(t, err)
 		if assert.Len(t, ops, 1) {
 			assert.Equal(t, "update role app_organization_owner (description; not in file, reset to default)", ops[0].String())
-			assert.Equal(t, "", ops[0].spec.Description) // the definition sets no description
+			assert.Equal(t, "", ops[0].fields.Description) // the definition sets no description
 		}
 	})
 
 	t.Run("predefined role title and permissions can be managed", func(t *testing.T) {
 		specs := append(keepCustom, RoleSpec{
 			Name:        schema.RoleOrganizationOwner,
-			Title:       "Workspace Owner",
-			Permissions: []string{"app_organization_administer", "app_organization_get"},
+			Title:       ptr("Workspace Owner"),
+			Permissions: ptr([]string{"app_organization_administer", "app_organization_get"}),
 		})
 		ops, err := diffRoles(specs, current)
 
@@ -178,42 +237,54 @@ func TestDiffRoles(t *testing.T) {
 	})
 
 	t.Run("a listed predefined role missing on the server fails the plan", func(t *testing.T) {
-		_, err := diffRoles(append(keepCustom, RoleSpec{Name: schema.GroupOwnerRole, Title: "X"}), current)
+		_, err := diffRoles(append(keepCustom, RoleSpec{Name: schema.GroupOwnerRole, Title: ptr("X")}), current)
 		assert.ErrorContains(t, err, "not found on the server")
 	})
 
 	t.Run("a custom server role missing from the file fails the plan", func(t *testing.T) {
 		_, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Permissions: []string{"compute_order_get", "compute_order_update"}},
+			{Name: "compute_manager", Permissions: ptr([]string{"compute_order_get", "compute_order_update"})},
 		}, current)
 		assert.ErrorContains(t, err, "old_role")
 		assert.ErrorContains(t, err, "delete: true")
 	})
 
-	t.Run("a custom role must list at least one permission", func(t *testing.T) {
-		_, err := diffRoles([]RoleSpec{{Name: "compute_manager", Title: "X"}}, current)
-		assert.ErrorContains(t, err, "must list at least one permission")
-
-		_, err = diffRoles([]RoleSpec{{Name: "compute_manager", Permissions: []string{}}}, current)
-		assert.ErrorContains(t, err, "must list at least one permission")
+	t.Run("a custom role with no permissions is allowed", func(t *testing.T) {
+		// The old "must list at least one permission" rule is gone. A custom role
+		// with an omitted or empty permission list is a valid desired state.
+		withEmpty := []currentRole{
+			{ID: "r1", Name: "compute_manager", Title: "Compute Manager",
+				Permissions: []string{"compute_order_get", "compute_order_update"}, Scopes: []string{"compute/order"}},
+			{ID: "r2", Name: "old_role", Title: "Old"}, // no permissions on the server
+		}
+		ops, err := diffRoles([]RoleSpec{
+			{Name: "compute_manager", Title: ptr("Compute Manager"),
+				Permissions: ptr([]string{"compute_order_get", "compute_order_update"}), Scopes: ptr([]string{"compute/order"})},
+			{Name: "old_role", Title: ptr("Old")}, // omitted permissions default to empty for a custom role
+		}, withEmpty)
+		assert.NoError(t, err)
+		assert.Empty(t, ops)
 	})
 
-	t.Run("emptying a predefined role's permissions or scopes is rejected", func(t *testing.T) {
-		_, err := diffRoles(append(keepCustom, RoleSpec{
-			Name: schema.RoleOrganizationOwner, Permissions: []string{},
-		}), current)
-		assert.ErrorContains(t, err, "permissions to an empty list")
-
-		_, err = diffRoles(append(keepCustom, RoleSpec{
-			Name: schema.RoleOrganizationOwner, Scopes: []string{},
-		}), current)
-		assert.ErrorContains(t, err, "scopes to an empty list")
+	t.Run("an omitted custom title clears it", func(t *testing.T) {
+		// A custom role defaults to empty fields, so omitting the title means the
+		// desired title is empty. A server role that still has a title drifts and
+		// the title is cleared.
+		ops, err := diffRoles([]RoleSpec{
+			{Name: "compute_manager", Permissions: ptr([]string{"compute_order_get", "compute_order_update"}), Scopes: ptr([]string{"compute/order"})}, // title omitted
+			{Name: "old_role", Title: ptr("Old"), Permissions: ptr([]string{"compute_order_get"})},
+		}, current)
+		assert.NoError(t, err)
+		if assert.Len(t, ops, 1) {
+			assert.Equal(t, "update role compute_manager (title)", ops[0].String())
+			assert.Equal(t, "", ops[0].fields.Title)
+		}
 	})
 
 	t.Run("duplicate names fail", func(t *testing.T) {
 		_, err := diffRoles([]RoleSpec{
-			{Name: "compute_manager", Permissions: []string{"a"}},
-			{Name: "compute_manager", Permissions: []string{"b"}},
+			{Name: "compute_manager", Permissions: ptr([]string{"a"})},
+			{Name: "compute_manager", Permissions: ptr([]string{"b"})},
 		}, current)
 		assert.ErrorContains(t, err, "listed more than once")
 	})


### PR DESCRIPTION
## What

Collapses the Role kind's two code paths (custom roles and predefined roles) into one field
model, part of adopting rules v2. A role's managed fields now follow a single rule: a field
written in the file is the whole desired value; an omitted field takes the role's default;
an explicitly empty field means empty. Custom and predefined roles differ only in their
default (empty for custom, the shipped definition for predefined) and in that a predefined
role is never created or deleted by the flow.

## Why

Role was the most complex kind. The old code had a separate `diffPredefinedRole` with four
carve-out conditions, keep-if-omitted guards on custom roles, and three empty-list
rejections, all to protect the export round trip. Measured effect of the unification on
`role.go`:

- branch keywords 42 -> 15, compound conditions (`&&`/`||`) 13 -> 1
- `diffPredefinedRole` (53 lines) deleted, folded into one `diffRoles`
- `validateRoleSpec` 24 lines / 4 rules -> ~14 lines / 3 rules (name, no predefined delete, at least one permission)
- production code (role.go + reconciler) down ~50 lines

It also closes Role's two gaps on the rules-v2 compatibility audit (Rule 2, the field model,
and Rule 5, the export round trip).

## The model

- `roleDefault(name)` returns the default fields: the shipped definition for a predefined
  role, empty for a custom role.
- `resolve` lays the spec's present fields over the default; `diffFields` reports what
  changed. One path for both role types.
- Presence tracking uses pointers (`*string`, `*[]string`) so an omitted field and an
  explicitly empty field are distinguishable, and so export can write `scopes: []` for a
  field that is empty on the server. This removes the carve-outs entirely; the round trip
  was verified over the tricky reachable state (a predefined field emptied on the server).

## Behavior changes to know

- Omitting a field on a role now means its default, not "keep the server value." For a custom
  role an omitted title clears it; for a predefined role an omitted field converges to the
  definition (unchanged from before). Files generated by `frontier export` write every
  managed field, so the normal edit-the-export workflow is unaffected; only a hand-trimmed
  file behaves differently.
- An unlisted predefined role with an empty legacy field now converges to its definition
  instead of staying frozen. More predictable, and export keeps such roles listed so the
  round trip never triggers a surprise.
- Empty title, description, and scopes are legal explicit values now: write `scopes: []` to
  blank scopes, and an omitted custom field clears it. Permissions are the exception. The
  server rejects a role with no permissions, so a role must still resolve to at least one.
  A custom role with omitted or `permissions: []`, or a predefined role set to `[]`, fails
  the plan up front with a clear message rather than late at the API. (This guard was briefly
  dropped in an earlier revision of this PR and is restored.)

## Testing

- `go build`, `go test ./internal/reconcile/...`, `go vet`, `gofmt`, `golangci-lint` all
  pass. Test updates were mostly mechanical (pointer literals), plus new cases: an omitted
  custom title clears, a predefined field emptied on the server round-trips, and a role that
  resolves to no permissions (a custom role with omitted or empty permissions, or a predefined
  role set to `[]`) fails the plan.

## Status

RFC 0001 now describes this one field model (raystack/frontier#1751), so this PR implements
what the RFC specifies. It targets `main`, now that the `Validate` interface change (#1776)
it built on has merged. The branch is rebased on the current `main` and merges cleanly. The
framework's "validate every document before applying" commit that this branch used to carry
has since landed in `main` on its own, so it is dropped here. The branch now holds just the
two role commits: the field-model unification and the no-permissions plan-time guard.
