### PR TITLE
chore: dedupe imports and simplify expressions

### DIFF
--- a/billing/credit/service_test.go
+++ b/billing/credit/service_test.go
@@ -195,7 +195,7 @@ func TestService_Add(t *testing.T) {
 					Amount: 10,
 				},
 			},
-			want: errors.New(fmt.Sprintf("transactionRepository.CreateEntry: %v", dummyError)),
+			want: fmt.Errorf("transactionRepository.CreateEntry: %v", dummyError),
 			setup: func() *credit.Service {
 				s, mockTransactionRepo := mockService(t)
 				mockTransactionRepo.EXPECT().CreateEntry(ctx, mock.Anything, mock.Anything).Return([]credit.Transaction{}, dummyError)
@@ -320,7 +320,7 @@ func TestService_Deduct(t *testing.T) {
 					CustomerID: "customer_id",
 				},
 			},
-			want: errors.New(fmt.Sprintf("failed to deduct credits: %v", dummyError)),
+			want: fmt.Errorf("failed to deduct credits: %v", dummyError),
 			setup: func() *credit.Service {
 				s, mockTransactionRepo := mockService(t)
 				mockTransactionRepo.EXPECT().CreateEntry(ctx, mock.Anything, mock.Anything).Return([]credit.Transaction{}, dummyError)

--- a/cmd/preferences.go
+++ b/cmd/preferences.go
@@ -8,12 +8,11 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
 	"github.com/raystack/salt/cli/printer"
-	"github.com/spf13/cobra"
 	cli "github.com/spf13/cobra"
 )
 
-func PreferencesCommand(cliConfig *Config) *cobra.Command {
-	cmd := &cobra.Command{
+func PreferencesCommand(cliConfig *Config) *cli.Command {
+	cmd := &cli.Command{
 		Use:     "preferences",
 		Aliases: []string{"p"},
 		Short:   "Preferences management",
@@ -34,13 +33,13 @@ func PreferencesCommand(cliConfig *Config) *cobra.Command {
 	return cmd
 }
 
-func preferencesListCommand(cliConfig *Config) *cobra.Command {
+func preferencesListCommand(cliConfig *Config) *cli.Command {
 	var header string
-	cmd := &cobra.Command{
+	cmd := &cli.Command{
 		Use:   "list",
 		Short: "list preferences",
 		Long:  "List preferences prints the current preferences set in the db. If no preferences are set, it will print the default preferences.",
-		Args:  cobra.NoArgs,
+		Args:  cli.NoArgs,
 		Example: heredoc.Doc(`
 			$ frontier preferences list
 		`),
@@ -88,12 +87,12 @@ func preferencesListCommand(cliConfig *Config) *cobra.Command {
 	return cmd
 }
 
-func preferencesSetCommand(cliConfig *Config) *cobra.Command {
+func preferencesSetCommand(cliConfig *Config) *cli.Command {
 	var header, name, value string
-	cmd := &cobra.Command{
+	cmd := &cli.Command{
 		Use:   "set",
 		Short: "Set value for a preference trait",
-		Args:  cobra.NoArgs,
+		Args:  cli.NoArgs,
 		Example: heredoc.Doc(`
 			$ frontier preferences set --name mail_link_subject --value Your Frontier login link
 			$ frontier preferences set -n disable_orgs_on_create -v true
@@ -101,7 +100,7 @@ func preferencesSetCommand(cliConfig *Config) *cobra.Command {
 		Annotations: map[string]string{
 			"group": "core",
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cli.Command, args []string) error {
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
@@ -144,13 +143,13 @@ func preferencesSetCommand(cliConfig *Config) *cobra.Command {
 	return cmd
 }
 
-func preferencesGetCommand(cliConfig *Config) *cobra.Command {
+func preferencesGetCommand(cliConfig *Config) *cli.Command {
 	var header string
-	cmd := &cobra.Command{
+	cmd := &cli.Command{
 		Use:   "get",
 		Short: "Get preference traits list",
 		Long:  "Display the predefined preferences traits used by Frontier for settings at platform, org, group and project levels.",
-		Args:  cobra.NoArgs,
+		Args:  cli.NoArgs,
 		Example: heredoc.Doc(`
 			$ frontier preferences get
 		`),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/salt/cli/commander"
-	"github.com/spf13/cobra"
 	cli "github.com/spf13/cobra"
 )
 
@@ -30,7 +29,7 @@ func New(cliConfig *Config) *cli.Command {
 		},
 	}
 
-	cmd.PersistentPreRunE = func(subCmd *cobra.Command, args []string) error {
+	cmd.PersistentPreRunE = func(subCmd *cli.Command, args []string) error {
 		if isClientCLI(subCmd) {
 			if err := overrideClientConfigHost(subCmd, cliConfig); err != nil {
 				return err

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -13,14 +13,13 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/raystack/frontier/config"
 	frontierlogger "github.com/raystack/frontier/pkg/logger"
-	"github.com/spf13/cobra"
 	cli "github.com/spf13/cobra"
 
 	_ "net/http/pprof"
 )
 
-func ServerCommand() *cobra.Command {
-	cmd := &cobra.Command{
+func ServerCommand() *cli.Command {
+	cmd := &cli.Command{
 		Use:     "server",
 		Aliases: []string{"s"},
 		Short:   "Server management",
@@ -46,7 +45,7 @@ func ServerCommand() *cobra.Command {
 	return cmd
 }
 
-func serverInitCommand() *cobra.Command {
+func serverInitCommand() *cli.Command {
 	var configFile string
 	c := &cli.Command{
 		Use:   "init",
@@ -70,7 +69,7 @@ func serverInitCommand() *cobra.Command {
 	return c
 }
 
-func serverStartCommand() *cobra.Command {
+func serverStartCommand() *cli.Command {
 	var configFile string
 
 	c := &cli.Command{
@@ -102,7 +101,7 @@ func serverStartCommand() *cobra.Command {
 	return c
 }
 
-func serverMigrateCommand() *cobra.Command {
+func serverMigrateCommand() *cli.Command {
 	var configFile string
 
 	c := &cli.Command{
@@ -133,7 +132,7 @@ func serverMigrateCommand() *cobra.Command {
 	return c
 }
 
-func serverMigrateRollbackCommand() *cobra.Command {
+func serverMigrateRollbackCommand() *cli.Command {
 	var configFile string
 
 	c := &cli.Command{
@@ -163,7 +162,7 @@ func serverMigrateRollbackCommand() *cobra.Command {
 	return c
 }
 
-func serverGenRSACommand() *cobra.Command {
+func serverGenRSACommand() *cli.Command {
 	var numOfKeys int
 	c := &cli.Command{
 		Use:     "keygen",

--- a/core/event/service.go
+++ b/core/event/service.go
@@ -170,7 +170,7 @@ func (p *Service) EnsureDefaultPlan(ctx context.Context, orgID string) error {
 		}
 
 		if amount := p.billingConf.AccountConfig.OnboardCreditsWithOrg; amount > 0 {
-			txID := uuid.NewSHA1(credit.TxNamespaceUUID, []byte(fmt.Sprintf("%s", customr.OrgID))).String()
+			txID := uuid.NewSHA1(credit.TxNamespaceUUID, []byte(customr.OrgID)).String()
 			if err := p.creditService.Add(ctx, credit.Credit{
 				ID:          txID,
 				CustomerID:  customr.ID,

--- a/core/relation/service.go
+++ b/core/relation/service.go
@@ -102,6 +102,6 @@ func (s Service) ListRelations(ctx context.Context, rel Relation) ([]Relation, e
 }
 
 func isValidID(id string) bool {
-	idRegex := regexp.MustCompile("^(([a-zA-Z0-9_][a-zA-Z0-9/_|-]{0,127})|\\*)$")
+	idRegex := regexp.MustCompile(`^(([a-zA-Z0-9_][a-zA-Z0-9/_|-]{0,127})|\*)$`)
 	return idRegex.MatchString(id)
 }

--- a/internal/api/v1beta1connect/permission_test.go
+++ b/internal/api/v1beta1connect/permission_test.go
@@ -397,9 +397,7 @@ func TestHandler_ListPermissions(t *testing.T) {
 			name: "should return success if permission service return nil error",
 			setup: func(as *mocks.PermissionService) {
 				var testPermissionList []permission.Permission
-				for _, act := range testPermissions {
-					testPermissionList = append(testPermissionList, act)
-				}
+				testPermissionList = append(testPermissionList, testPermissions...)
 				as.EXPECT().List(mock.Anything, permission.Filter{}).Return(testPermissionList, nil)
 			},
 			request: connect.NewRequest(&frontierv1beta1.ListPermissionsRequest{}),

--- a/internal/api/v1beta1connect/policy_test.go
+++ b/internal/api/v1beta1connect/policy_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/raystack/frontier/core/project"
 	"github.com/raystack/frontier/core/role"
 	"github.com/raystack/frontier/internal/api/v1beta1connect/mocks"
-	projectMocks "github.com/raystack/frontier/internal/api/v1beta1connect/mocks"
 	"github.com/raystack/frontier/pkg/metadata"
 	"github.com/raystack/frontier/pkg/utils"
 	frontierv1beta1 "github.com/raystack/frontier/proto/v1beta1"
@@ -752,7 +751,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 	tests := []struct {
 		name         string
 		setupPolicy  func(ps *mocks.PolicyService)
-		setupProject func(ps *projectMocks.ProjectService)
+		setupProject func(ps *mocks.ProjectService)
 		request      *connect.Request[frontierv1beta1.CreatePolicyForProjectRequest]
 		want         *connect.Response[frontierv1beta1.CreatePolicyForProjectResponse]
 		wantErr      error
@@ -763,7 +762,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 			setupPolicy: func(ps *mocks.PolicyService) {
 				// No expectations as we return early
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				// No expectations as we return early
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -779,7 +778,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 			setupPolicy: func(ps *mocks.PolicyService) {
 				// No expectations as we return early
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				// No expectations as we return early
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -798,7 +797,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 			setupPolicy: func(ps *mocks.PolicyService) {
 				// No expectations as we return early
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				// No expectations as we return early
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -817,7 +816,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 			setupPolicy: func(ps *mocks.PolicyService) {
 				// No expectations as we return early
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				// No expectations as we return early
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -836,7 +835,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 			setupPolicy: func(ps *mocks.PolicyService) {
 				// No expectations as we return early
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				ps.On("Get", mock.Anything, testProjectID).Return(project.Project{}, errors.New("project not found"))
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -861,7 +860,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 					ResourceType:  "app/project",
 				}).Return(policy.Policy{}, role.ErrInvalidID)
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				ps.On("Get", mock.Anything, testProjectID).Return(testProject, nil)
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -886,7 +885,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 					ResourceType:  "app/project",
 				}).Return(policy.Policy{}, policy.ErrInvalidDetail)
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				ps.On("Get", mock.Anything, testProjectID).Return(testProject, nil)
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -911,7 +910,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 					ResourceType:  "app/project",
 				}).Return(policy.Policy{}, errors.New("service error"))
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				ps.On("Get", mock.Anything, testProjectID).Return(testProject, nil)
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -945,7 +944,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 					UpdatedAt:     fixedTime,
 				}, nil)
 			},
-			setupProject: func(ps *projectMocks.ProjectService) {
+			setupProject: func(ps *mocks.ProjectService) {
 				ps.On("Get", mock.Anything, testProjectID).Return(testProject, nil)
 			},
 			request: connect.NewRequest(&frontierv1beta1.CreatePolicyForProjectRequest{
@@ -963,7 +962,7 @@ func TestConnectHandler_CreatePolicyForProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockPolicyService := &mocks.PolicyService{}
-			mockProjectService := &projectMocks.ProjectService{}
+			mockProjectService := &mocks.ProjectService{}
 
 			if tt.setupPolicy != nil {
 				tt.setupPolicy(mockPolicyService)

--- a/internal/api/v1beta1connect/prospect.go
+++ b/internal/api/v1beta1connect/prospect.go
@@ -291,9 +291,7 @@ func convertStatusToPBFormat(status prospect.Status) frontierv1beta1.Prospect_St
 }
 
 func buildAndValidateMetadata(m map[string]any, h *ConnectHandler) (metadata.Metadata, error) {
-	var metaDataMap metadata.Metadata
-
-	metaDataMap = metadata.Build(m)
+	metaDataMap := metadata.Build(m)
 	if err := h.metaSchemaService.Validate(metaDataMap, prospectMetaSchema); err != nil {
 		return nil, ErrBadBodyMetaSchemaError
 	}

--- a/internal/store/postgres/null_converters.go
+++ b/internal/store/postgres/null_converters.go
@@ -24,7 +24,7 @@ func nullJSONTextToMetadata(njt types.NullJSONText) metadata.Metadata {
 // metadataToNullJSONText converts metadata.Metadata to NullJSONText.
 // Empty or nil metadata will be stored as NULL in the database, not as an empty JSON object.
 func metadataToNullJSONText(m metadata.Metadata) types.NullJSONText {
-	if m == nil || len(m) == 0 {
+	if len(m) == 0 {
 		return types.NullJSONText{Valid: false}
 	}
 

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -288,10 +288,8 @@ func buildOrgUpdateAuditRecord(ctx context.Context, orgBeforeUpdate, orgAfterUpd
 	if title != updatedTitle {
 		// Create a new one to avoid mutating the original
 		auditMetadata = make(map[string]interface{})
-		if metadata != nil {
-			for k, v := range metadata {
-				auditMetadata[k] = v
-			}
+		for k, v := range metadata {
+			auditMetadata[k] = v
 		}
 		auditMetadata["title"] = title
 		auditMetadata["updated_title"] = updatedTitle


### PR DESCRIPTION
## Summary
Mechanical cleanups with no behavior change: remove duplicate imports and replace expressions with their shorter defined-equivalent forms.

## Changes
- `cmd/preferences.go`, `cmd/root.go`, `cmd/server.go`: cobra was imported twice (bare and as `cli`) and both names were used in the same file. Keep the `cli` alias, which the rest of the package uses.
- `internal/api/v1beta1connect/policy_test.go`: the mocks package was imported under two names; keep `mocks`.
- `billing/credit/service_test.go`: `errors.New(fmt.Sprintf(...))` → `fmt.Errorf(...)` (same message, `%v` kept so wrapping semantics stay unchanged)
- `core/event/service.go`: drop a `fmt.Sprintf("%s", s)` on a value that is already a string
- `core/relation/service.go`: the ID regex uses a raw string, removing the double escaping
- `internal/api/v1beta1connect/permission_test.go`: copy loop → `append(dst, src...)`
- `internal/api/v1beta1connect/prospect.go`: merge a variable declaration with its assignment
- `internal/store/postgres/null_converters.go`, `organization_repository.go`: drop nil checks that duplicate what `len` and `range` already define for nil maps

## Test Plan
- [x] Build and type checking passes
- [x] Tests pass for every touched package (cmd, billing/credit, core/event, v1beta1connect, postgres)

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
- [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
- [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
- [x] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.
