### PR TITLE
chore: acknowledge deprecated API usage

### DIFF
--- a/cmd/permission.go
+++ b/cmd/permission.go
@@ -187,6 +187,7 @@ func viewPermissionCommand(cliConfig *Config) *cli.Command {
 			spinner.Stop()
 
 			report = append(report, []string{"ID", "NAME", "NAMESPACE"})
+			//nolint:staticcheck
 			report = append(report, []string{
 				action.GetId(),
 				action.GetName(),
@@ -247,6 +248,7 @@ func listPermissionCommand(cliConfig *Config) *cli.Command {
 			fmt.Printf(" \nShowing %d permission(s)\n \n", len(permissions))
 
 			report = append(report, []string{"ID", "NAME", "NAMESPACE"})
+			//nolint:staticcheck
 			for _, a := range permissions {
 				report = append(report, []string{
 					a.GetId(),

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -112,6 +112,7 @@ func createCustomRolesAndPermissions(ctx context.Context, client frontierv1beta1
 	}
 
 	str := "created custom permissions : "
+	//nolint:staticcheck
 	for _, v := range permissionBodies {
 		str = fmt.Sprintf("%s %s:%s", str, v.GetNamespace(), v.GetName())
 		resourceNamespaces = append(resourceNamespaces, v.GetNamespace())

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -399,7 +399,7 @@ func buildAPIDependencies(
 
 	authzSchemaRepository := spicedb.NewSchemaRepository(logger, sdb)
 	consistencyLevel := spicedb.ConsistencyLevel(cfg.SpiceDB.Consistency)
-	if cfg.SpiceDB.FullyConsistent {
+	if cfg.SpiceDB.FullyConsistent { //nolint:staticcheck
 		consistencyLevel = spicedb.ConsistencyLevelFull
 	}
 	if !slices.Contains([]spicedb.ConsistencyLevel{

--- a/internal/api/v1beta1connect/billing_subscription.go
+++ b/internal/api/v1beta1connect/billing_subscription.go
@@ -98,6 +98,7 @@ func (h *ConnectHandler) CancelSubscription(ctx context.Context, request *connec
 }
 
 func (h *ConnectHandler) ChangeSubscription(ctx context.Context, request *connect.Request[frontierv1beta1.ChangeSubscriptionRequest]) (*connect.Response[frontierv1beta1.ChangeSubscriptionResponse], error) {
+	//nolint:staticcheck
 	changeReq := subscription.ChangeRequest{
 		PlanID:         request.Msg.GetPlan(),
 		Immediate:      request.Msg.GetImmediate(),

--- a/internal/api/v1beta1connect/billing_usage.go
+++ b/internal/api/v1beta1connect/billing_usage.go
@@ -83,6 +83,7 @@ func (h *ConnectHandler) ListBillingTransactions(ctx context.Context, request *c
 
 	var transactions []*frontierv1beta1.BillingTransaction
 	var startRange time.Time
+	//nolint:staticcheck
 	if request.Msg.GetSince() != nil {
 		startRange = request.Msg.GetSince().AsTime()
 	}

--- a/internal/api/v1beta1connect/permission.go
+++ b/internal/api/v1beta1connect/permission.go
@@ -24,7 +24,7 @@ func (h *ConnectHandler) CreatePermission(ctx context.Context, request *connect.
 	for _, permBody := range request.Msg.GetBodies() {
 		permNamespace, permName := schema.PermissionNamespaceAndNameFromKey(permBody.GetKey())
 		if permNamespace == "" || permName == "" {
-			permNamespace, permName = permBody.GetNamespace(), permBody.GetName()
+			permNamespace, permName = permBody.GetNamespace(), permBody.GetName() //nolint:staticcheck
 		}
 		if permName == "" || permNamespace == "" {
 			return nil, connect.NewError(connect.CodeInvalidArgument, ErrBadRequest)
@@ -116,7 +116,7 @@ func (h *ConnectHandler) UpdatePermission(ctx context.Context, request *connect.
 
 	permNamespace, permName := schema.PermissionNamespaceAndNameFromKey(request.Msg.GetBody().GetKey())
 	if permNamespace == "" || permName == "" {
-		permNamespace, permName = request.Msg.GetBody().GetNamespace(), request.Msg.GetBody().GetName()
+		permNamespace, permName = request.Msg.GetBody().GetNamespace(), request.Msg.GetBody().GetName() //nolint:staticcheck
 	}
 	updatedPermission, err := h.permissionService.Update(ctx, permission.Permission{
 		ID:          request.Msg.GetId(),

--- a/internal/api/v1beta1connect/permission_check.go
+++ b/internal/api/v1beta1connect/permission_check.go
@@ -156,6 +156,7 @@ func (h *ConnectHandler) CheckResourcePermission(ctx context.Context, req *conne
 	errorLogger := NewErrorLogger()
 
 	objectNamespace, objectID, err := schema.SplitNamespaceAndResourceID(req.Msg.GetResource())
+	//nolint:staticcheck
 	if len(req.Msg.GetResource()) == 0 || err != nil {
 		objectNamespace = schema.ParseNamespaceAliasIfRequired(req.Msg.GetObjectNamespace())
 		objectID = req.Msg.GetObjectId()

--- a/internal/reconcile/permission_reconciler.go
+++ b/internal/reconcile/permission_reconciler.go
@@ -91,6 +91,7 @@ func (r *PermissionReconciler) fetchCurrent(ctx context.Context) ([]currentPermi
 		return nil, fmt.Errorf("list permissions: %w", err)
 	}
 	var current []currentPermission
+	//nolint:staticcheck
 	for _, p := range resp.Msg.GetPermissions() {
 		if isBaseNamespace(p.GetNamespace()) {
 			continue

--- a/internal/store/spicedb/relation_repository.go
+++ b/internal/store/spicedb/relation_repository.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 
 	authzedpb "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	newrelic "github.com/newrelic/go-agent"
+	newrelic "github.com/newrelic/go-agent" //nolint:staticcheck
 	"github.com/raystack/frontier/core/relation"
 )
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/raystack/frontier/internal/metrics"
 
-	newrelic "github.com/newrelic/go-agent"
+	newrelic "github.com/newrelic/go-agent" //nolint:staticcheck
 
 	"github.com/jmoiron/sqlx"
 )

--- a/test/e2e/regression/billing_test.go
+++ b/test/e2e/regression/billing_test.go
@@ -1068,6 +1068,7 @@ func (s *BillingRegressionTestSuite) TestUsageAPI() {
 		beforeBalance := getBalanceResp.Msg.GetBalance().GetAmount()
 
 		// set limit to -20
+		//nolint:staticcheck
 		_, err = s.testBench.AdminClient.UpdateBillingAccountLimits(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.UpdateBillingAccountLimitsRequest{
 			OrgId:     createOrgResp.Msg.GetOrganization().GetId(),
 			Id:        createBillingResp.Msg.GetBillingAccount().GetId(),
@@ -1129,6 +1130,7 @@ func (s *BillingRegressionTestSuite) TestUsageAPI() {
 		s.Assert().NoError(err)
 
 		// reset limit
+		//nolint:staticcheck
 		_, err = s.testBench.AdminClient.UpdateBillingAccountLimits(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.UpdateBillingAccountLimitsRequest{
 			OrgId:     createOrgResp.Msg.GetOrganization().GetId(),
 			Id:        createBillingResp.Msg.GetBillingAccount().GetId(),

--- a/test/e2e/regression/service_registration_test.go
+++ b/test/e2e/regression/service_registration_test.go
@@ -153,6 +153,7 @@ func (s *ServiceRegistrationRegressionTestSuite) TestServiceRegistration() {
 		var lastPermCount int
 		for _, perm := range []string{"get", "update", "delete"} {
 			for _, listPerm := range listPermResp.Msg.GetPermissions() {
+				//nolint:staticcheck
 				if listPerm.GetName() == perm && listPerm.GetNamespace() == "database/instance" {
 					lastPermCount++
 				}
@@ -235,6 +236,7 @@ func (s *ServiceRegistrationRegressionTestSuite) TestPermissionDeleteCascade() {
 	s.Require().NoError(err)
 	var builtinID string
 	for _, p := range listResp.Msg.GetPermissions() {
+		//nolint:staticcheck
 		if p.GetNamespace() == "app/organization" && p.GetName() == "get" {
 			builtinID = p.GetId()
 			break


### PR DESCRIPTION
## Summary
Annotate every remaining use of a deprecated API with `//nolint:staticcheck`. Each use is deliberate; none can be removed today without breaking a compatibility contract or losing information.

## Changes
- Handler fallbacks that honor deprecated request fields for old clients: billing usage `Since`, subscription flat `Plan`/`Immediate`, permission create/update `namespace`/`name`, federated check split object fields
- `cmd/serve.go`: the deprecated `FullyConsistent` config flag is still honored for existing configs
- `cmd/seed.go`: seed data deliberately sends the deprecated permission body shape
- `internal/reconcile` and `cmd/permission.go`: read the deprecated `Namespace`/`Name` response fields — the replacement `Key` round-trips lossily (single-segment namespaces gain a `/default` suffix, dotted names split wrong), so the deprecated fields are the only faithful representation today
- e2e: two uses of the deprecated `UpdateBillingAccountLimits` RPC and two assertions on the deprecated response fields
- `pkg/db`, `internal/store/spicedb`: the deprecated New Relic go-agent v2 imports; the v3 migration is a separate piece of work

## Test Plan
- [x] Build and type checking passes
- [x] Reconcile and cmd test suites pass
- [x] Full staticcheck sweep shows a single remaining deprecation finding, fixed separately in #1777


Issue [1782](https://github.com/raystack/frontier/issues/1782) tracks this so we remove the deprecated usage
