### PR TITLE
chore: name error vars by convention

### DIFF
--- a/billing/customer/service_test.go
+++ b/billing/customer/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stripe/stripe-go/v79/client"
 )
 
-var sampleError = errors.New("sample error")
+var errSample = errors.New("sample error")
 
 func mockService(t *testing.T) (*client.API, *stripemock.Backend, *mocks.Repository, *mocks.CreditService) {
 	t.Helper()
@@ -277,11 +277,11 @@ func TestService_Update(t *testing.T) {
 			},
 			want: customer.Customer{},
 
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *customer.Service {
 				stripeClient, _, mockRepo, mockCredit := mockService(t)
 
-				mockRepo.EXPECT().GetByID(ctx, "1").Return(customer.Customer{}, sampleError)
+				mockRepo.EXPECT().GetByID(ctx, "1").Return(customer.Customer{}, errSample)
 
 				cfg := billing.Config{}
 
@@ -298,7 +298,7 @@ func TestService_Update(t *testing.T) {
 				},
 			},
 			want:    customer.Customer{},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *customer.Service {
 				stripeClient, mockStripeBackend, mockRepo, mockCredit := mockService(t)
 
@@ -329,7 +329,7 @@ func TestService_Update(t *testing.T) {
 							"managed_by": "frontier",
 							"org_id":     "org1",
 						},
-					}, &stripe.Customer{ID: ""}).Return(sampleError)
+					}, &stripe.Customer{ID: ""}).Return(errSample)
 
 				cfg := billing.Config{}
 
@@ -397,11 +397,11 @@ func TestService_GetByID(t *testing.T) {
 				id: "1",
 			},
 			want:    customer.Customer{},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *customer.Service {
 				stripeClient, _, mockRepo, mockCredit := mockService(t)
 				mockRepo.EXPECT().GetByID(ctx, "1").Return(
-					customer.Customer{}, sampleError)
+					customer.Customer{}, errSample)
 
 				cfg := billing.Config{}
 
@@ -481,11 +481,11 @@ func TestService_List(t *testing.T) {
 				filter: customer.Filter{},
 			},
 			want:    []customer.Customer{},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *customer.Service {
 				stripeClient, _, mockRepo, mockCredit := mockService(t)
 				mockRepo.EXPECT().List(ctx, customer.Filter{}).Return(
-					[]customer.Customer{}, sampleError)
+					[]customer.Customer{}, errSample)
 
 				cfg := billing.Config{}
 

--- a/core/event/service.go
+++ b/core/event/service.go
@@ -30,7 +30,7 @@ import (
 	"github.com/raystack/frontier/core/organization"
 )
 
-var DefaultPlanNotFree = errors.New("default plan is not free")
+var ErrDefaultPlanNotFree = errors.New("default plan is not free")
 
 type CheckoutService interface {
 	Apply(ctx context.Context, ch checkout.Checkout) (*subscription.Subscription, *product.Product, error)
@@ -157,7 +157,7 @@ func (p *Service) EnsureDefaultPlan(ctx context.Context, orgID string) error {
 			}
 
 			if !defaultPlan.IsFree() {
-				return DefaultPlanNotFree
+				return ErrDefaultPlanNotFree
 			}
 			_, _, err = p.checkoutService.Apply(ctx, checkout.Checkout{
 				CustomerID: customr.ID,

--- a/core/event/service_test.go
+++ b/core/event/service_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var sampleError = errors.New("sample error")
+var errSample = errors.New("sample error")
 
 func mockService(t *testing.T) (*billing.Config, *mocks.CheckoutService, *mocks.CustomerService, *mocks.OrganizationService, *mocks.PlanService, *mocks.UserService, *mocks.MembershipService, *mocks.RoleService, *mocks.SubscriptionService, *mocks.CreditService, *mocks.InvoiceService) {
 	t.Helper()
@@ -89,12 +89,12 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
 
-				customerService.On("List", ctx, customer.Filter{}).Return(nil, sampleError).Once()
+				customerService.On("List", ctx, customer.Filter{}).Return(nil, errSample).Once()
 				return service
 			},
 		},
@@ -119,13 +119,13 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
 
 				customerService.On("List", ctx, customer.Filter{}).Return([]customer.Customer{}, nil).Once()
-				orgService.On("GetRaw", ctx, "").Return(organization.Organization{}, sampleError).Once()
+				orgService.On("GetRaw", ctx, "").Return(organization.Organization{}, errSample).Once()
 				return service
 			},
 		},
@@ -135,14 +135,14 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
 
 				customerService.On("List", ctx, customer.Filter{}).Return(nil, nil).Once()
 				orgService.On("GetRaw", ctx, "").Return(organization.Organization{ID: "org_1"}, nil).Once()
-				roleService.On("Get", ctx, organization.AdminRole).Return(role.Role{}, sampleError).Once()
+				roleService.On("Get", ctx, organization.AdminRole).Return(role.Role{}, errSample).Once()
 				return service
 			},
 		},
@@ -152,7 +152,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
@@ -168,7 +168,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 					Currency: "USD",
 					Metadata: map[string]any{
 						"auto_created": "true",
-					}}, false).Return(customer.Customer{}, sampleError).Once()
+					}}, false).Return(customer.Customer{}, errSample).Once()
 				return service
 			},
 		},
@@ -178,7 +178,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
@@ -195,7 +195,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 					Metadata: map[string]any{
 						"auto_created": "true",
 					}}, false).Return(customer.Customer{ID: "cid_1"}, nil).Once()
-				planService.On("GetByID", ctx, "default_plan").Return(plan.Plan{}, sampleError).Once()
+				planService.On("GetByID", ctx, "default_plan").Return(plan.Plan{}, errSample).Once()
 				return service
 			},
 		},
@@ -205,7 +205,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: DefaultPlanNotFree,
+			wantErr: ErrDefaultPlanNotFree,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
@@ -243,7 +243,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				service := NewService(*billingConf, orgService, checkoutService, customerService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService)
@@ -277,7 +277,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 					CustomerID: "cid_1",
 					PlanID:     "plan_1",
 					SkipTrial:  true,
-				}).Return(nil, nil, sampleError).Once()
+				}).Return(nil, nil, errSample).Once()
 				return service
 			},
 		},
@@ -342,7 +342,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 				ctx:   ctx,
 				orgID: "",
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *Service {
 				billingConf, checkoutService, customerService, orgService, planService, userService, membershipService, roleService, subsService, creditService, invoiceService := mockService(t)
 				const onboardingAmount = 10.0
@@ -387,7 +387,7 @@ func TestEnsureDefaultPlan(t *testing.T) {
 					Source:      "system.awarded",
 					Description: "Awarded 10 credits for onboarding",
 					Metadata:    metadata.Metadata{"auto_created": "true"},
-				}).Return(sampleError).Once()
+				}).Return(errSample).Once()
 				return service
 			},
 		},

--- a/core/prospect/service_test.go
+++ b/core/prospect/service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var sampleError = errors.New("sample error")
+var errSample = errors.New("sample error")
 
 func mockService(t *testing.T) *mocks.Repository {
 	t.Helper()
@@ -41,13 +41,13 @@ func TestService_Get(t *testing.T) {
 				ctx:        ctx,
 				prospectID: prospectId,
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			want:    prospect.Prospect{},
 			setup: func() *prospect.Service {
 				repository := mockService(t)
 				service := prospect.NewService(repository)
 
-				repository.On("Get", ctx, prospectId).Return(prospect.Prospect{}, sampleError).Once()
+				repository.On("Get", ctx, prospectId).Return(prospect.Prospect{}, errSample).Once()
 				return service
 			},
 		},
@@ -104,12 +104,12 @@ func TestService_Delete(t *testing.T) {
 				ctx:        ctx,
 				prospectID: prospectId,
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *prospect.Service {
 				repository := mockService(t)
 				service := prospect.NewService(repository)
 
-				repository.On("Delete", ctx, prospectId).Return(sampleError).Once()
+				repository.On("Delete", ctx, prospectId).Return(errSample).Once()
 				return service
 			},
 		},
@@ -170,12 +170,12 @@ func TestService_Create(t *testing.T) {
 				prospect: testProspect,
 			},
 			want:    prospect.Prospect{},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *prospect.Service {
 				repository := mockService(t)
 				service := prospect.NewService(repository)
 
-				repository.On("Create", ctx, testProspect).Return(prospect.Prospect{}, sampleError).Once()
+				repository.On("Create", ctx, testProspect).Return(prospect.Prospect{}, errSample).Once()
 				return service
 			},
 		},
@@ -235,13 +235,13 @@ func TestService_List(t *testing.T) {
 				ctx:   ctx,
 				query: testQuery,
 			},
-			wantErr: sampleError,
+			wantErr: errSample,
 			want:    prospect.ListProspects{},
 			setup: func() *prospect.Service {
 				repository := mockService(t)
 				service := prospect.NewService(repository)
 
-				repository.On("List", ctx, testQuery).Return(prospect.ListProspects{}, sampleError).Once()
+				repository.On("List", ctx, testQuery).Return(prospect.ListProspects{}, errSample).Once()
 				return service
 			},
 		},
@@ -313,12 +313,12 @@ func TestService_Update(t *testing.T) {
 				prospect: testProspect,
 			},
 			want:    prospect.Prospect{},
-			wantErr: sampleError,
+			wantErr: errSample,
 			setup: func() *prospect.Service {
 				repository := mockService(t)
 				service := prospect.NewService(repository)
 
-				repository.On("Update", ctx, testProspect).Return(prospect.Prospect{}, sampleError).Once()
+				repository.On("Update", ctx, testProspect).Return(prospect.Prospect{}, errSample).Once()
 				return service
 			},
 		},

--- a/internal/store/postgres/audit_record_repository.go
+++ b/internal/store/postgres/audit_record_repository.go
@@ -106,12 +106,12 @@ func (r AuditRecordRepository) Create(ctx context.Context, auditRecord auditreco
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return auditrecord.AuditRecord{}, auditrecord.ErrInvalidUUID
 		default:
-			return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", dbErr, err)
+			return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 	transformedAuditRecord, err := auditRecordModel.transformToDomain()
 	if err != nil {
-		return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", parseErr, err)
+		return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	return transformedAuditRecord, nil
 }
@@ -145,13 +145,13 @@ func (r AuditRecordRepository) getByField(ctx context.Context, field string, val
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return auditrecord.AuditRecord{}, auditrecord.ErrInvalidUUID
 		default:
-			return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", dbErr, err)
+			return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 
 	transformedAuditRecord, err := auditRecordModel.transformToDomain()
 	if err != nil {
-		return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", parseErr, err)
+		return auditrecord.AuditRecord{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	return transformedAuditRecord, nil
 }

--- a/internal/store/postgres/audit_repository.go
+++ b/internal/store/postgres/audit_repository.go
@@ -38,15 +38,15 @@ func (a AuditRepository) Create(ctx context.Context, l *audit.Log) error {
 
 	marshaledActor, err := json.Marshal(l.Actor)
 	if err != nil {
-		return fmt.Errorf("%w: %w", err, parseErr)
+		return fmt.Errorf("%w: %w", err, errParse)
 	}
 	marshaledTarget, err := json.Marshal(l.Target)
 	if err != nil {
-		return fmt.Errorf("%w: %w", err, parseErr)
+		return fmt.Errorf("%w: %w", err, errParse)
 	}
 	marshaledMetadata, err := json.Marshal(l.Metadata)
 	if err != nil {
-		return fmt.Errorf("%w: %w", err, parseErr)
+		return fmt.Errorf("%w: %w", err, errParse)
 	}
 
 	query, params, err := dialect.Insert(TABLE_AUDITLOGS).Rows(
@@ -60,7 +60,7 @@ func (a AuditRepository) Create(ctx context.Context, l *audit.Log) error {
 			"metadata": marshaledMetadata,
 		}).Returning(&Audit{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", err, queryErr)
+		return fmt.Errorf("%w: %w", err, errQuery)
 	}
 
 	var auditModel Audit
@@ -95,7 +95,7 @@ func (a AuditRepository) List(ctx context.Context, flt audit.Filter) ([]audit.Lo
 
 	query, params, err := sqlStatement.Order(goqu.C("created_at").Desc()).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var fetched []Audit
@@ -107,7 +107,7 @@ func (a AuditRepository) List(ctx context.Context, flt audit.Filter) ([]audit.Lo
 		case errors.Is(err, sql.ErrNoRows):
 			return nil, nil
 		default:
-			return nil, fmt.Errorf("%w: %w", dbErr, err)
+			return nil, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 
@@ -126,7 +126,7 @@ func (a AuditRepository) List(ctx context.Context, flt audit.Filter) ([]audit.Lo
 	for _, v := range fetched {
 		transformedGroup, err := v.transform()
 		if err != nil {
-			return nil, fmt.Errorf("%w: %w", parseErr, err)
+			return nil, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedLogs = append(transformedLogs, transformedGroup)
 	}
@@ -144,7 +144,7 @@ func (a AuditRepository) GetByID(ctx context.Context, id string) (audit.Log, err
 			"id": id,
 		}).Where(notDisabledGroupExp).ToSQL()
 	if err != nil {
-		return audit.Log{}, fmt.Errorf("%w: %w", queryErr, err)
+		return audit.Log{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var logModel Audit

--- a/internal/store/postgres/billing_checkout_repository.go
+++ b/internal/store/postgres/billing_checkout_repository.go
@@ -158,7 +158,7 @@ func (r BillingCheckoutRepository) Create(ctx context.Context, toCreate checkout
 	}
 	query, params, err := dialect.Insert(TABLE_BILLING_CHECKOUTS).Rows(record).Returning(&Checkout{}).ToSQL()
 	if err != nil {
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", parseErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var checkoutModel Checkout
@@ -204,7 +204,7 @@ func (r BillingCheckoutRepository) Create(ctx context.Context, toCreate checkout
 			return InsertAuditRecordInTx(ctx, tx, auditRecord)
 		})
 	}); err != nil {
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", dbErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return checkoutModel.transform()
@@ -216,7 +216,7 @@ func (r BillingCheckoutRepository) GetByID(ctx context.Context, id string) (chec
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", parseErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var checkoutModel Checkout
@@ -228,7 +228,7 @@ func (r BillingCheckoutRepository) GetByID(ctx context.Context, id string) (chec
 		case errors.Is(err, sql.ErrNoRows):
 			return checkout.Checkout{}, checkout.ErrNotFound
 		}
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", dbErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return checkoutModel.transform()
@@ -240,7 +240,7 @@ func (r BillingCheckoutRepository) GetByName(ctx context.Context, name string) (
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", parseErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var checkoutModel Checkout
@@ -252,7 +252,7 @@ func (r BillingCheckoutRepository) GetByName(ctx context.Context, name string) (
 		case errors.Is(err, sql.ErrNoRows):
 			return checkout.Checkout{}, checkout.ErrNotFound
 		}
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", dbErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return checkoutModel.transform()
@@ -267,7 +267,7 @@ func (r BillingCheckoutRepository) UpdateByID(ctx context.Context, toUpdate chec
 	}
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", parseErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	updateRecord := goqu.Record{
 		"metadata":   marshaledMetadata,
@@ -283,7 +283,7 @@ func (r BillingCheckoutRepository) UpdateByID(ctx context.Context, toUpdate chec
 		"id": toUpdate.ID,
 	}).Returning(&Checkout{}).ToSQL()
 	if err != nil {
-		return checkout.Checkout{}, fmt.Errorf("%w: %s", queryErr, err)
+		return checkout.Checkout{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var customerModel Checkout
@@ -297,7 +297,7 @@ func (r BillingCheckoutRepository) UpdateByID(ctx context.Context, toUpdate chec
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return checkout.Checkout{}, checkout.ErrInvalidUUID
 		default:
-			return checkout.Checkout{}, fmt.Errorf("%w: %w", txnErr, err)
+			return checkout.Checkout{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -318,14 +318,14 @@ func (r BillingCheckoutRepository) List(ctx context.Context, flt checkout.Filter
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var checkoutModels []Checkout
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_CHECKOUTS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &checkoutModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	checkouts := make([]checkout.Checkout, 0, len(checkoutModels))

--- a/internal/store/postgres/billing_customer_repository.go
+++ b/internal/store/postgres/billing_customer_repository.go
@@ -151,7 +151,7 @@ func (r BillingCustomerRepository) Create(ctx context.Context, toCreate customer
 			"metadata": marshaledMetadata,
 		}).Returning(&Customer{}).ToSQL()
 	if err != nil {
-		return customer.Customer{}, fmt.Errorf("%w: %w", parseErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var customerModel Customer
@@ -185,7 +185,7 @@ func (r BillingCustomerRepository) Create(ctx context.Context, toCreate customer
 			return InsertAuditRecordInTx(ctx, tx, auditRecord)
 		})
 	}); err != nil {
-		return customer.Customer{}, fmt.Errorf("%w: %w", dbErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return customerModel.transform()
@@ -197,7 +197,7 @@ func (r BillingCustomerRepository) GetByID(ctx context.Context, id string) (cust
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return customer.Customer{}, fmt.Errorf("%w: %w", parseErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var customerModel Customer
@@ -209,7 +209,7 @@ func (r BillingCustomerRepository) GetByID(ctx context.Context, id string) (cust
 		case errors.Is(err, sql.ErrNoRows):
 			return customer.Customer{}, customer.ErrNotFound
 		}
-		return customer.Customer{}, fmt.Errorf("%w: %w", dbErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return customerModel.transform()
@@ -240,7 +240,7 @@ func (r BillingCustomerRepository) List(ctx context.Context, flt customer.Filter
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", parseErr, err)
+		return nil, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var customerModels []Customer
@@ -250,7 +250,7 @@ func (r BillingCustomerRepository) List(ctx context.Context, flt customer.Filter
 		if errors.Is(err, sql.ErrNoRows) {
 			return []customer.Customer{}, nil
 		}
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	customers := make([]customer.Customer, 0, len(customerModels))
@@ -277,7 +277,7 @@ func (r BillingCustomerRepository) UpdateByID(ctx context.Context, toUpdate cust
 	}
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return customer.Customer{}, fmt.Errorf("%w: %w", parseErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	// Query to fetch customer name before update
@@ -285,7 +285,7 @@ func (r BillingCustomerRepository) UpdateByID(ctx context.Context, toUpdate cust
 		Select("name").
 		Where(goqu.Ex{"id": toUpdate.ID}).ToSQL()
 	if err != nil {
-		return customer.Customer{}, fmt.Errorf("%w: %w", queryErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	updateRecord := goqu.Record{
@@ -311,7 +311,7 @@ func (r BillingCustomerRepository) UpdateByID(ctx context.Context, toUpdate cust
 		"id": toUpdate.ID,
 	}).Returning(&Customer{}).ToSQL()
 	if err != nil {
-		return customer.Customer{}, fmt.Errorf("%w: %w", queryErr, err)
+		return customer.Customer{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var customerModel Customer
@@ -363,7 +363,7 @@ func (r BillingCustomerRepository) UpdateByID(ctx context.Context, toUpdate cust
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return customer.Customer{}, customer.ErrInvalidUUID
 		default:
-			return customer.Customer{}, fmt.Errorf("%w: %w", txnErr, err)
+			return customer.Customer{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -382,7 +382,7 @@ func (r BillingCustomerRepository) UpdateCreditMinByID(ctx context.Context, cust
 		"id": customerID,
 	}).Returning(&Customer{}).ToSQL()
 	if err != nil {
-		return customer.Details{}, fmt.Errorf("%w: %w", queryErr, err)
+		return customer.Details{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var customerModel Customer
@@ -396,7 +396,7 @@ func (r BillingCustomerRepository) UpdateCreditMinByID(ctx context.Context, cust
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return customer.Details{}, customer.ErrInvalidUUID
 		default:
-			return customer.Details{}, fmt.Errorf("%w: %w", txnErr, err)
+			return customer.Details{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -412,7 +412,7 @@ func (r BillingCustomerRepository) GetDetailsByID(ctx context.Context, customerI
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return customer.Details{}, fmt.Errorf("%w: %w", parseErr, err)
+		return customer.Details{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var customerModel Customer
@@ -426,7 +426,7 @@ func (r BillingCustomerRepository) GetDetailsByID(ctx context.Context, customerI
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return customer.Details{}, customer.ErrInvalidUUID
 		default:
-			return customer.Details{}, fmt.Errorf("%w: %w", dbErr, err)
+			return customer.Details{}, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 
@@ -449,7 +449,7 @@ func (r BillingCustomerRepository) UpdateDetailsByID(ctx context.Context, custom
 		"id": customerID,
 	}).Returning(&Customer{}).ToSQL()
 	if err != nil {
-		return customer.Details{}, fmt.Errorf("%w: %w", queryErr, err)
+		return customer.Details{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var customerModel Customer
@@ -486,7 +486,7 @@ func (r BillingCustomerRepository) UpdateDetailsByID(ctx context.Context, custom
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return customer.Details{}, customer.ErrInvalidUUID
 		default:
-			return customer.Details{}, fmt.Errorf("%w: %w", txnErr, err)
+			return customer.Details{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -501,7 +501,7 @@ func (r BillingCustomerRepository) Delete(ctx context.Context, id string) error 
 		Where(goqu.Ex{"id": id}).
 		Returning(&Customer{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", parseErr, err)
+		return fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var customerModel Customer
@@ -545,7 +545,7 @@ func (r BillingCustomerRepository) Delete(ctx context.Context, id string) error 
 		case errors.Is(err, sql.ErrNoRows):
 			return customer.ErrNotFound
 		default:
-			return fmt.Errorf("%w: %w", txnErr, err)
+			return fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 

--- a/internal/store/postgres/billing_feature_repository.go
+++ b/internal/store/postgres/billing_feature_repository.go
@@ -83,14 +83,14 @@ func (r BillingFeatureRepository) Create(ctx context.Context, toCreate product.F
 			"updated_at":  goqu.L("now()"),
 		}).Returning(&Feature{}).ToSQL()
 	if err != nil {
-		return product.Feature{}, fmt.Errorf("%w: %w", parseErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var featureModel Feature
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_FEATURES, "Create", func(ctx context.Context) error {
 		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&featureModel)
 	}); err != nil {
-		return product.Feature{}, fmt.Errorf("%w: %w", dbErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return featureModel.transform()
@@ -102,7 +102,7 @@ func (r BillingFeatureRepository) GetByID(ctx context.Context, id string) (produ
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return product.Feature{}, fmt.Errorf("%w: %w", parseErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var featureModel Feature
@@ -114,7 +114,7 @@ func (r BillingFeatureRepository) GetByID(ctx context.Context, id string) (produ
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Feature{}, product.ErrFeatureNotFound
 		}
-		return product.Feature{}, fmt.Errorf("%w: %w", dbErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return featureModel.transform()
@@ -126,7 +126,7 @@ func (r BillingFeatureRepository) GetByName(ctx context.Context, name string) (p
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return product.Feature{}, fmt.Errorf("%w: %w", parseErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var featureModel Feature
@@ -138,7 +138,7 @@ func (r BillingFeatureRepository) GetByName(ctx context.Context, name string) (p
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Feature{}, product.ErrFeatureNotFound
 		}
-		return product.Feature{}, fmt.Errorf("%w: %w", dbErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return featureModel.transform()
@@ -154,14 +154,14 @@ func (r BillingFeatureRepository) List(ctx context.Context, flt product.Filter) 
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", parseErr, err)
+		return nil, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var featureModels []Feature
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_FEATURES, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &featureModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	features := make([]product.Feature, 0, len(featureModels))
@@ -187,7 +187,7 @@ func (r BillingFeatureRepository) UpdateByName(ctx context.Context, toUpdate pro
 	if toUpdate.Metadata != nil {
 		marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 		if err != nil {
-			return product.Feature{}, fmt.Errorf("%w: %s", parseErr, err)
+			return product.Feature{}, fmt.Errorf("%w: %s", errParse, err)
 		}
 		updateRecord["metadata"] = marshaledMetadata
 	}
@@ -197,7 +197,7 @@ func (r BillingFeatureRepository) UpdateByName(ctx context.Context, toUpdate pro
 		"name": toUpdate.Name,
 	}).Returning(&Feature{}).ToSQL()
 	if err != nil {
-		return product.Feature{}, fmt.Errorf("%w: %s", queryErr, err)
+		return product.Feature{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var featureModel Feature
@@ -209,7 +209,7 @@ func (r BillingFeatureRepository) UpdateByName(ctx context.Context, toUpdate pro
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Feature{}, product.ErrFeatureNotFound
 		default:
-			return product.Feature{}, fmt.Errorf("%w: %w", txnErr, err)
+			return product.Feature{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 

--- a/internal/store/postgres/billing_invoice_repository.go
+++ b/internal/store/postgres/billing_invoice_repository.go
@@ -171,14 +171,14 @@ func (r BillingInvoiceRepository) Create(ctx context.Context, toCreate invoice.I
 			"updated_at":      goqu.L("now()"),
 		}).Returning(&Invoice{}).ToSQL()
 	if err != nil {
-		return invoice.Invoice{}, fmt.Errorf("%w: %w", parseErr, err)
+		return invoice.Invoice{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var invoiceModel Invoice
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "Create", func(ctx context.Context) error {
 		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&invoiceModel)
 	}); err != nil {
-		return invoice.Invoice{}, fmt.Errorf("%w: %w", dbErr, err)
+		return invoice.Invoice{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return invoiceModel.transform()
@@ -190,7 +190,7 @@ func (r BillingInvoiceRepository) GetByID(ctx context.Context, id string) (invoi
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return invoice.Invoice{}, fmt.Errorf("%w: %w", parseErr, err)
+		return invoice.Invoice{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var invoiceModel Invoice
@@ -202,7 +202,7 @@ func (r BillingInvoiceRepository) GetByID(ctx context.Context, id string) (invoi
 		case errors.Is(err, sql.ErrNoRows):
 			return invoice.Invoice{}, invoice.ErrNotFound
 		}
-		return invoice.Invoice{}, fmt.Errorf("%w: %w", dbErr, err)
+		return invoice.Invoice{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return invoiceModel.transform()
@@ -235,14 +235,14 @@ func (r BillingInvoiceRepository) List(ctx context.Context, flt invoice.Filter) 
 		totalCountQuery, totalCountParams, err := totalCountStmt.ToSQL()
 
 		if err != nil {
-			return []invoice.Invoice{}, fmt.Errorf("%w: %w", queryErr, err)
+			return []invoice.Invoice{}, fmt.Errorf("%w: %w", errQuery, err)
 		}
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "Count", func(ctx context.Context) error {
 			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery, totalCountParams...)
 		}); err != nil {
-			return nil, fmt.Errorf("%w: %w", dbErr, err)
+			return nil, fmt.Errorf("%w: %w", errDB, err)
 		}
 
 		flt.Pagination.SetCount(totalCount)
@@ -252,14 +252,14 @@ func (r BillingInvoiceRepository) List(ctx context.Context, flt invoice.Filter) 
 	stmt = stmt.Order(goqu.I("created_at").Desc())
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", parseErr, err)
+		return nil, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var invoiceModels []Invoice
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &invoiceModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	invoices := make([]invoice.Invoice, 0, len(invoiceModels))
@@ -284,7 +284,7 @@ func (r BillingInvoiceRepository) UpdateByID(ctx context.Context, toUpdate invoi
 	if toUpdate.Metadata != nil {
 		marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 		if err != nil {
-			return invoice.Invoice{}, fmt.Errorf("%w: %s", parseErr, err)
+			return invoice.Invoice{}, fmt.Errorf("%w: %s", errParse, err)
 		}
 		updateRecord["metadata"] = marshaledMetadata
 	}
@@ -302,7 +302,7 @@ func (r BillingInvoiceRepository) UpdateByID(ctx context.Context, toUpdate invoi
 		"id": toUpdate.ID,
 	}).Returning(&Invoice{}).ToSQL()
 	if err != nil {
-		return invoice.Invoice{}, fmt.Errorf("%w: %s", queryErr, err)
+		return invoice.Invoice{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var invoiceModel Invoice
@@ -314,7 +314,7 @@ func (r BillingInvoiceRepository) UpdateByID(ctx context.Context, toUpdate invoi
 		case errors.Is(err, sql.ErrNoRows):
 			return invoice.Invoice{}, invoice.ErrNotFound
 		default:
-			return invoice.Invoice{}, fmt.Errorf("%w: %w", txnErr, err)
+			return invoice.Invoice{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -326,14 +326,14 @@ func (r BillingInvoiceRepository) Delete(ctx context.Context, id string) error {
 		"id": id,
 	}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "Delete", func(ctx context.Context) error {
 		_, err := r.dbc.ExecContext(ctx, query, params...)
 		return err
 	}); err != nil {
-		return fmt.Errorf("%w: %w", txnErr, err)
+		return fmt.Errorf("%w: %w", errTxn, err)
 	}
 	return nil
 }
@@ -349,7 +349,7 @@ func (r BillingInvoiceRepository) Search(ctx context.Context, rqlQuery *rql.Quer
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_INVOICES, "Search", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &invoiceModels, dataQuery, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	// Transform results

--- a/internal/store/postgres/billing_plan_repository.go
+++ b/internal/store/postgres/billing_plan_repository.go
@@ -186,14 +186,14 @@ func (r BillingPlanRepository) Create(ctx context.Context, toCreate plan.Plan) (
 			"updated_at":       goqu.L("now()"),
 		}).Returning(&Plan{}).ToSQL()
 	if err != nil {
-		return plan.Plan{}, fmt.Errorf("%w: %w", parseErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var planModel Plan
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_PLANS, "Create", func(ctx context.Context) error {
 		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&planModel)
 	}); err != nil {
-		return plan.Plan{}, fmt.Errorf("%w: %w", dbErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return planModel.transform()
@@ -205,7 +205,7 @@ func (r BillingPlanRepository) GetByID(ctx context.Context, id string) (plan.Pla
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return plan.Plan{}, fmt.Errorf("%w: %w", parseErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var planModel Plan
@@ -217,7 +217,7 @@ func (r BillingPlanRepository) GetByID(ctx context.Context, id string) (plan.Pla
 		case errors.Is(err, sql.ErrNoRows):
 			return plan.Plan{}, plan.ErrNotFound
 		}
-		return plan.Plan{}, fmt.Errorf("%w: %w", dbErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return planModel.transform()
@@ -229,7 +229,7 @@ func (r BillingPlanRepository) GetByName(ctx context.Context, name string) (plan
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return plan.Plan{}, fmt.Errorf("%w: %w", parseErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var planModel Plan
@@ -241,7 +241,7 @@ func (r BillingPlanRepository) GetByName(ctx context.Context, name string) (plan
 		case errors.Is(err, sql.ErrNoRows):
 			return plan.Plan{}, plan.ErrNotFound
 		}
-		return plan.Plan{}, fmt.Errorf("%w: %w", dbErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return planModel.transform()
@@ -253,7 +253,7 @@ func (r BillingPlanRepository) UpdateByName(ctx context.Context, toUpdate plan.P
 	}
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return plan.Plan{}, fmt.Errorf("%w: %w", parseErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	if toUpdate.State == "" {
@@ -273,7 +273,7 @@ func (r BillingPlanRepository) UpdateByName(ctx context.Context, toUpdate plan.P
 		"name": toUpdate.Name,
 	}).Returning(&Plan{}).ToSQL()
 	if err != nil {
-		return plan.Plan{}, fmt.Errorf("%w: %w", queryErr, err)
+		return plan.Plan{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var planModel Plan
@@ -287,7 +287,7 @@ func (r BillingPlanRepository) UpdateByName(ctx context.Context, toUpdate plan.P
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return plan.Plan{}, plan.ErrInvalidUUID
 		default:
-			return plan.Plan{}, fmt.Errorf("%w: %w", txnErr, err)
+			return plan.Plan{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -329,14 +329,14 @@ func (r BillingPlanRepository) List(ctx context.Context, filter plan.Filter) ([]
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", parseErr, err)
+		return nil, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var planModels []Plan
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_PLANS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &planModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	plans := make([]plan.Plan, 0, len(planModels))
@@ -420,14 +420,14 @@ func (r BillingPlanRepository) ListWithProducts(ctx context.Context, filter plan
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", parseErr, err)
+		return nil, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var planProductRows []PlanProductRow
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_PLANS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &planProductRows, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	planMap := map[string]plan.Plan{}

--- a/internal/store/postgres/billing_price_repository.go
+++ b/internal/store/postgres/billing_price_repository.go
@@ -114,14 +114,14 @@ func (r BillingPriceRepository) Create(ctx context.Context, toCreate product.Pri
 			"metadata":          marshaledMetadata,
 		}).Returning(&Price{}).ToSQL()
 	if err != nil {
-		return product.Price{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var priceModel Price
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_PRICES, "Create", func(ctx context.Context) error {
 		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&priceModel)
 	}); err != nil {
-		return product.Price{}, fmt.Errorf("%w: %s", dbErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return priceModel.transform()
@@ -133,7 +133,7 @@ func (r BillingPriceRepository) GetByID(ctx context.Context, id string) (product
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return product.Price{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var priceModel Price
@@ -145,7 +145,7 @@ func (r BillingPriceRepository) GetByID(ctx context.Context, id string) (product
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Price{}, product.ErrPriceNotFound
 		}
-		return product.Price{}, fmt.Errorf("%w: %s", dbErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return priceModel.transform()
@@ -157,7 +157,7 @@ func (r BillingPriceRepository) GetByName(ctx context.Context, name string) (pro
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return product.Price{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var priceModel Price
@@ -169,7 +169,7 @@ func (r BillingPriceRepository) GetByName(ctx context.Context, name string) (pro
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Price{}, product.ErrPriceNotFound
 		}
-		return product.Price{}, fmt.Errorf("%w: %s", dbErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return priceModel.transform()
@@ -181,7 +181,7 @@ func (r BillingPriceRepository) UpdateByID(ctx context.Context, toUpdate product
 	}
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return product.Price{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	updateRecord := goqu.Record{
 		"name":       toUpdate.Name,
@@ -192,7 +192,7 @@ func (r BillingPriceRepository) UpdateByID(ctx context.Context, toUpdate product
 		"id": toUpdate.ID,
 	}).Returning(&Price{}).ToSQL()
 	if err != nil {
-		return product.Price{}, fmt.Errorf("%w: %s", queryErr, err)
+		return product.Price{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var priceModel Price
@@ -204,7 +204,7 @@ func (r BillingPriceRepository) UpdateByID(ctx context.Context, toUpdate product
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Price{}, product.ErrPriceNotFound
 		default:
-			return product.Price{}, fmt.Errorf("%w: %w", txnErr, err)
+			return product.Price{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -224,7 +224,7 @@ func (r BillingPriceRepository) List(ctx context.Context, filter product.Filter)
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var priceModels []Price
@@ -234,7 +234,7 @@ func (r BillingPriceRepository) List(ctx context.Context, filter product.Filter)
 		if errors.Is(err, sql.ErrNoRows) {
 			return []product.Price{}, nil
 		}
-		return nil, fmt.Errorf("%w: %w", err, dbErr)
+		return nil, fmt.Errorf("%w: %w", err, errDB)
 	}
 
 	prices := make([]product.Price, 0, len(priceModels))

--- a/internal/store/postgres/billing_product_repository.go
+++ b/internal/store/postgres/billing_product_repository.go
@@ -127,14 +127,14 @@ func (r BillingProductRepository) Create(ctx context.Context, toCreate product.P
 			"metadata":    marshaledMetadata,
 		}).Returning(&Product{}).Prepared(true).ToSQL()
 	if err != nil {
-		return product.Product{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var productModel Product
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_PRODUCTS, "Create", func(ctx context.Context) error {
 		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&productModel)
 	}); err != nil {
-		return product.Product{}, fmt.Errorf("%w: %s", dbErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return productModel.transform()
@@ -146,7 +146,7 @@ func (r BillingProductRepository) GetByID(ctx context.Context, id string) (produ
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return product.Product{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var productModel Product
@@ -158,7 +158,7 @@ func (r BillingProductRepository) GetByID(ctx context.Context, id string) (produ
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Product{}, product.ErrProductNotFound
 		}
-		return product.Product{}, fmt.Errorf("%w: %s", dbErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return productModel.transform()
@@ -170,7 +170,7 @@ func (r BillingProductRepository) GetByName(ctx context.Context, name string) (p
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return product.Product{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var productModel Product
@@ -182,7 +182,7 @@ func (r BillingProductRepository) GetByName(ctx context.Context, name string) (p
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Product{}, product.ErrProductNotFound
 		}
-		return product.Product{}, fmt.Errorf("%w: %s", dbErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return productModel.transform()
@@ -200,14 +200,14 @@ func (r BillingProductRepository) List(ctx context.Context, flt product.Filter) 
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var productModels []Product
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_PRODUCTS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &productModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	features := make([]product.Product, 0, len(productModels))
@@ -227,7 +227,7 @@ func (r BillingProductRepository) UpdateByName(ctx context.Context, toUpdate pro
 	}
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return product.Product{}, fmt.Errorf("%w: %s", parseErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	updateRecord := goqu.Record{
 		"title":       toUpdate.Title,
@@ -246,7 +246,7 @@ func (r BillingProductRepository) UpdateByName(ctx context.Context, toUpdate pro
 		"name": toUpdate.Name,
 	}).Returning(&Product{}).ToSQL()
 	if err != nil {
-		return product.Product{}, fmt.Errorf("%w: %s", queryErr, err)
+		return product.Product{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var productModel Product
@@ -258,7 +258,7 @@ func (r BillingProductRepository) UpdateByName(ctx context.Context, toUpdate pro
 		case errors.Is(err, sql.ErrNoRows):
 			return product.Product{}, product.ErrProductNotFound
 		default:
-			return product.Product{}, fmt.Errorf("%w: %w", txnErr, err)
+			return product.Product{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 

--- a/internal/store/postgres/billing_subscription_repository.go
+++ b/internal/store/postgres/billing_subscription_repository.go
@@ -210,7 +210,7 @@ func (r BillingSubscriptionRepository) Create(ctx context.Context, toCreate subs
 		customerNameSubquery.As("customer_name"),
 	).ToSQL()
 	if err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", parseErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var result subscriptionWithCustomer
@@ -234,7 +234,7 @@ func (r BillingSubscriptionRepository) Create(ctx context.Context, toCreate subs
 			)
 		})
 	}); err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", dbErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return result.Subscription.transform()
@@ -246,7 +246,7 @@ func (r BillingSubscriptionRepository) GetByID(ctx context.Context, id string) (
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", parseErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var subscriptionModel Subscription
@@ -258,7 +258,7 @@ func (r BillingSubscriptionRepository) GetByID(ctx context.Context, id string) (
 		case errors.Is(err, sql.ErrNoRows):
 			return subscription.Subscription{}, subscription.ErrNotFound
 		}
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", dbErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return subscriptionModel.transform()
@@ -270,7 +270,7 @@ func (r BillingSubscriptionRepository) GetByName(ctx context.Context, name strin
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", parseErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var subscriptionModel Subscription
@@ -282,7 +282,7 @@ func (r BillingSubscriptionRepository) GetByName(ctx context.Context, name strin
 		case errors.Is(err, sql.ErrNoRows):
 			return subscription.Subscription{}, subscription.ErrNotFound
 		}
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", dbErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return subscriptionModel.transform()
@@ -294,7 +294,7 @@ func (r BillingSubscriptionRepository) GetByProviderID(ctx context.Context, id s
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", parseErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var subscriptionModel Subscription
@@ -306,7 +306,7 @@ func (r BillingSubscriptionRepository) GetByProviderID(ctx context.Context, id s
 		case errors.Is(err, sql.ErrNoRows):
 			return subscription.Subscription{}, subscription.ErrNotFound
 		}
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", dbErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return subscriptionModel.transform()
@@ -328,7 +328,7 @@ func (r BillingSubscriptionRepository) UpdateByID(ctx context.Context, toUpdate 
 
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", parseErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	updateRecord := goqu.Record{
@@ -372,7 +372,7 @@ func (r BillingSubscriptionRepository) UpdateByID(ctx context.Context, toUpdate 
 		customerNameSubquery.As("customer_name"),
 	).ToSQL()
 	if err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %s", queryErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var result subscriptionWithCustomer
@@ -408,7 +408,7 @@ func (r BillingSubscriptionRepository) UpdateByID(ctx context.Context, toUpdate 
 			return nil
 		})
 	}); err != nil {
-		return subscription.Subscription{}, fmt.Errorf("%w: %w", txnErr, err)
+		return subscription.Subscription{}, fmt.Errorf("%w: %w", errTxn, err)
 	}
 
 	return result.Subscription.transform()
@@ -452,14 +452,14 @@ func (r BillingSubscriptionRepository) List(ctx context.Context, filter subscrip
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var subscriptionModels []Subscription
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_SUBSCRIPTIONS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &subscriptionModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var subscriptions []subscription.Subscription
@@ -479,14 +479,14 @@ func (r BillingSubscriptionRepository) Delete(ctx context.Context, id string) er
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", parseErr, err)
+		return fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_SUBSCRIPTIONS, "Delete", func(ctx context.Context) error {
 		_, err := r.dbc.ExecContext(ctx, query, params...)
 		return err
 	}); err != nil {
-		return fmt.Errorf("%w: %s", dbErr, err)
+		return fmt.Errorf("%w: %s", errDB, err)
 	}
 	return nil
 }

--- a/internal/store/postgres/billing_transactions_repository.go
+++ b/internal/store/postgres/billing_transactions_repository.go
@@ -213,7 +213,7 @@ func (r BillingTransactionRepository) createTransactionEntry(ctx context.Context
 
 	query, params, err := dialect.Insert(TABLE_BILLING_TRANSACTIONS).Rows(record).Returning(&Transaction{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", parseErr, err)
+		return fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "Create", func(ctx context.Context) error {
@@ -225,7 +225,7 @@ func (r BillingTransactionRepository) createTransactionEntry(ctx context.Context
 				return credit.ErrAlreadyApplied
 			}
 		}
-		return fmt.Errorf("%w: %w", dbErr, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return nil
@@ -250,7 +250,7 @@ func (r BillingTransactionRepository) GetByID(ctx context.Context, id string) (c
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return credit.Transaction{}, fmt.Errorf("%w: %w", parseErr, err)
+		return credit.Transaction{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var transactionModel Transaction
@@ -262,7 +262,7 @@ func (r BillingTransactionRepository) GetByID(ctx context.Context, id string) (c
 		case errors.Is(err, sql.ErrNoRows):
 			return credit.Transaction{}, credit.ErrNotFound
 		}
-		return credit.Transaction{}, fmt.Errorf("%w: %s", dbErr, err)
+		return credit.Transaction{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return transactionModel.transform()
@@ -274,7 +274,7 @@ func (r BillingTransactionRepository) UpdateByID(ctx context.Context, toUpdate c
 	}
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return credit.Transaction{}, fmt.Errorf("%w: %s", parseErr, err)
+		return credit.Transaction{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	updateRecord := goqu.Record{
 		"metadata":   marshaledMetadata,
@@ -284,7 +284,7 @@ func (r BillingTransactionRepository) UpdateByID(ctx context.Context, toUpdate c
 		"id": toUpdate.ID,
 	}).Returning(&Transaction{}).ToSQL()
 	if err != nil {
-		return credit.Transaction{}, fmt.Errorf("%w: %s", queryErr, err)
+		return credit.Transaction{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var customerModel Transaction
@@ -298,7 +298,7 @@ func (r BillingTransactionRepository) UpdateByID(ctx context.Context, toUpdate c
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return credit.Transaction{}, credit.ErrInvalidUUID
 		default:
-			return credit.Transaction{}, fmt.Errorf("%w: %w", txnErr, err)
+			return credit.Transaction{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -329,14 +329,14 @@ func (r BillingTransactionRepository) List(ctx context.Context, filter credit.Fi
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var transactionModels []Transaction
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &transactionModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transactions []credit.Transaction
@@ -368,14 +368,14 @@ func (r BillingTransactionRepository) getDebitBalance(ctx context.Context, tx *s
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var debitBalance *int64
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "GetDebitBalance", func(ctx context.Context) error {
 		return tx.QueryRowxContext(ctx, query, params...).Scan(&debitBalance)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 	return debitBalance, nil
 }
@@ -398,14 +398,14 @@ func (r BillingTransactionRepository) getCreditBalance(ctx context.Context, tx *
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var creditBalance *int64
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "GetCreditBalance", func(ctx context.Context) error {
 		return tx.QueryRowxContext(ctx, query, params...).Scan(&creditBalance)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 	return creditBalance, nil
 }
@@ -513,14 +513,14 @@ func (r BillingTransactionRepository) getCreditBalanceExcludingSource(ctx contex
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var creditBalance *int64
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_TRANSACTIONS, "GetCreditBalanceExcludingSource", func(ctx context.Context) error {
 		return tx.QueryRowxContext(ctx, query, params...).Scan(&creditBalance)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 	return creditBalance, nil
 }

--- a/internal/store/postgres/domain_repository.go
+++ b/internal/store/postgres/domain_repository.go
@@ -40,7 +40,7 @@ func (s *DomainRepository) Create(ctx context.Context, toCreate domain.Domain) (
 			"token":  toCreate.Token,
 		}).Returning(&Domain{}).ToSQL()
 	if err != nil {
-		return domain.Domain{}, fmt.Errorf("%w: %s", parseErr, err)
+		return domain.Domain{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var domainModel Domain
@@ -51,7 +51,7 @@ func (s *DomainRepository) Create(ctx context.Context, toCreate domain.Domain) (
 		if errors.Is(err, ErrDuplicateKey) {
 			return domain.Domain{}, domain.ErrDuplicateKey
 		}
-		return domain.Domain{}, fmt.Errorf("%w: %s", dbErr, err)
+		return domain.Domain{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	dmn := domainModel.transform()
@@ -78,7 +78,7 @@ func (s *DomainRepository) List(ctx context.Context, flt domain.Filter) ([]domai
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var domains []Domain
@@ -86,7 +86,7 @@ func (s *DomainRepository) List(ctx context.Context, flt domain.Filter) ([]domai
 		return s.dbc.SelectContext(ctx, &domains, query, params...)
 	}); err != nil {
 		err = checkPostgresError(err)
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var result []domain.Domain
@@ -104,7 +104,7 @@ func (s *DomainRepository) Get(ctx context.Context, id string) (domain.Domain, e
 	}).ToSQL()
 
 	if err != nil {
-		return domain.Domain{}, fmt.Errorf("%w: %s", queryErr, err)
+		return domain.Domain{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var domainModel Domain
@@ -112,7 +112,7 @@ func (s *DomainRepository) Get(ctx context.Context, id string) (domain.Domain, e
 		return s.dbc.QueryRowxContext(ctx, query, params...).StructScan(&domainModel)
 	}); err != nil {
 		err = checkPostgresError(err)
-		return domain.Domain{}, fmt.Errorf("%w: %s", dbErr, err)
+		return domain.Domain{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	domain := domainModel.transform()
@@ -124,14 +124,14 @@ func (s *DomainRepository) Delete(ctx context.Context, id string) error {
 		"id": id,
 	}).Returning(&Domain{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_DOMAINS, "Delete", func(ctx context.Context) error {
 		result, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
 			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 
 		if count, _ := result.RowsAffected(); count > 0 {
@@ -156,7 +156,7 @@ func (s *DomainRepository) Update(ctx context.Context, toUpdate domain.Domain) (
 		"id": toUpdate.ID,
 	}).Returning(&Domain{}).ToSQL()
 	if err != nil {
-		return domain.Domain{}, fmt.Errorf("%w: %s", queryErr, err)
+		return domain.Domain{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var domainModel Domain
@@ -168,7 +168,7 @@ func (s *DomainRepository) Update(ctx context.Context, toUpdate domain.Domain) (
 		case errors.Is(err, sql.ErrNoRows):
 			return domain.Domain{}, domain.ErrNotExist
 		default:
-			return domain.Domain{}, fmt.Errorf("%w: %s", dbErr, err)
+			return domain.Domain{}, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
@@ -182,14 +182,14 @@ func (s *DomainRepository) DeleteExpiredDomainRequests(ctx context.Context) erro
 		"state":      domain.Pending,
 	}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_DOMAINS, "DeleteExpiredDomain", func(ctx context.Context) error {
 		result, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
 			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 
 		count, _ := result.RowsAffected()

--- a/internal/store/postgres/flow_repository.go
+++ b/internal/store/postgres/flow_repository.go
@@ -43,7 +43,7 @@ func (s *FlowRepository) Set(ctx context.Context, flow *authenticate.Flow) error
 	flow.Metadata["finish_url"] = flow.FinishURL
 	marshaledMetadata, err := json.Marshal(flow.Metadata)
 	if err != nil {
-		return fmt.Errorf("%w: %s", parseErr, err)
+		return fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Insert(TABLE_FLOWS).Rows(
@@ -63,7 +63,7 @@ func (s *FlowRepository) Set(ctx context.Context, flow *authenticate.Flow) error
 		"expires_at": flow.ExpiresAt,
 	})).Returning(&Flow{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var flowModel Flow
@@ -71,7 +71,7 @@ func (s *FlowRepository) Set(ctx context.Context, flow *authenticate.Flow) error
 		return s.dbc.QueryRowxContext(ctx, query, params...).StructScan(&flowModel)
 	}); err != nil {
 		err = checkPostgresError(err)
-		return fmt.Errorf("%w: %s", dbErr, err)
+		return fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return nil
@@ -86,7 +86,7 @@ func (s *FlowRepository) Get(ctx context.Context, id uuid.UUID) (*authenticate.F
 	).ToSQL()
 
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_FLOWS, "Get", func(ctx context.Context) error {
@@ -97,7 +97,7 @@ func (s *FlowRepository) Get(ctx context.Context, id uuid.UUID) (*authenticate.F
 		case errors.Is(err, sql.ErrNoRows):
 			return nil, authenticate.ErrFlowInvalid
 		default:
-			return nil, fmt.Errorf("%w: %s", dbErr, err)
+			return nil, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
@@ -112,7 +112,7 @@ func (s *FlowRepository) Delete(ctx context.Context, id uuid.UUID) error {
 			},
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_FLOWS,
@@ -120,7 +120,7 @@ func (s *FlowRepository) Delete(ctx context.Context, id uuid.UUID) error {
 			result, err := s.dbc.ExecContext(ctx, query, params...)
 			if err != nil {
 				err = checkPostgresError(err)
-				return fmt.Errorf("%w: %s", dbErr, err)
+				return fmt.Errorf("%w: %s", errDB, err)
 			}
 
 			if count, _ := result.RowsAffected(); count > 0 {
@@ -139,14 +139,14 @@ func (s *FlowRepository) DeleteExpiredFlows(ctx context.Context) error {
 			},
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_FLOWS, "DeleteExpiredFlows", func(ctx context.Context) error {
 		result, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
 			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 
 		count, _ := result.RowsAffected()

--- a/internal/store/postgres/group_repository.go
+++ b/internal/store/postgres/group_repository.go
@@ -43,7 +43,7 @@ func (r GroupRepository) GetByID(ctx context.Context, id string) (group.Group, e
 			"id": id,
 		}).Where(notDisabledGroupExp).ToSQL()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var groupModel Group
@@ -63,7 +63,7 @@ func (r GroupRepository) GetByID(ctx context.Context, id string) (group.Group, e
 
 	transformedGroup, err := groupModel.transformToGroup()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedGroup, nil
@@ -94,7 +94,7 @@ func (r GroupRepository) GetByIDs(ctx context.Context, groupIDs []string, flt gr
 	}
 	query, params, err := sqlStatement.ToSQL()
 	if err != nil {
-		return []group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []group.Group{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_GROUPS, "GetByIDs", func(ctx context.Context) error {
@@ -115,7 +115,7 @@ func (r GroupRepository) GetByIDs(ctx context.Context, groupIDs []string, flt gr
 	for _, g := range fetchedGroups {
 		transformedGroup, err := g.transformToGroup()
 		if err != nil {
-			return []group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+			return []group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 
 		transformedGroups = append(transformedGroups, transformedGroup)
@@ -131,7 +131,7 @@ func (r GroupRepository) Create(ctx context.Context, grp group.Group) (group.Gro
 
 	marshaledMetadata, err := json.Marshal(grp.Metadata)
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	insertRow := goqu.Record{
@@ -145,7 +145,7 @@ func (r GroupRepository) Create(ctx context.Context, grp group.Group) (group.Gro
 	}
 	query, params, err := dialect.Insert(TABLE_GROUPS).Rows(insertRow).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var groupModel Group
@@ -167,7 +167,7 @@ func (r GroupRepository) Create(ctx context.Context, grp group.Group) (group.Gro
 
 	transformedGroup, err := groupModel.transformToGroup()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedGroup, nil
@@ -189,7 +189,7 @@ func (r GroupRepository) List(ctx context.Context, flt group.Filter) ([]group.Gr
 
 	query, params, err := sqlStatement.ToSQL()
 	if err != nil {
-		return []group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []group.Group{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var fetchedGroups []Group
@@ -203,7 +203,7 @@ func (r GroupRepository) List(ctx context.Context, flt group.Filter) ([]group.Gr
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return []group.Group{}, nil
 		default:
-			return []group.Group{}, fmt.Errorf("%w: %w", dbErr, err)
+			return []group.Group{}, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 
@@ -211,7 +211,7 @@ func (r GroupRepository) List(ctx context.Context, flt group.Filter) ([]group.Gr
 	for _, v := range fetchedGroups {
 		transformedGroup, err := v.transformToGroup()
 		if err != nil {
-			return []group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+			return []group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedGroups = append(transformedGroups, transformedGroup)
 	}
@@ -230,7 +230,7 @@ func (r GroupRepository) UpdateByID(ctx context.Context, grp group.Group) (group
 
 	marshaledMetadata, err := json.Marshal(grp.Metadata)
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_GROUPS).Set(
@@ -243,7 +243,7 @@ func (r GroupRepository) UpdateByID(ctx context.Context, grp group.Group) (group
 		"id": grp.ID,
 	}).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", queryErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var groupModel Group
@@ -259,13 +259,13 @@ func (r GroupRepository) UpdateByID(ctx context.Context, grp group.Group) (group
 		case errors.Is(err, ErrDuplicateKey):
 			return group.Group{}, group.ErrConflict
 		default:
-			return group.Group{}, fmt.Errorf("%w: %w", dbErr, err)
+			return group.Group{}, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 
 	updated, err := groupModel.transformToGroup()
 	if err != nil {
-		return group.Group{}, fmt.Errorf("%w: %w", parseErr, err)
+		return group.Group{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return updated, nil
@@ -281,7 +281,7 @@ func (r GroupRepository) SetState(ctx context.Context, id string, state group.St
 		},
 	).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var groupModel Group
@@ -308,7 +308,7 @@ func (r GroupRepository) Delete(ctx context.Context, id string) error {
 		},
 	).Returning(&Group{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var groupModel Group

--- a/internal/store/postgres/invitation_repository.go
+++ b/internal/store/postgres/invitation_repository.go
@@ -48,7 +48,7 @@ func (s *InvitationRepository) Set(ctx context.Context, invite invitation.Invita
 	invite.Metadata["role_ids"] = invite.RoleIDs
 	marshaledMetadata, err := json.Marshal(invite.Metadata)
 	if err != nil {
-		return invitation.Invitation{}, fmt.Errorf("%w: %s", parseErr, err)
+		return invitation.Invitation{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	invite.CreatedAt = s.Now()
 	if invite.ExpiresAt.IsZero() {
@@ -82,7 +82,7 @@ func (s *InvitationRepository) Set(ctx context.Context, invite invitation.Invita
 		orgNameSubquery.As("org_name"),
 	).ToSQL()
 	if err != nil {
-		return invitation.Invitation{}, fmt.Errorf("%w: %s", queryErr, err)
+		return invitation.Invitation{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var result invitationWithContext
@@ -118,7 +118,7 @@ func (s *InvitationRepository) Set(ctx context.Context, invite invitation.Invita
 		})
 	}); err != nil {
 		err = checkPostgresError(err)
-		return invitation.Invitation{}, fmt.Errorf("%w: %s", dbErr, err)
+		return invitation.Invitation{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return result.Invitation.transformToInvitation()
@@ -132,7 +132,7 @@ func (s *InvitationRepository) Get(ctx context.Context, id uuid.UUID) (invitatio
 		},
 	).ToSQL()
 	if err != nil {
-		return invitation.Invitation{}, fmt.Errorf("%w: %s", queryErr, err)
+		return invitation.Invitation{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "Get", func(ctx context.Context) error {
@@ -143,7 +143,7 @@ func (s *InvitationRepository) Get(ctx context.Context, id uuid.UUID) (invitatio
 		case errors.Is(err, sql.ErrNoRows):
 			return invitation.Invitation{}, invitation.ErrNotFound
 		}
-		return invitation.Invitation{}, fmt.Errorf("%w: %s", dbErr, err)
+		return invitation.Invitation{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return inviteModel.transformToInvitation()
@@ -165,7 +165,7 @@ func (s *InvitationRepository) List(ctx context.Context, flt invitation.Filter) 
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "List", func(ctx context.Context) error {
@@ -174,7 +174,7 @@ func (s *InvitationRepository) List(ctx context.Context, flt invitation.Filter) 
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedInvitations []invitation.Invitation
@@ -197,7 +197,7 @@ func (s *InvitationRepository) ListByUser(ctx context.Context, id string) ([]inv
 		},
 	).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "ListByUser", func(ctx context.Context) error {
@@ -206,7 +206,7 @@ func (s *InvitationRepository) ListByUser(ctx context.Context, id string) ([]inv
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedInvitations []invitation.Invitation
@@ -229,14 +229,14 @@ func (s *InvitationRepository) Delete(ctx context.Context, id uuid.UUID) error {
 			},
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "Delete", func(ctx context.Context) error {
 		_, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
 			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 
 		return nil
@@ -254,7 +254,7 @@ func (s *InvitationRepository) ListExpired(ctx context.Context, expiredBefore ti
 			},
 		).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_INVITATIONS, "ListExpired", func(ctx context.Context) error {
@@ -263,7 +263,7 @@ func (s *InvitationRepository) ListExpired(ctx context.Context, expiredBefore ti
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedInvitations []invitation.Invitation

--- a/internal/store/postgres/kyc_repository.go
+++ b/internal/store/postgres/kyc_repository.go
@@ -53,7 +53,7 @@ func (r OrgKycRepository) GetByOrgID(ctx context.Context, orgID string) (kyc.KYC
 	}).ToSQL()
 
 	if err != nil {
-		return kyc.KYC{}, fmt.Errorf("%w: %w", queryErr, err)
+		return kyc.KYC{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var kycModel KYC
@@ -108,7 +108,7 @@ func (r OrgKycRepository) Upsert(ctx context.Context, input kyc.KYC) (kyc.KYC, e
 				goqu.I(TABLE_ORGANIZATIONS+".title").As("org_name"),
 			).ToSQL()
 		if err != nil {
-			return kyc.KYC{}, fmt.Errorf("%w: %w", queryErr, err)
+			return kyc.KYC{}, fmt.Errorf("%w: %w", errQuery, err)
 		}
 	} else if err.Error() == kyc.ErrNotExist.Error() {
 		// kyc for org doesn't exist, prepare INSERT query with subquery for org name
@@ -127,14 +127,14 @@ func (r OrgKycRepository) Upsert(ctx context.Context, input kyc.KYC) (kyc.KYC, e
 				orgNameSubquery.As("org_name"),
 			).ToSQL()
 		if err != nil {
-			return kyc.KYC{}, fmt.Errorf("%w: %w", queryErr, err)
+			return kyc.KYC{}, fmt.Errorf("%w: %w", errQuery, err)
 		}
 	} else if errors.Is(err, kyc.ErrInvalidUUID) {
 		// invalid UUID provided
 		return kyc.KYC{}, kyc.ErrInvalidUUID
 	} else {
 		// unexpected error happened in getting org kyc
-		return kyc.KYC{}, fmt.Errorf("%w: %w", queryErr, err)
+		return kyc.KYC{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
@@ -204,7 +204,7 @@ func (r OrgKycRepository) List(ctx context.Context) ([]kyc.KYC, error) {
 		).Prepared(true).ToSQL()
 
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var results []joinResult

--- a/internal/store/postgres/metaschema_repository.go
+++ b/internal/store/postgres/metaschema_repository.go
@@ -70,7 +70,7 @@ func (m MetaSchemaRepository) Get(ctx context.Context, id string) (metaschema.Me
 		},
 	).ToSQL()
 	if err != nil {
-		return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", queryErr, err)
+		return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var fetchedMetaSchema MetaSchema
@@ -82,7 +82,7 @@ func (m MetaSchemaRepository) Get(ctx context.Context, id string) (metaschema.Me
 		case errors.Is(err, sql.ErrNoRows):
 			return metaschema.MetaSchema{}, metaschema.ErrNotExist
 		default:
-			return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", dbErr, err)
+			return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
@@ -104,7 +104,7 @@ func (m MetaSchemaRepository) Create(ctx context.Context, mschema metaschema.Met
 			"schema": mschema.Schema,
 		}).OnConflict(goqu.DoNothing()).Returning(&MetaSchema{}).ToSQL()
 	if err != nil {
-		return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", queryErr, err)
+		return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var schemaModel MetaSchema
@@ -126,7 +126,7 @@ func (m MetaSchemaRepository) Create(ctx context.Context, mschema metaschema.Met
 func (m MetaSchemaRepository) List(ctx context.Context) ([]metaschema.MetaSchema, error) {
 	query, params, err := dialect.From(TABLE_METASCHEMA).ToSQL()
 	if err != nil {
-		return []metaschema.MetaSchema{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var schemaModels []MetaSchema
@@ -137,7 +137,7 @@ func (m MetaSchemaRepository) List(ctx context.Context) ([]metaschema.MetaSchema
 		if errors.Is(err, sql.ErrNoRows) {
 			return []metaschema.MetaSchema{}, metaschema.ErrNotExist
 		}
-		return []metaschema.MetaSchema{}, fmt.Errorf("%w: %s", dbErr, err)
+		return []metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedSchemas []metaschema.MetaSchema
@@ -156,7 +156,7 @@ func (m MetaSchemaRepository) Delete(ctx context.Context, id string) (string, er
 			},
 		).Returning("name").ToSQL()
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", queryErr, err)
+		return "", fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var name string
@@ -168,7 +168,7 @@ func (m MetaSchemaRepository) Delete(ctx context.Context, id string) (string, er
 		case errors.Is(err, sql.ErrNoRows):
 			return "", metaschema.ErrNotExist
 		default:
-			return "", fmt.Errorf("%w: %s", dbErr, err)
+			return "", fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
@@ -185,7 +185,7 @@ func (m MetaSchemaRepository) Update(ctx context.Context, id string, mschema met
 	}).Returning(&MetaSchema{}).ToSQL()
 
 	if err != nil {
-		return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", queryErr, err)
+		return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var schemaModel MetaSchema
@@ -197,7 +197,7 @@ func (m MetaSchemaRepository) Update(ctx context.Context, id string, mschema met
 		case errors.Is(err, sql.ErrNoRows):
 			return metaschema.MetaSchema{}, metaschema.ErrNotExist
 		default:
-			return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", dbErr, err)
+			return metaschema.MetaSchema{}, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 

--- a/internal/store/postgres/namespace_repository.go
+++ b/internal/store/postgres/namespace_repository.go
@@ -43,7 +43,7 @@ func (r NamespaceRepository) Get(ctx context.Context, id string) (namespace.Name
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return namespace.Namespace{}, fmt.Errorf("%w: %s", queryErr, err)
+		return namespace.Namespace{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var fetchedNamespace Namespace
@@ -53,7 +53,7 @@ func (r NamespaceRepository) Get(ctx context.Context, id string) (namespace.Name
 		if errors.Is(err, sql.ErrNoRows) {
 			return namespace.Namespace{}, namespace.ErrNotExist
 		}
-		return namespace.Namespace{}, fmt.Errorf("%w: %s", dbErr, err)
+		return namespace.Namespace{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return fetchedNamespace.transformToNamespace()
@@ -69,7 +69,7 @@ func (r NamespaceRepository) Upsert(ctx context.Context, ns namespace.Namespace)
 	}
 	marshaledMetadata, err := json.Marshal(ns.Metadata)
 	if err != nil {
-		return namespace.Namespace{}, fmt.Errorf("namespace metadata: %w: %s", parseErr, err)
+		return namespace.Namespace{}, fmt.Errorf("namespace metadata: %w: %s", errParse, err)
 	}
 	query, params, err := dialect.Insert(TABLE_NAMESPACES).Rows(
 		goqu.Record{
@@ -82,7 +82,7 @@ func (r NamespaceRepository) Upsert(ctx context.Context, ns namespace.Namespace)
 			"updated_at": goqu.L("now()"),
 		})).Returning(&Namespace{}).ToSQL()
 	if err != nil {
-		return namespace.Namespace{}, fmt.Errorf("%w: %s", queryErr, err)
+		return namespace.Namespace{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var nsModel Namespace
@@ -104,7 +104,7 @@ func (r NamespaceRepository) Upsert(ctx context.Context, ns namespace.Namespace)
 func (r NamespaceRepository) List(ctx context.Context) ([]namespace.Namespace, error) {
 	query, params, err := dialect.Select(&Namespace{}).From(TABLE_NAMESPACES).ToSQL()
 	if err != nil {
-		return []namespace.Namespace{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []namespace.Namespace{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var fetchedNamespaces []Namespace
@@ -114,7 +114,7 @@ func (r NamespaceRepository) List(ctx context.Context) ([]namespace.Namespace, e
 		if errors.Is(err, sql.ErrNoRows) {
 			return []namespace.Namespace{}, nil
 		}
-		return []namespace.Namespace{}, fmt.Errorf("%w: %s", dbErr, err)
+		return []namespace.Namespace{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedNamespaces []namespace.Namespace
@@ -136,7 +136,7 @@ func (r NamespaceRepository) Update(ctx context.Context, ns namespace.Namespace)
 
 	marshaledMetadata, err := json.Marshal(ns.Metadata)
 	if err != nil {
-		return namespace.Namespace{}, fmt.Errorf("namespace metadata: %w: %s", parseErr, err)
+		return namespace.Namespace{}, fmt.Errorf("namespace metadata: %w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_NAMESPACES).Set(
@@ -149,7 +149,7 @@ func (r NamespaceRepository) Update(ctx context.Context, ns namespace.Namespace)
 		},
 	).Returning(&Namespace{}).ToSQL()
 	if err != nil {
-		return namespace.Namespace{}, fmt.Errorf("%w: %s", queryErr, err)
+		return namespace.Namespace{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var nsModel Namespace

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -44,7 +44,7 @@ func (r OrganizationRepository) GetByID(ctx context.Context, id string) (organiz
 		"id": id,
 	}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization
@@ -64,7 +64,7 @@ func (r OrganizationRepository) GetByID(ctx context.Context, id string) (organiz
 
 	transformedOrg, err := orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedOrg, nil
@@ -79,7 +79,7 @@ func (r OrganizationRepository) GetByIDs(ctx context.Context, ids []string) ([]o
 		"id": goqu.Op{"in": ids},
 	}).Where(notDisabledOrgExp).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgs []Organization
@@ -119,7 +119,7 @@ func (r OrganizationRepository) GetByName(ctx context.Context, name string) (org
 		"name": name,
 	}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization
@@ -139,7 +139,7 @@ func (r OrganizationRepository) GetByName(ctx context.Context, name string) (org
 
 	transformedOrg, err := orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedOrg, nil
@@ -153,7 +153,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	insertRow := goqu.Record{
@@ -167,7 +167,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 	}
 	query, params, err := dialect.Insert(TABLE_ORGANIZATIONS).Rows(insertRow).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization
@@ -210,7 +210,7 @@ func (r OrganizationRepository) Create(ctx context.Context, org organization.Org
 
 	transformedOrg, err := orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedOrg, nil
@@ -238,14 +238,14 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 		totalCountStmt := stmt.Select(goqu.COUNT("*"))
 		totalCountQuery, totalCountParams, err := totalCountStmt.ToSQL()
 		if err != nil {
-			return []organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+			return []organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 		}
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_ORGANIZATIONS, "Count", func(ctx context.Context) error {
 			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery, totalCountParams...)
 		}); err != nil {
-			return nil, fmt.Errorf("%w: %w", dbErr, err)
+			return nil, fmt.Errorf("%w: %w", errDB, err)
 		}
 
 		flt.Pagination.SetCount(totalCount)
@@ -254,7 +254,7 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModels []Organization
@@ -264,14 +264,14 @@ func (r OrganizationRepository) List(ctx context.Context, flt organization.Filte
 		if errors.Is(err, sql.ErrNoRows) {
 			return []organization.Organization{}, nil
 		}
-		return []organization.Organization{}, fmt.Errorf("%w: %w", dbErr, err)
+		return []organization.Organization{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	var transformedOrgs []organization.Organization
 	for _, o := range orgModels {
 		transformedOrg, err := o.transformToOrg()
 		if err != nil {
-			return []organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+			return []organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedOrgs = append(transformedOrgs, transformedOrg)
 	}
@@ -327,7 +327,7 @@ func (r OrganizationRepository) UpdateByID(ctx context.Context, org organization
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	// Query to fetch org title before update
@@ -335,7 +335,7 @@ func (r OrganizationRepository) UpdateByID(ctx context.Context, org organization
 		Select("title").
 		Where(goqu.Ex{"id": org.ID}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_ORGANIZATIONS).Set(
@@ -348,7 +348,7 @@ func (r OrganizationRepository) UpdateByID(ctx context.Context, org organization
 		"id": org.ID,
 	}).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization
@@ -379,13 +379,13 @@ func (r OrganizationRepository) UpdateByID(ctx context.Context, org organization
 		case errors.Is(err, ErrInvalidTextRepresentation):
 			return organization.Organization{}, organization.ErrInvalidUUID
 		default:
-			return organization.Organization{}, fmt.Errorf("%w: %w", txnErr, err)
+			return organization.Organization{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
 	org, err = orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return org, nil
@@ -398,7 +398,7 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 
 	marshaledMetadata, err := json.Marshal(org.Metadata)
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	// Query to fetch org data before update
@@ -406,7 +406,7 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 		Select("title").
 		Where(goqu.Ex{"name": org.Name}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_ORGANIZATIONS).Set(
@@ -420,7 +420,7 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 			"name": org.Name,
 		}).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", queryErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization
@@ -448,13 +448,13 @@ func (r OrganizationRepository) UpdateByName(ctx context.Context, org organizati
 		case errors.Is(err, ErrDuplicateKey):
 			return organization.Organization{}, organization.ErrConflict
 		default:
-			return organization.Organization{}, fmt.Errorf("%w: %w", txnErr, err)
+			return organization.Organization{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
 	org, err = orgModel.transformToOrg()
 	if err != nil {
-		return organization.Organization{}, fmt.Errorf("%w: %w", parseErr, err)
+		return organization.Organization{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return org, nil
@@ -471,7 +471,7 @@ func (r OrganizationRepository) SetState(ctx context.Context, id string, state o
 		},
 	).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization
@@ -519,7 +519,7 @@ func (r OrganizationRepository) Delete(ctx context.Context, id string) error {
 		},
 	).Returning(&Organization{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var orgModel Organization

--- a/internal/store/postgres/permission_repository.go
+++ b/internal/store/postgres/permission_repository.go
@@ -42,7 +42,7 @@ func (r PermissionRepository) Get(ctx context.Context, id string) (permission.Pe
 		},
 	).ToSQL()
 	if err != nil {
-		return permission.Permission{}, fmt.Errorf("%w: %w", queryErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_PERMISSIONS, "Get", func(ctx context.Context) error {
@@ -51,7 +51,7 @@ func (r PermissionRepository) Get(ctx context.Context, id string) (permission.Pe
 		if errors.Is(err, sql.ErrNoRows) {
 			return permission.Permission{}, permission.ErrNotExist
 		}
-		return permission.Permission{}, fmt.Errorf("%w: %w", dbErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return fetchedPermission.transformToPermission()
@@ -65,7 +65,7 @@ func (r PermissionRepository) GetBySlug(ctx context.Context, slug string) (permi
 		},
 	).ToSQL()
 	if err != nil {
-		return permission.Permission{}, fmt.Errorf("%w: %w", queryErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_PERMISSIONS, "GetByName", func(ctx context.Context) error {
@@ -74,7 +74,7 @@ func (r PermissionRepository) GetBySlug(ctx context.Context, slug string) (permi
 		if errors.Is(err, sql.ErrNoRows) {
 			return permission.Permission{}, permission.ErrNotExist
 		}
-		return permission.Permission{}, fmt.Errorf("%w: %w", dbErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return fetchedPermission.transformToPermission()
@@ -87,7 +87,7 @@ func (r PermissionRepository) Upsert(ctx context.Context, perm permission.Permis
 
 	marshaledMetadata, err := json.Marshal(perm.Metadata)
 	if err != nil {
-		return permission.Permission{}, fmt.Errorf("%w: %w", parseErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	if strings.TrimSpace(perm.ID) == "" {
@@ -105,7 +105,7 @@ func (r PermissionRepository) Upsert(ctx context.Context, perm permission.Permis
 		"metadata": marshaledMetadata,
 	})).Returning(&permReturnedColumns{}).ToSQL()
 	if err != nil {
-		return permission.Permission{}, fmt.Errorf("%w: %w", queryErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var actionModel Permission
@@ -140,7 +140,7 @@ func (r PermissionRepository) List(ctx context.Context, flt permission.Filter) (
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []permission.Permission{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []permission.Permission{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_PERMISSIONS, "List", func(ctx context.Context) error {
@@ -149,7 +149,7 @@ func (r PermissionRepository) List(ctx context.Context, flt permission.Filter) (
 		if errors.Is(err, sql.ErrNoRows) {
 			return []permission.Permission{}, nil
 		}
-		return []permission.Permission{}, fmt.Errorf("%w: %w", dbErr, err)
+		return []permission.Permission{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	var transformedPermissions []permission.Permission
@@ -182,7 +182,7 @@ func (r PermissionRepository) Update(ctx context.Context, act permission.Permiss
 		"id": act.ID,
 	}).Returning(&permReturnedColumns{}).ToSQL()
 	if err != nil {
-		return permission.Permission{}, fmt.Errorf("%w: %w", queryErr, err)
+		return permission.Permission{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var actionModel Permission
@@ -210,7 +210,7 @@ func (r PermissionRepository) Delete(ctx context.Context, id string) error {
 		},
 	).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_PERMISSIONS, "Delete", func(ctx context.Context) error {

--- a/internal/store/postgres/policy_repository.go
+++ b/internal/store/postgres/policy_repository.go
@@ -53,7 +53,7 @@ func (r PolicyRepository) Get(ctx context.Context, id string) (policy.Policy, er
 			},
 		).ToSQL()
 	if err != nil {
-		return policy.Policy{}, fmt.Errorf("%w: %w", queryErr, err)
+		return policy.Policy{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var policyModel Policy
@@ -73,7 +73,7 @@ func (r PolicyRepository) Get(ctx context.Context, id string) (policy.Policy, er
 
 	transformedPolicy, err := policyModel.transformToPolicy()
 	if err != nil {
-		return policy.Policy{}, fmt.Errorf("%w: %w", parseErr, err)
+		return policy.Policy{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedPolicy, nil
@@ -151,7 +151,7 @@ func (r PolicyRepository) List(ctx context.Context, flt policy.Filter) ([]policy
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []policy.Policy{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []policy.Policy{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_POLICIES, "List", func(ctx context.Context) error {
@@ -170,7 +170,7 @@ func (r PolicyRepository) List(ctx context.Context, flt policy.Filter) ([]policy
 	for _, p := range fetchedPolicies {
 		transformedPolicy, err := p.transformToPolicy()
 		if err != nil {
-			return []policy.Policy{}, fmt.Errorf("%w: %w", parseErr, err)
+			return []policy.Policy{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedPolicies = append(transformedPolicies, transformedPolicy)
 	}
@@ -185,7 +185,7 @@ func (r PolicyRepository) Count(ctx context.Context, flt policy.Filter) (int64, 
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return count, fmt.Errorf("%w: %w", queryErr, err)
+		return count, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_POLICIES, "Count", func(ctx context.Context) error {
@@ -205,7 +205,7 @@ func (r PolicyRepository) Count(ctx context.Context, flt policy.Filter) (int64, 
 func (r PolicyRepository) Upsert(ctx context.Context, pol policy.Policy) (policy.Policy, error) {
 	marshaledMetadata, err := json.Marshal(pol.Metadata)
 	if err != nil {
-		return policy.Policy{}, fmt.Errorf("%w: %w", parseErr, err)
+		return policy.Policy{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	query, params, err := dialect.Insert(TABLE_POLICIES).Rows(
@@ -223,7 +223,7 @@ func (r PolicyRepository) Upsert(ctx context.Context, pol policy.Policy) (policy
 		"updated_at":     goqu.L("now()"),
 	})).Returning(&PolicyCols{}).ToSQL()
 	if err != nil {
-		return policy.Policy{}, fmt.Errorf("%w: %w", queryErr, err)
+		return policy.Policy{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	// Check if policy exists before upsert
@@ -261,7 +261,7 @@ func (r PolicyRepository) Upsert(ctx context.Context, pol policy.Policy) (policy
 		case errors.Is(err, ErrForeignKeyViolation):
 			return policy.Policy{}, fmt.Errorf("%w: %w", policy.ErrInvalidDetail, err)
 		default:
-			return policy.Policy{}, fmt.Errorf("%w: %s", dbErr, err)
+			return policy.Policy{}, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
@@ -281,7 +281,7 @@ func (r PolicyRepository) Update(ctx context.Context, toUpdate policy.Policy) (s
 
 	marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", parseErr, err)
+		return "", fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_POLICIES).Set(
@@ -293,7 +293,7 @@ func (r PolicyRepository) Update(ctx context.Context, toUpdate policy.Policy) (s
 		"id": toUpdate.ID,
 	}).Returning("id", "updated_at").ToSQL()
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", queryErr, err)
+		return "", fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var policyID string
@@ -349,7 +349,7 @@ func (r PolicyRepository) Delete(ctx context.Context, id string) error {
 				Where(goqu.Ex{"id": id}).
 				ToSQL()
 			if err != nil {
-				return fmt.Errorf("%w: %w", queryErr, err)
+				return fmt.Errorf("%w: %w", errQuery, err)
 			}
 			if _, err := tx.ExecContext(ctx, deleteQuery, deleteParams...); err != nil {
 				return err
@@ -474,7 +474,7 @@ func (r PolicyRepository) GroupMemberCount(ctx context.Context, groupIDs []strin
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var result []policy.MemberCount
@@ -510,7 +510,7 @@ func (r PolicyRepository) ProjectMemberCount(ctx context.Context, projectIDs []s
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var result []policy.MemberCount
@@ -546,7 +546,7 @@ func (r PolicyRepository) OrgMemberCount(ctx context.Context, id string) (policy
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return policy.MemberCount{}, fmt.Errorf("%w: %s", queryErr, err)
+		return policy.MemberCount{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var result policy.MemberCount

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -14,11 +14,11 @@ import (
 const pgUserDefinedImmutabilityError = "45000"
 
 var (
-	parseErr    = errors.New("parsing error")
-	queryErr    = errors.New("error while creating the query")
-	dbErr       = errors.New("error while running query")
-	beginTnxErr = errors.New("error while beginning transaction")
-	txnErr      = errors.New("error while running transaction")
+	errParse    = errors.New("parsing error")
+	errQuery    = errors.New("error while creating the query")
+	errDB       = errors.New("error while running query")
+	errBeginTnx = errors.New("error while beginning transaction")
+	errTxn      = errors.New("error while running transaction")
 	dialect     = goqu.Dialect("postgres")
 )
 

--- a/internal/store/postgres/preference_repository.go
+++ b/internal/store/postgres/preference_repository.go
@@ -55,7 +55,7 @@ func (s *PreferenceRepository) Set(ctx context.Context, pref preference.Preferen
 		},
 	)).Returning(&Preference{}).ToSQL()
 	if err != nil {
-		return preference.Preference{}, fmt.Errorf("%w: %s", queryErr, err)
+		return preference.Preference{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var prefModel Preference
@@ -63,7 +63,7 @@ func (s *PreferenceRepository) Set(ctx context.Context, pref preference.Preferen
 		return s.dbc.QueryRowxContext(ctx, query, params...).StructScan(&prefModel)
 	}); err != nil {
 		err = checkPostgresError(err)
-		return preference.Preference{}, fmt.Errorf("%w: %s", dbErr, err)
+		return preference.Preference{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return prefModel.transformToPreference(), nil
@@ -77,7 +77,7 @@ func (s *PreferenceRepository) Get(ctx context.Context, id uuid.UUID) (preferenc
 		},
 	).ToSQL()
 	if err != nil {
-		return preference.Preference{}, fmt.Errorf("%w: %s", queryErr, err)
+		return preference.Preference{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_PREFERENCES, "Get", func(ctx context.Context) error {
@@ -88,7 +88,7 @@ func (s *PreferenceRepository) Get(ctx context.Context, id uuid.UUID) (preferenc
 		case errors.Is(err, sql.ErrNoRows):
 			return preference.Preference{}, preference.ErrNotFound
 		}
-		return preference.Preference{}, fmt.Errorf("%w: %s", dbErr, err)
+		return preference.Preference{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return prefModel.transformToPreference(), nil
@@ -142,7 +142,7 @@ func (s *PreferenceRepository) List(ctx context.Context, flt preference.Filter) 
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_PREFERENCES, "List", func(ctx context.Context) error {
@@ -151,7 +151,7 @@ func (s *PreferenceRepository) List(ctx context.Context, flt preference.Filter) 
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedPreferences []preference.Preference

--- a/internal/store/postgres/project_repository.go
+++ b/internal/store/postgres/project_repository.go
@@ -43,7 +43,7 @@ func (r ProjectRepository) GetByID(ctx context.Context, id string) (project.Proj
 		"id": id,
 	}).Where(notDisabledProjectExp).ToSQL()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", queryErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var projectModel Project
@@ -78,7 +78,7 @@ func (r ProjectRepository) GetByName(ctx context.Context, name string) (project.
 		"name": name,
 	}).Where(notDisabledProjectExp).ToSQL()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", queryErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var projectModel Project
@@ -112,7 +112,7 @@ func (r ProjectRepository) Create(ctx context.Context, prj project.Project) (pro
 
 	marshaledMetadata, err := json.Marshal(prj.Metadata)
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", parseErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	insertRow := goqu.Record{
@@ -126,7 +126,7 @@ func (r ProjectRepository) Create(ctx context.Context, prj project.Project) (pro
 	}
 	query, params, err := dialect.Insert(TABLE_PROJECTS).Rows(insertRow).Returning(&Project{}).ToSQL()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", queryErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var projectModel Project
@@ -148,7 +148,7 @@ func (r ProjectRepository) Create(ctx context.Context, prj project.Project) (pro
 
 	transformedProj, err := projectModel.transformToProject()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", parseErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedProj, nil
@@ -188,14 +188,14 @@ func (r ProjectRepository) List(ctx context.Context, flt project.Filter) ([]proj
 		totalCountQuery, totalCountParams, err := totalCountStmt.ToSQL()
 
 		if err != nil {
-			return []project.Project{}, fmt.Errorf("%w: %w", queryErr, err)
+			return []project.Project{}, fmt.Errorf("%w: %w", errQuery, err)
 		}
 
 		var totalCount int32
 		if err = r.dbc.WithTimeout(ctx, TABLE_PROJECTS, "Count", func(ctx context.Context) error {
 			return r.dbc.GetContext(ctx, &totalCount, totalCountQuery, totalCountParams...)
 		}); err != nil {
-			return nil, fmt.Errorf("%w: %w", dbErr, err)
+			return nil, fmt.Errorf("%w: %w", errDB, err)
 		}
 
 		flt.Pagination.SetCount(totalCount)
@@ -204,7 +204,7 @@ func (r ProjectRepository) List(ctx context.Context, flt project.Filter) ([]proj
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []project.Project{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []project.Project{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var projectModels []Project
@@ -214,14 +214,14 @@ func (r ProjectRepository) List(ctx context.Context, flt project.Filter) ([]proj
 		if errors.Is(err, sql.ErrNoRows) {
 			return []project.Project{}, project.ErrNotExist
 		}
-		return []project.Project{}, fmt.Errorf("%w: %w", dbErr, err)
+		return []project.Project{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	var transformedProjects []project.Project
 	for _, p := range projectModels {
 		transformedProj, err := p.transformToProject()
 		if err != nil {
-			return []project.Project{}, fmt.Errorf("%w: %w", parseErr, err)
+			return []project.Project{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 
 		transformedProjects = append(transformedProjects, transformedProj)
@@ -237,7 +237,7 @@ func (r ProjectRepository) UpdateByID(ctx context.Context, prj project.Project) 
 
 	marshaledMetadata, err := json.Marshal(prj.Metadata)
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %s", parseErr, err)
+		return project.Project{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_PROJECTS).Set(
@@ -247,7 +247,7 @@ func (r ProjectRepository) UpdateByID(ctx context.Context, prj project.Project) 
 			"updated_at": goqu.L("now()"),
 		}).Where(goqu.Ex{"id": prj.ID}).Returning(&Project{}).ToSQL()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %s", queryErr, err)
+		return project.Project{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var projectModel Project
@@ -263,13 +263,13 @@ func (r ProjectRepository) UpdateByID(ctx context.Context, prj project.Project) 
 		case errors.Is(err, ErrDuplicateKey):
 			return project.Project{}, project.ErrConflict
 		default:
-			return project.Project{}, fmt.Errorf("%w: %s", dbErr, err)
+			return project.Project{}, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
 	prj, err = projectModel.transformToProject()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", parseErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return prj, nil
@@ -282,7 +282,7 @@ func (r ProjectRepository) UpdateByName(ctx context.Context, prj project.Project
 
 	marshaledMetadata, err := json.Marshal(prj.Metadata)
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %s", parseErr, err)
+		return project.Project{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_PROJECTS).Set(
@@ -292,7 +292,7 @@ func (r ProjectRepository) UpdateByName(ctx context.Context, prj project.Project
 			"updated_at": goqu.L("now()"),
 		}).Where(goqu.Ex{"name": prj.Name}).Returning(&Project{}).ToSQL()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %s", queryErr, err)
+		return project.Project{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var projectModel Project
@@ -308,13 +308,13 @@ func (r ProjectRepository) UpdateByName(ctx context.Context, prj project.Project
 		case errors.Is(err, ErrDuplicateKey):
 			return project.Project{}, project.ErrConflict
 		default:
-			return project.Project{}, fmt.Errorf("%w: %s", dbErr, err)
+			return project.Project{}, fmt.Errorf("%w: %s", errDB, err)
 		}
 	}
 
 	prj, err = projectModel.transformToProject()
 	if err != nil {
-		return project.Project{}, fmt.Errorf("%w: %w", parseErr, err)
+		return project.Project{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return prj, nil
@@ -330,7 +330,7 @@ func (r ProjectRepository) SetState(ctx context.Context, id string, state projec
 		},
 	).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_PROJECTS, "SetState", func(ctx context.Context) error {
@@ -357,7 +357,7 @@ func (r ProjectRepository) Delete(ctx context.Context, id string) error {
 		},
 	).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_PROJECTS, "Delete", func(ctx context.Context) error {

--- a/internal/store/postgres/prospect_repository.go
+++ b/internal/store/postgres/prospect_repository.go
@@ -55,7 +55,7 @@ func NewProspectRepository(dbc *db.Client) *ProspectRepository {
 func (r ProspectRepository) Create(ctx context.Context, prspct prospect.Prospect) (prospect.Prospect, error) {
 	marshaledMetadata, err := json.Marshal(prspct.Metadata)
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", parseErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	insertRow := goqu.Record{
@@ -71,12 +71,12 @@ func (r ProspectRepository) Create(ctx context.Context, prspct prospect.Prospect
 
 	createQuery, params, err := dialect.Insert(TABLE_PROSPECTS).Rows(insertRow).Returning(&Prospect{}).ToSQL()
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	tx, err := r.dbc.BeginTxx(ctx, nil)
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", beginTnxErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errBeginTnx, err)
 	}
 
 	var prospectModel Prospect
@@ -99,7 +99,7 @@ func (r ProspectRepository) Create(ctx context.Context, prspct prospect.Prospect
 	}
 	transformedProspect, err := prospectModel.transformToProspect()
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", parseErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	return transformedProspect, nil
 }
@@ -108,7 +108,7 @@ func (r ProspectRepository) Get(ctx context.Context, id string) (prospect.Prospe
 	stmt := dialect.From(TABLE_PROSPECTS).Where(goqu.Ex{"id": id})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var prospectModel Prospect
@@ -128,7 +128,7 @@ func (r ProspectRepository) Get(ctx context.Context, id string) (prospect.Prospe
 
 	transformedProspect, err := prospectModel.transformToProspect()
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", parseErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	return transformedProspect, nil
 }
@@ -155,7 +155,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 	// Get total row count
 	countQuery, countParams, err := countStmt.Select(goqu.L("COUNT(*) as total")).ToSQL()
 	if err != nil {
-		return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.ListProspects{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 	var totalCount int64
 	if err = r.dbc.WithTimeout(ctx, TABLE_PROSPECTS, "Count", func(ctx context.Context) error {
@@ -175,7 +175,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 
 		query, params, err := groupStmt.ToSQL()
 		if err != nil {
-			return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+			return prospect.ListProspects{}, fmt.Errorf("%w: %w", errQuery, err)
 		}
 
 		if err = r.dbc.WithTimeout(ctx, TABLE_PROSPECTS, "groupCount", func(ctx context.Context) error {
@@ -198,7 +198,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 
 	query, params, err := listStmt.ToSQL()
 	if err != nil {
-		return prospect.ListProspects{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.ListProspects{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var prospectModel []Prospect
@@ -222,7 +222,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 	for _, p := range prospectModel {
 		transformedProspect, err := p.transformToProspect()
 		if err != nil {
-			return prospect.ListProspects{}, fmt.Errorf("%w: %w", parseErr, err)
+			return prospect.ListProspects{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedProspects = append(transformedProspects, transformedProspect)
 	}
@@ -245,7 +245,7 @@ func (r ProspectRepository) List(ctx context.Context, rqlQuery *rql.Query) (pros
 func (r ProspectRepository) Update(ctx context.Context, prspct prospect.Prospect) (prospect.Prospect, error) {
 	marshaledMetadata, err := json.Marshal(prspct.Metadata)
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", parseErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	updateRow := goqu.Record{
@@ -264,12 +264,12 @@ func (r ProspectRepository) Update(ctx context.Context, prspct prospect.Prospect
 		Returning(&Prospect{}).
 		ToSQL()
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", queryErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	tx, err := r.dbc.BeginTxx(ctx, nil)
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", beginTnxErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errBeginTnx, err)
 	}
 
 	var prospectModel Prospect
@@ -297,7 +297,7 @@ func (r ProspectRepository) Update(ctx context.Context, prspct prospect.Prospect
 	}
 	transformedProspect, err := prospectModel.transformToProspect()
 	if err != nil {
-		return prospect.Prospect{}, fmt.Errorf("%w: %w", parseErr, err)
+		return prospect.Prospect{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	return transformedProspect, nil
 }
@@ -305,7 +305,7 @@ func (r ProspectRepository) Update(ctx context.Context, prspct prospect.Prospect
 func (r ProspectRepository) Delete(ctx context.Context, id string) error {
 	query, params, err := dialect.Delete(TABLE_PROSPECTS).Where(goqu.Ex{"id": id}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 	return r.dbc.WithTimeout(ctx, TABLE_PROSPECTS, "Delete", func(ctx context.Context) error {
 		_, err := r.dbc.ExecContext(ctx, query, params...)

--- a/internal/store/postgres/relation_repository.go
+++ b/internal/store/postgres/relation_repository.go
@@ -39,7 +39,7 @@ func (r RelationRepository) Upsert(ctx context.Context, relationToCreate relatio
 			"subject_namespace_name": relationToCreate.Subject.Namespace,
 		})).Returning(&relationCols{}).ToSQL()
 	if err != nil {
-		return relation.Relation{}, fmt.Errorf("%w: %s", queryErr, err)
+		return relation.Relation{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var relationModel Relation
@@ -74,7 +74,7 @@ func (r RelationRepository) List(ctx context.Context, flt relation.Filter) ([]re
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []relation.Relation{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []relation.Relation{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var fetchedRelations []Relation
@@ -85,7 +85,7 @@ func (r RelationRepository) List(ctx context.Context, flt relation.Filter) ([]re
 		if errors.Is(err, sql.ErrNoRows) {
 			return []relation.Relation{}, nil
 		}
-		return []relation.Relation{}, fmt.Errorf("%w: %s", dbErr, err)
+		return []relation.Relation{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedRelations []relation.Relation
@@ -106,7 +106,7 @@ func (r RelationRepository) Get(ctx context.Context, id string) (relation.Relati
 			"id": id,
 		}).ToSQL()
 	if err != nil {
-		return relation.Relation{}, fmt.Errorf("%w: %s", queryErr, err)
+		return relation.Relation{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var relationModel Relation
@@ -135,7 +135,7 @@ func (r RelationRepository) DeleteByID(ctx context.Context, id string) error {
 		"id": id,
 	}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return r.dbc.WithTimeout(ctx, TABLE_RELATIONS, "DeleteByID", func(ctx context.Context) error {
@@ -195,7 +195,7 @@ func (r RelationRepository) GetByFields(ctx context.Context, rel relation.Relati
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 	if err = r.dbc.WithTimeout(ctx, TABLE_RELATIONS, "GetByFields", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &fetchedRelations, query, params...)
@@ -232,7 +232,7 @@ func (r RelationRepository) ListByFields(ctx context.Context, rel relation.Relat
 	}
 	query, params, err := dialect.Select(&relationCols{}).From(TABLE_RELATIONS).Where(exprs...).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 	if err = r.dbc.WithTimeout(ctx, TABLE_RELATIONS, "GetByFields", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &fetchedRelation, query, params...)

--- a/internal/store/postgres/resource_repository.go
+++ b/internal/store/postgres/resource_repository.go
@@ -53,7 +53,7 @@ func (r ResourceRepository) Create(ctx context.Context, res resource.Resource) (
 
 	marshaledMetadata, err := json.Marshal(res.Metadata)
 	if err != nil {
-		return resource.Resource{}, fmt.Errorf("resource metadata: %w: %s", parseErr, err)
+		return resource.Resource{}, fmt.Errorf("resource metadata: %w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Insert(TABLE_RESOURCES).Rows(
@@ -78,7 +78,7 @@ func (r ResourceRepository) Create(ctx context.Context, res resource.Resource) (
 			"metadata":       marshaledMetadata,
 		})).Returning(&ResourceCols{}).ToSQL()
 	if err != nil {
-		return resource.Resource{}, fmt.Errorf("%w: %s", queryErr, err)
+		return resource.Resource{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var resourceModel Resource
@@ -130,7 +130,7 @@ func (r ResourceRepository) List(ctx context.Context, flt resource.Filter) ([]re
 		if errors.Is(err, ErrInvalidTextRepresentation) {
 			return []resource.Resource{}, nil
 		}
-		return []resource.Resource{}, fmt.Errorf("%w: %s", dbErr, err)
+		return []resource.Resource{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedResources []resource.Resource
@@ -154,7 +154,7 @@ func (r ResourceRepository) GetByID(ctx context.Context, id string) (resource.Re
 		"id": id,
 	}).ToSQL()
 	if err != nil {
-		return resource.Resource{}, fmt.Errorf("%w: %s", queryErr, err)
+		return resource.Resource{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var resourceModel Resource
@@ -182,7 +182,7 @@ func (r ResourceRepository) Update(ctx context.Context, res resource.Resource) (
 
 	marshaledMetadata, err := json.Marshal(res.Metadata)
 	if err != nil {
-		return resource.Resource{}, fmt.Errorf("resource metadata: %w: %s", parseErr, err)
+		return resource.Resource{}, fmt.Errorf("resource metadata: %w: %s", errParse, err)
 	}
 	query, params, err := dialect.Update(TABLE_RESOURCES).Set(
 		goqu.Record{
@@ -191,7 +191,7 @@ func (r ResourceRepository) Update(ctx context.Context, res resource.Resource) (
 		},
 	).Where(goqu.Ex{"id": res.ID}).Returning(&ResourceCols{}).ToSQL()
 	if err != nil {
-		return resource.Resource{}, fmt.Errorf("%w: %s", queryErr, err)
+		return resource.Resource{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var resourceModel Resource
@@ -226,7 +226,7 @@ func (r ResourceRepository) GetByURN(ctx context.Context, urn string) (resource.
 			"urn": urn,
 		}).ToSQL()
 	if err != nil {
-		return resource.Resource{}, fmt.Errorf("%w: %s", queryErr, err)
+		return resource.Resource{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var resourceModel Resource
@@ -249,7 +249,7 @@ func (r ResourceRepository) Delete(ctx context.Context, id string) error {
 		},
 	).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_RESOURCES, "Delete", func(ctx context.Context) error {

--- a/internal/store/postgres/role_repository.go
+++ b/internal/store/postgres/role_repository.go
@@ -58,7 +58,7 @@ func (r RoleRepository) Get(ctx context.Context, id string) (role.Role, error) {
 			goqu.Ex{"r.id": id},
 		).ToSQL()
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %w", queryErr, err)
+		return role.Role{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var roleModel Role
@@ -68,7 +68,7 @@ func (r RoleRepository) Get(ctx context.Context, id string) (role.Role, error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			return role.Role{}, role.ErrNotExist
 		}
-		return role.Role{}, fmt.Errorf("%w: %w", dbErr, err)
+		return role.Role{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return roleModel.transformToRole()
@@ -87,7 +87,7 @@ func (r RoleRepository) GetByName(ctx context.Context, orgID, name string) (role
 			goqu.Ex{"r.org_id": orgID},
 		).ToSQL()
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %w", queryErr, err)
+		return role.Role{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var roleModel Role
@@ -97,7 +97,7 @@ func (r RoleRepository) GetByName(ctx context.Context, orgID, name string) (role
 		if errors.Is(err, sql.ErrNoRows) {
 			return role.Role{}, role.ErrNotExist
 		}
-		return role.Role{}, fmt.Errorf("%w: %w", dbErr, err)
+		return role.Role{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return roleModel.transformToRole()
@@ -114,12 +114,12 @@ func (r RoleRepository) Upsert(ctx context.Context, rl role.Role) (role.Role, er
 
 	marshaledMetadata, err := json.Marshal(rl.Metadata)
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %w", parseErr, err)
+		return role.Role{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	marshaledPermissions, err := json.Marshal(rl.Permissions)
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %s", parseErr, err)
+		return role.Role{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Insert(TABLE_ROLES).Rows(
@@ -140,7 +140,7 @@ func (r RoleRepository) Upsert(ctx context.Context, rl role.Role) (role.Role, er
 		"scopes":      pq.Array(rl.Scopes),
 	})).Returning(&Role{}).ToSQL()
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %s", queryErr, err)
+		return role.Role{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var roleDB Role
@@ -180,21 +180,21 @@ func (r RoleRepository) List(ctx context.Context, flt role.Filter) ([]role.Role,
 
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return []role.Role{}, fmt.Errorf("%w: %s", queryErr, err)
+		return []role.Role{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var fetchedRoles []Role
 	if err = r.dbc.WithTimeout(ctx, TABLE_ROLES, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &fetchedRoles, query, params...)
 	}); err != nil {
-		return []role.Role{}, fmt.Errorf("%w: %w", err, dbErr)
+		return []role.Role{}, fmt.Errorf("%w: %w", err, errDB)
 	}
 
 	var transformedRoles []role.Role
 	for _, o := range fetchedRoles {
 		transformedRole, err := o.transformToRole()
 		if err != nil {
-			return []role.Role{}, fmt.Errorf("%w: %s", parseErr, err)
+			return []role.Role{}, fmt.Errorf("%w: %s", errParse, err)
 		}
 		transformedRoles = append(transformedRoles, transformedRole)
 	}
@@ -213,11 +213,11 @@ func (r RoleRepository) Update(ctx context.Context, rl role.Role) (role.Role, er
 
 	marshaledMetadata, err := json.Marshal(rl.Metadata)
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %s", parseErr, err)
+		return role.Role{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	marshaledPermissions, err := json.Marshal(rl.Permissions)
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %s", parseErr, err)
+		return role.Role{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_ROLES).Set(
@@ -233,7 +233,7 @@ func (r RoleRepository) Update(ctx context.Context, rl role.Role) (role.Role, er
 		goqu.Ex{"id": rl.ID},
 	).Returning(&Role{}).ToSQL()
 	if err != nil {
-		return role.Role{}, fmt.Errorf("%w: %s", queryErr, err)
+		return role.Role{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var roleDB Role
@@ -263,7 +263,7 @@ func (r RoleRepository) Delete(ctx context.Context, id string) error {
 		},
 	).Returning(&Role{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var roleModel Role
@@ -298,7 +298,7 @@ func (r RoleRepository) RemovePermissionFromRoles(ctx context.Context, slug stri
 		goqu.L("permissions @> ?::jsonb", fmt.Sprintf("[%q]", slug)),
 	).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return r.dbc.WithTimeout(ctx, TABLE_ROLES, "RemovePermissionFromRoles", func(ctx context.Context) error {

--- a/internal/store/postgres/serviceuser_credential_repository.go
+++ b/internal/store/postgres/serviceuser_credential_repository.go
@@ -58,21 +58,21 @@ func (s ServiceUserCredentialRepository) List(ctx context.Context, flt serviceus
 
 	query, params, err := stmt.From(goqu.T(TABLE_SERVICEUSERCREDENTIALS).As("s")).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var svUserCreds []ServiceUserCredential
 	if err = s.dbc.WithTimeout(ctx, TABLE_SERVICEUSERCREDENTIALS, "List", func(ctx context.Context) error {
 		return s.dbc.SelectContext(ctx, &svUserCreds, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	var transformedServiceUsers []serviceuser.Credential
 	for _, o := range svUserCreds {
 		transformedServiceUser, err := o.transform()
 		if err != nil {
-			return nil, fmt.Errorf("%w: %w", parseErr, err)
+			return nil, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedServiceUsers = append(transformedServiceUsers, transformedServiceUser)
 	}
@@ -87,12 +87,12 @@ func (s ServiceUserCredentialRepository) Create(ctx context.Context, credential 
 
 	marshaledMetadata, err := json.Marshal(credential.Metadata)
 	if err != nil {
-		return serviceuser.Credential{}, fmt.Errorf("%w: %w", parseErr, err)
+		return serviceuser.Credential{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	publicKeyJson, err := json.Marshal(credential.PublicKey)
 	if err != nil {
-		return serviceuser.Credential{}, fmt.Errorf("%w: %w", parseErr, err)
+		return serviceuser.Credential{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	svUserCred := ServiceUserCredential{}
@@ -111,13 +111,13 @@ func (s ServiceUserCredentialRepository) Create(ctx context.Context, credential 
 			"metadata": marshaledMetadata,
 		})).Returning(&ServiceUserCredential{}).ToSQL()
 	if err != nil {
-		return serviceuser.Credential{}, fmt.Errorf("%w: %w", queryErr, err)
+		return serviceuser.Credential{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_SERVICEUSERCREDENTIALS, "Create", func(ctx context.Context) error {
 		return s.dbc.QueryRowxContext(ctx, query, params...).StructScan(&svUserCred)
 	}); err != nil {
-		return serviceuser.Credential{}, fmt.Errorf("%w: %w", dbErr, err)
+		return serviceuser.Credential{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return svUserCred.transform()
@@ -142,7 +142,7 @@ func (s ServiceUserCredentialRepository) Get(ctx context.Context, id string) (se
 		goqu.Ex{"s.id": id},
 	).From(goqu.T(TABLE_SERVICEUSERCREDENTIALS).As("s")).ToSQL()
 	if err != nil {
-		return serviceuser.Credential{}, fmt.Errorf("%w: %w", queryErr, err)
+		return serviceuser.Credential{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var svUserCredentialModel ServiceUserCredential
@@ -152,7 +152,7 @@ func (s ServiceUserCredentialRepository) Get(ctx context.Context, id string) (se
 		if errors.Is(err, sql.ErrNoRows) {
 			return serviceuser.Credential{}, serviceuser.ErrCredNotExist
 		}
-		return serviceuser.Credential{}, fmt.Errorf("%w: %w", dbErr, err)
+		return serviceuser.Credential{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return svUserCredentialModel.transform()
@@ -165,7 +165,7 @@ func (s ServiceUserCredentialRepository) Delete(ctx context.Context, id string) 
 		},
 	).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTimeout(ctx, TABLE_SERVICEUSERCREDENTIALS, "Delete", func(ctx context.Context) error {

--- a/internal/store/postgres/serviceuser_repository.go
+++ b/internal/store/postgres/serviceuser_repository.go
@@ -64,21 +64,21 @@ func (s ServiceUserRepository) List(ctx context.Context, flt serviceuser.Filter)
 
 	query, params, err := stmt.From(goqu.T(TABLE_SERVICEUSER).As("s")).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var fetchedServiceUsers []ServiceUser
 	if err = s.dbc.WithTimeout(ctx, TABLE_SERVICEUSER, "List", func(ctx context.Context) error {
 		return s.dbc.SelectContext(ctx, &fetchedServiceUsers, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	var transformedServiceUsers []serviceuser.ServiceUser
 	for _, o := range fetchedServiceUsers {
 		transformedServiceUser, err := o.transform()
 		if err != nil {
-			return nil, fmt.Errorf("%w: %w", parseErr, err)
+			return nil, fmt.Errorf("%w: %w", errParse, err)
 		}
 		transformedServiceUsers = append(transformedServiceUsers, transformedServiceUser)
 	}
@@ -93,7 +93,7 @@ func (s ServiceUserRepository) Create(ctx context.Context, serviceUser serviceus
 
 	marshaledMetadata, err := json.Marshal(serviceUser.Metadata)
 	if err != nil {
-		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", parseErr, err)
+		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var result serviceUserWithContext
@@ -117,7 +117,7 @@ func (s ServiceUserRepository) Create(ctx context.Context, serviceUser serviceus
 		orgNameSubquery.As("org_name"),
 	).ToSQL()
 	if err != nil {
-		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", queryErr, err)
+		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = s.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
@@ -146,7 +146,7 @@ func (s ServiceUserRepository) Create(ctx context.Context, serviceUser serviceus
 			return InsertAuditRecordInTx(ctx, tx, auditRecord)
 		})
 	}); err != nil {
-		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", dbErr, err)
+		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return result.ServiceUser.transform()
@@ -169,7 +169,7 @@ func (s ServiceUserRepository) GetByID(ctx context.Context, id string) (serviceu
 		goqu.Ex{"s.id": id},
 	).From(goqu.T(TABLE_SERVICEUSER).As("s")).ToSQL()
 	if err != nil {
-		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", queryErr, err)
+		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var serviceUserModel ServiceUser
@@ -179,7 +179,7 @@ func (s ServiceUserRepository) GetByID(ctx context.Context, id string) (serviceu
 		if errors.Is(err, sql.ErrNoRows) {
 			return serviceuser.ServiceUser{}, serviceuser.ErrNotExist
 		}
-		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", dbErr, err)
+		return serviceuser.ServiceUser{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return serviceUserModel.transform()
@@ -203,7 +203,7 @@ func (s ServiceUserRepository) GetByIDs(ctx context.Context, ids []string) ([]se
 		goqu.Ex{"s.id": goqu.Op{"in": ids}},
 	).From(goqu.T(TABLE_SERVICEUSER).As("s")).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var fetchedUsers []ServiceUser
@@ -213,7 +213,7 @@ func (s ServiceUserRepository) GetByIDs(ctx context.Context, ids []string) ([]se
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, serviceuser.ErrNotExist
 		}
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var transformedUsers []serviceuser.ServiceUser
@@ -250,7 +250,7 @@ func (s ServiceUserRepository) ListMissingOrgPolicy(ctx context.Context) ([]boot
 			goqu.L("NOT EXISTS ?", policiesSubquery),
 		).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	type row struct {
@@ -264,7 +264,7 @@ func (s ServiceUserRepository) ListMissingOrgPolicy(ctx context.Context) ([]boot
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	candidates := make([]bootstrap.ServiceUserCandidate, 0, len(rows))
@@ -291,7 +291,7 @@ func (s ServiceUserRepository) Delete(ctx context.Context, id string) error {
 			orgNameSubquery.As("org_name"),
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {

--- a/internal/store/postgres/session_repository.go
+++ b/internal/store/postgres/session_repository.go
@@ -42,7 +42,7 @@ func (s *SessionRepository) Set(ctx context.Context, session *frontiersession.Se
 
 	marshaledMetadata, err := json.Marshal(session.Metadata)
 	if err != nil {
-		return fmt.Errorf("%w: %s", parseErr, err)
+		return fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	query, params, err := dialect.Insert(TABLE_SESSIONS).Rows(
@@ -56,7 +56,7 @@ func (s *SessionRepository) Set(ctx context.Context, session *frontiersession.Se
 			"metadata":         marshaledMetadata,
 		}).Returning(&Session{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var sessionModel Session
@@ -64,7 +64,7 @@ func (s *SessionRepository) Set(ctx context.Context, session *frontiersession.Se
 		return s.dbc.QueryRowxContext(ctx, query, params...).StructScan(&sessionModel)
 	}); err != nil {
 		err = checkPostgresError(err)
-		return fmt.Errorf("%w: %s", dbErr, err)
+		return fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return nil
@@ -77,7 +77,7 @@ func (s *SessionRepository) Get(ctx context.Context, id uuid.UUID) (*frontierses
 			"id": id,
 		}).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err := s.dbc.WithTimeout(ctx, TABLE_SESSIONS, "Get", func(ctx context.Context) error {
@@ -86,9 +86,9 @@ func (s *SessionRepository) Get(ctx context.Context, id uuid.UUID) (*frontierses
 		err = checkPostgresError(err)
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			return nil, fmt.Errorf("%w: %w", dbErr, frontiersession.ErrNoSession)
+			return nil, fmt.Errorf("%w: %w", errDB, frontiersession.ErrNoSession)
 		default:
-			return nil, fmt.Errorf("%w: %w", dbErr, err)
+			return nil, fmt.Errorf("%w: %w", errDB, err)
 		}
 	}
 
@@ -120,7 +120,7 @@ func (s *SessionRepository) Delete(ctx context.Context, id uuid.UUID) error {
 			userNameSubquery.As("user_name"),
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = s.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
@@ -135,7 +135,7 @@ func (s *SessionRepository) Delete(ctx context.Context, id uuid.UUID) error {
 			return s.createSessionRevokeAuditRecord(ctx, tx, result)
 		})
 	}); err != nil {
-		return fmt.Errorf("%w: %w", dbErr, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return nil
@@ -188,14 +188,14 @@ func (s *SessionRepository) DeleteExpiredSessions(ctx context.Context) error {
 			),
 		).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_SESSIONS, "DeleteExpiredSessions", func(ctx context.Context) error {
 		result, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
 			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 
 		count, _ := result.RowsAffected()
@@ -214,14 +214,14 @@ func (s *SessionRepository) UpdateValidity(ctx context.Context, id uuid.UUID, va
 	}).ToSQL()
 
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	return s.dbc.WithTimeout(ctx, TABLE_SESSIONS, "Update", func(ctx context.Context) error {
 		result, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
 			err = checkPostgresError(err)
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 
 		if count, _ := result.RowsAffected(); count > 0 {
@@ -245,12 +245,12 @@ func (s *SessionRepository) UpdateSessionMetadata(ctx context.Context, id uuid.U
 		},
 	).Where(goqu.Ex{"id": id}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 	return s.dbc.WithTimeout(ctx, TABLE_SESSIONS, "UpdateSessionMetadata", func(ctx context.Context) error {
 		result, err := s.dbc.ExecContext(ctx, query, params...)
 		if err != nil {
-			return fmt.Errorf("%w: %s", dbErr, err)
+			return fmt.Errorf("%w: %s", errDB, err)
 		}
 		if count, _ := result.RowsAffected(); count == 0 {
 			return sql.ErrNoRows
@@ -271,14 +271,14 @@ func (s *SessionRepository) List(ctx context.Context, userID string) ([]*frontie
 			"deleted_at": nil,
 		}).Order(goqu.I("created_at").Desc()).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", queryErr, err)
+		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var sessions []*Session
 	if err := s.dbc.WithTimeout(ctx, TABLE_SESSIONS, "List", func(ctx context.Context) error {
 		return s.dbc.SelectContext(ctx, &sessions, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	var domainSessions []*frontiersession.Session

--- a/internal/store/postgres/user_repository.go
+++ b/internal/store/postgres/user_repository.go
@@ -49,7 +49,7 @@ func (r UserRepository) GetByID(ctx context.Context, id string) (user.User, erro
 			"id": id,
 		}).Where(notDisabledUserExp).ToSQL()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", queryErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_USERS, "GetByID", func(ctx context.Context) error {
@@ -70,7 +70,7 @@ func (r UserRepository) GetByID(ctx context.Context, id string) (user.User, erro
 
 	transformedUser, err := fetchedUser.transformToUser()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", parseErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedUser, nil
@@ -87,7 +87,7 @@ func (r UserRepository) GetByName(ctx context.Context, name string) (user.User, 
 			"name": strings.ToLower(name),
 		}).ToSQL()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", queryErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_USERS, "GetByName", func(ctx context.Context) error {
@@ -104,7 +104,7 @@ func (r UserRepository) GetByName(ctx context.Context, name string) (user.User, 
 
 	transformedUser, err := fetchedUser.transformToUser()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", parseErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	return transformedUser, nil
@@ -126,7 +126,7 @@ func (r UserRepository) Create(ctx context.Context, usr user.User) (user.User, e
 	if usr.Metadata != nil {
 		marshaledMetadata, err := json.Marshal(usr.Metadata)
 		if err != nil {
-			return user.User{}, fmt.Errorf("%w: %w", parseErr, err)
+			return user.User{}, fmt.Errorf("%w: %w", errParse, err)
 		}
 		insertRow["metadata"] = marshaledMetadata
 	}
@@ -135,7 +135,7 @@ func (r UserRepository) Create(ctx context.Context, usr user.User) (user.User, e
 	}
 	createQuery, params, err := dialect.Insert(TABLE_USERS).Rows(insertRow).Returning(&User{}).ToSQL()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", queryErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	tx, err := r.dbc.BeginTxx(ctx, nil)
@@ -166,7 +166,7 @@ func (r UserRepository) Create(ctx context.Context, usr user.User) (user.User, e
 
 	transformedUser, err := userModel.transformToUser()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", parseErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	return transformedUser, nil
 }
@@ -201,7 +201,7 @@ func (r UserRepository) List(ctx context.Context, flt user.Filter) ([]user.User,
 
 	query, params, err := sqlStmt.Limit(uint(flt.Limit)).Offset(uint(offset)).ToSQL()
 	if err != nil {
-		return []user.User{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []user.User{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var dbUsers []User
@@ -211,7 +211,7 @@ func (r UserRepository) List(ctx context.Context, flt user.Filter) ([]user.User,
 		if errors.Is(err, sql.ErrNoRows) {
 			return []user.User{}, nil
 		}
-		return []user.User{}, fmt.Errorf("%w: %w", dbErr, err)
+		return []user.User{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	var transformedUsers []user.User
@@ -237,7 +237,7 @@ func (r UserRepository) GetByIDs(ctx context.Context, userIDs []string) ([]user.
 			"id": goqu.Op{"in": userIDs},
 		}).Where(notDisabledUserExp).ToSQL()
 	if err != nil {
-		return []user.User{}, fmt.Errorf("%w: %w", queryErr, err)
+		return []user.User{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_USERS, "GetByIDs", func(ctx context.Context) error {
@@ -272,7 +272,7 @@ func (r UserRepository) UpdateByEmail(ctx context.Context, usr user.User) (user.
 	}
 	marshaledMetadata, err := json.Marshal(usr.Metadata)
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %w", parseErr, err)
+		return user.User{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 	var transformedUser user.User
 
@@ -289,7 +289,7 @@ func (r UserRepository) UpdateByEmail(ctx context.Context, usr user.User) (user.
 			},
 		).Returning(&User{}).ToSQL()
 		if err != nil {
-			return fmt.Errorf("%w: %s", queryErr, err)
+			return fmt.Errorf("%w: %s", errQuery, err)
 		}
 
 		var userModel User
@@ -299,12 +299,12 @@ func (r UserRepository) UpdateByEmail(ctx context.Context, usr user.User) (user.
 			if errors.Is(err, sql.ErrNoRows) {
 				return user.ErrNotExist
 			}
-			return fmt.Errorf("%w: %w", txnErr, err)
+			return fmt.Errorf("%w: %w", errTxn, err)
 		}
 
 		transformedUser, err = userModel.transformToUser()
 		if err != nil {
-			return fmt.Errorf("%w: %w", parseErr, err)
+			return fmt.Errorf("%w: %w", errParse, err)
 		}
 
 		return nil
@@ -324,7 +324,7 @@ func (r UserRepository) UpdateByID(ctx context.Context, usr user.User) (user.Use
 
 	marshaledMetadata, err := json.Marshal(usr.Metadata)
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %s", parseErr, err)
+		return user.User{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 	var transformedUser user.User
 	err = r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
@@ -340,7 +340,7 @@ func (r UserRepository) UpdateByID(ctx context.Context, usr user.User) (user.Use
 			},
 		).Returning(&User{}).ToSQL()
 		if err != nil {
-			return fmt.Errorf("%w: %s", queryErr, err)
+			return fmt.Errorf("%w: %s", errQuery, err)
 		}
 
 		var userModel User
@@ -360,7 +360,7 @@ func (r UserRepository) UpdateByID(ctx context.Context, usr user.User) (user.Use
 
 		transformedUser, err = userModel.transformToUser()
 		if err != nil {
-			return fmt.Errorf("%w: %w", parseErr, err)
+			return fmt.Errorf("%w: %w", errParse, err)
 		}
 
 		return nil
@@ -386,7 +386,7 @@ func (r UserRepository) UpdateByName(ctx context.Context, usr user.User) (user.U
 	if len(usr.Metadata) > 0 {
 		marshaledMetadata, err := json.Marshal(usr.Metadata)
 		if err != nil {
-			return user.User{}, fmt.Errorf("%w: %s", parseErr, err)
+			return user.User{}, fmt.Errorf("%w: %s", errParse, err)
 		}
 		updateRecord["metadata"] = marshaledMetadata
 	}
@@ -397,7 +397,7 @@ func (r UserRepository) UpdateByName(ctx context.Context, usr user.User) (user.U
 		},
 	).Returning(&User{}).ToSQL()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %s", queryErr, err)
+		return user.User{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var userModel User
@@ -437,7 +437,7 @@ func (r UserRepository) GetByEmail(ctx context.Context, email string) (user.User
 		}).Where(notDisabledUserExp).ToSQL()
 
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %s", queryErr, err)
+		return user.User{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_USERS, "GetByEmail", func(ctx context.Context) error {
@@ -446,12 +446,12 @@ func (r UserRepository) GetByEmail(ctx context.Context, email string) (user.User
 		if errors.Is(err, sql.ErrNoRows) {
 			return user.User{}, user.ErrNotExist
 		}
-		return user.User{}, fmt.Errorf("%w: %s", dbErr, err)
+		return user.User{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	transformedUser, err := fetchedUser.transformToUser()
 	if err != nil {
-		return user.User{}, fmt.Errorf("%w: %s", parseErr, err)
+		return user.User{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	return transformedUser, nil
@@ -467,7 +467,7 @@ func (r UserRepository) SetState(ctx context.Context, id string, state user.Stat
 		},
 	).Returning(&User{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var userModel User
@@ -492,7 +492,7 @@ func (r UserRepository) Delete(ctx context.Context, id string) error {
 		},
 	).Returning(&User{}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var userModel User

--- a/internal/store/postgres/userpat_repository.go
+++ b/internal/store/postgres/userpat_repository.go
@@ -42,7 +42,7 @@ func (r UserPATRepository) Create(ctx context.Context, pat models.PAT) (models.P
 
 	marshaledMetadata, err := json.Marshal(pat.Metadata)
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", parseErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	var model UserPAT
@@ -57,7 +57,7 @@ func (r UserPATRepository) Create(ctx context.Context, pat models.PAT) (models.P
 			"expires_at":  pat.ExpiresAt,
 		}).Returning(&UserPAT{}).ToSQL()
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", queryErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "Create", func(ctx context.Context) error {
@@ -67,7 +67,7 @@ func (r UserPATRepository) Create(ctx context.Context, pat models.PAT) (models.P
 		if errors.Is(err, ErrDuplicateKey) {
 			return models.PAT{}, paterrors.ErrConflict
 		}
-		return models.PAT{}, fmt.Errorf("%w: %w", dbErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return model.transform()
@@ -82,14 +82,14 @@ func (r UserPATRepository) CountActive(ctx context.Context, userID, orgID string
 		goqu.C("expires_at").Gt(now),
 	).ToSQL()
 	if err != nil {
-		return 0, fmt.Errorf("%w: %w", queryErr, err)
+		return 0, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var count int64
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "CountActive", func(ctx context.Context) error {
 		return r.dbc.GetContext(ctx, &count, query, params...)
 	}); err != nil {
-		return 0, fmt.Errorf("%w: %w", dbErr, err)
+		return 0, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return count, nil
@@ -103,7 +103,7 @@ func (r UserPATRepository) GetByID(ctx context.Context, id string) (models.PAT, 
 			goqu.Ex{"deleted_at": nil},
 		).Limit(1).ToSQL()
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", queryErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var model UserPAT
@@ -114,7 +114,7 @@ func (r UserPATRepository) GetByID(ctx context.Context, id string) (models.PAT, 
 		if errors.Is(err, sql.ErrNoRows) {
 			return models.PAT{}, paterrors.ErrNotFound
 		}
-		return models.PAT{}, fmt.Errorf("%w: %w", dbErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return model.transform()
@@ -142,7 +142,7 @@ func (r UserPATRepository) List(ctx context.Context, userID, orgID string, rqlQu
 
 	query, params, err := listStmt.ToSQL()
 	if err != nil {
-		return models.PATList{}, fmt.Errorf("%w: %w", queryErr, err)
+		return models.PATList{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var rows []UserPAT
@@ -153,7 +153,7 @@ func (r UserPATRepository) List(ctx context.Context, userID, orgID string, rqlQu
 		if errors.Is(err, sql.ErrNoRows) {
 			return models.PATList{}, nil
 		}
-		return models.PATList{}, fmt.Errorf("%w: %w", dbErr, err)
+		return models.PATList{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	pats := make([]models.PAT, 0, len(rows))
@@ -202,7 +202,7 @@ func (r UserPATRepository) buildPATFilteredQuery(userID, orgID string, rqlQuery 
 func (r UserPATRepository) countPATs(ctx context.Context, baseStmt *goqu.SelectDataset) (int64, error) {
 	countQuery, countParams, err := baseStmt.Select(goqu.L("COUNT(*) as total")).ToSQL()
 	if err != nil {
-		return 0, fmt.Errorf("%w: %w", queryErr, err)
+		return 0, fmt.Errorf("%w: %w", errQuery, err)
 	}
 	var totalCount int64
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "ListCount", func(ctx context.Context) error {
@@ -212,7 +212,7 @@ func (r UserPATRepository) countPATs(ctx context.Context, baseStmt *goqu.SelectD
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
-		return 0, fmt.Errorf("%w: %w", dbErr, err)
+		return 0, fmt.Errorf("%w: %w", errDB, err)
 	}
 	return totalCount, nil
 }
@@ -227,14 +227,14 @@ func (r UserPATRepository) IsTitleAvailable(ctx context.Context, userID, orgID, 
 		).Limit(1),
 	)).ToSQL()
 	if err != nil {
-		return false, fmt.Errorf("%w: %w", queryErr, err)
+		return false, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var available bool
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "IsTitleAvailable", func(ctx context.Context) error {
 		return r.dbc.GetContext(ctx, &available, query, params...)
 	}); err != nil {
-		return false, fmt.Errorf("%w: %w", dbErr, err)
+		return false, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return available, nil
@@ -248,7 +248,7 @@ func (r UserPATRepository) GetBySecretHash(ctx context.Context, secretHash strin
 			goqu.Ex{"deleted_at": nil},
 		).Limit(1).ToSQL()
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", queryErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var model UserPAT
@@ -259,7 +259,7 @@ func (r UserPATRepository) GetBySecretHash(ctx context.Context, secretHash strin
 		if errors.Is(err, sql.ErrNoRows) {
 			return models.PAT{}, paterrors.ErrNotFound
 		}
-		return models.PAT{}, fmt.Errorf("%w: %w", dbErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return model.transform()
@@ -271,14 +271,14 @@ func (r UserPATRepository) UpdateUsedAt(ctx context.Context, id string, at time.
 		Where(goqu.Ex{"id": id}).
 		ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "UpdateUsedAt", func(ctx context.Context) error {
 		_, err := r.dbc.ExecContext(ctx, query, params...)
 		return err
 	}); err != nil {
-		return fmt.Errorf("%w: %w", dbErr, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return nil
@@ -287,7 +287,7 @@ func (r UserPATRepository) UpdateUsedAt(ctx context.Context, id string, at time.
 func (r UserPATRepository) Update(ctx context.Context, pat models.PAT) (models.PAT, error) {
 	marshaledMetadata, err := json.Marshal(pat.Metadata)
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", parseErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	query, params, err := dialect.Update(TABLE_USER_PATS).
@@ -302,7 +302,7 @@ func (r UserPATRepository) Update(ctx context.Context, pat models.PAT) (models.P
 		Returning(&UserPAT{}).
 		ToSQL()
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", queryErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var model UserPAT
@@ -316,7 +316,7 @@ func (r UserPATRepository) Update(ctx context.Context, pat models.PAT) (models.P
 		if errors.Is(err, ErrDuplicateKey) {
 			return models.PAT{}, paterrors.ErrConflict
 		}
-		return models.PAT{}, fmt.Errorf("%w: %w", dbErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return model.transform()
@@ -338,7 +338,7 @@ func (r UserPATRepository) Regenerate(ctx context.Context, id, secretHash string
 		Returning(&UserPAT{}).
 		ToSQL()
 	if err != nil {
-		return models.PAT{}, fmt.Errorf("%w: %w", queryErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var model UserPAT
@@ -352,7 +352,7 @@ func (r UserPATRepository) Regenerate(ctx context.Context, id, secretHash string
 		if errors.Is(err, ErrDuplicateKey) {
 			return models.PAT{}, paterrors.ErrConflict
 		}
-		return models.PAT{}, fmt.Errorf("%w: %w", dbErr, err)
+		return models.PAT{}, fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	return model.transform()
@@ -366,13 +366,13 @@ func (r UserPATRepository) ListExpiryReminderPending(ctx context.Context, days i
 		goqu.L("(metadata->>?) IS NULL", userpat.ExpiryReminderMetadataKey),
 	).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 	var rows []UserPAT
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "ListExpiryReminderPending", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &rows, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 	var pats []models.PAT
 	for _, m := range rows {
@@ -392,13 +392,13 @@ func (r UserPATRepository) ListExpiredNoticePending(ctx context.Context) ([]mode
 		goqu.L("(metadata->>?) IS NULL", userpat.ExpiredNoticeMetadataKey),
 	).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 	var rows []UserPAT
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "ListExpiredNoticePending", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &rows, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 	var pats []models.PAT
 	for _, m := range rows {
@@ -418,13 +418,13 @@ func (r UserPATRepository) ListByUser(ctx context.Context, userID string) ([]mod
 		goqu.Ex{"deleted_at": nil},
 	).ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", queryErr, err)
+		return nil, fmt.Errorf("%w: %w", errQuery, err)
 	}
 	var rows []UserPAT
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "ListByUser", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &rows, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %w", dbErr, err)
+		return nil, fmt.Errorf("%w: %w", errDB, err)
 	}
 	pats := make([]models.PAT, 0, len(rows))
 	for _, m := range rows {
@@ -447,13 +447,13 @@ func (r UserPATRepository) SetAlertSentMetadata(ctx context.Context, id string, 
 		Where(goqu.Ex{"id": id}).
 		ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 	if err = r.dbc.WithTimeout(ctx, TABLE_USER_PATS, "SetAlertSentMetadata", func(ctx context.Context) error {
 		_, execErr := r.dbc.ExecContext(ctx, query, params...)
 		return execErr
 	}); err != nil {
-		return fmt.Errorf("%w: %w", dbErr, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 	return nil
 }
@@ -467,7 +467,7 @@ func (r UserPATRepository) Delete(ctx context.Context, id string) error {
 		).
 		ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %w", queryErr, err)
+		return fmt.Errorf("%w: %w", errQuery, err)
 	}
 
 	var result sql.Result
@@ -476,12 +476,12 @@ func (r UserPATRepository) Delete(ctx context.Context, id string) error {
 		result, execErr = r.dbc.ExecContext(ctx, query, params...)
 		return execErr
 	}); err != nil {
-		return fmt.Errorf("%w: %w", dbErr, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("%w: %w", dbErr, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 	if rowsAffected == 0 {
 		return paterrors.ErrNotFound

--- a/internal/store/postgres/webhook_endpoint_repository.go
+++ b/internal/store/postgres/webhook_endpoint_repository.go
@@ -60,14 +60,14 @@ func (r WebhookEndpointRepository) Create(ctx context.Context, toCreate webhook.
 			"updated_at":        goqu.L("now()"),
 		}).Returning(&WebhookEndpoint{}).ToSQL()
 	if err != nil {
-		return webhook.Endpoint{}, fmt.Errorf("%w: %s", parseErr, err)
+		return webhook.Endpoint{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var endpointModel WebhookEndpoint
 	if err = r.dbc.WithTimeout(ctx, TABLE_WEBHOOK_ENDPOINTS, "Create", func(ctx context.Context) error {
 		return r.dbc.QueryRowxContext(ctx, query, params...).StructScan(&endpointModel)
 	}); err != nil {
-		return webhook.Endpoint{}, fmt.Errorf("%w: %s", dbErr, err)
+		return webhook.Endpoint{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return endpointModel.transform(r.encryptionKey)
@@ -79,7 +79,7 @@ func (r WebhookEndpointRepository) GetByID(ctx context.Context, id string) (webh
 	})
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return webhook.Endpoint{}, fmt.Errorf("%w: %s", parseErr, err)
+		return webhook.Endpoint{}, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var endpointModel WebhookEndpoint
@@ -91,7 +91,7 @@ func (r WebhookEndpointRepository) GetByID(ctx context.Context, id string) (webh
 		case errors.Is(err, sql.ErrNoRows):
 			return webhook.Endpoint{}, webhook.ErrNotFound
 		}
-		return webhook.Endpoint{}, fmt.Errorf("%w: %s", dbErr, err)
+		return webhook.Endpoint{}, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	return endpointModel.transform(r.encryptionKey)
@@ -106,14 +106,14 @@ func (r WebhookEndpointRepository) List(ctx context.Context, flt webhook.Endpoin
 	}
 	query, params, err := stmt.ToSQL()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", parseErr, err)
+		return nil, fmt.Errorf("%w: %s", errParse, err)
 	}
 
 	var endpointModels []WebhookEndpoint
 	if err = r.dbc.WithTimeout(ctx, TABLE_WEBHOOK_ENDPOINTS, "List", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &endpointModels, query, params...)
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %s", dbErr, err)
+		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
 	endpoints := make([]webhook.Endpoint, 0, len(endpointModels))
@@ -142,7 +142,7 @@ func (r WebhookEndpointRepository) UpdateByID(ctx context.Context, toUpdate webh
 	if toUpdate.Metadata != nil {
 		marshaledMetadata, err := json.Marshal(toUpdate.Metadata)
 		if err != nil {
-			return webhook.Endpoint{}, fmt.Errorf("%w: %s", parseErr, err)
+			return webhook.Endpoint{}, fmt.Errorf("%w: %s", errParse, err)
 		}
 		updateRecord["metadata"] = marshaledMetadata
 	}
@@ -154,7 +154,7 @@ func (r WebhookEndpointRepository) UpdateByID(ctx context.Context, toUpdate webh
 		"id": toUpdate.ID,
 	}).Returning(&WebhookEndpoint{}).ToSQL()
 	if err != nil {
-		return webhook.Endpoint{}, fmt.Errorf("%w: %s", queryErr, err)
+		return webhook.Endpoint{}, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	var endpointModel WebhookEndpoint
@@ -166,7 +166,7 @@ func (r WebhookEndpointRepository) UpdateByID(ctx context.Context, toUpdate webh
 		case errors.Is(err, sql.ErrNoRows):
 			return webhook.Endpoint{}, webhook.ErrNotFound
 		default:
-			return webhook.Endpoint{}, fmt.Errorf("%w: %w", txnErr, err)
+			return webhook.Endpoint{}, fmt.Errorf("%w: %w", errTxn, err)
 		}
 	}
 
@@ -178,14 +178,14 @@ func (r WebhookEndpointRepository) Delete(ctx context.Context, id string) error 
 		"id": id,
 	}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", queryErr, err)
+		return fmt.Errorf("%w: %s", errQuery, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_WEBHOOK_ENDPOINTS, "Delete", func(ctx context.Context) error {
 		_, err := r.dbc.ExecContext(ctx, query, params...)
 		return err
 	}); err != nil {
-		return fmt.Errorf("%w: %w", txnErr, err)
+		return fmt.Errorf("%w: %w", errTxn, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Rename error variables to the standard Go form. Pure renames, +473/−473 across 38 files, no logic change.

## Changes
- `internal/store/postgres`: the five package error vars — `parseErr` → `errParse`, `queryErr` → `errQuery`, `dbErr` → `errDB`, `beginTnxErr` → `errBeginTnx`, `txnErr` → `errTxn` (~455 lines, all in this package)
- `core/event`: the exported `DefaultPlanNotFree` → `ErrDefaultPlanNotFree`
- Three test files: `sampleError` → `errSample`

## Test Plan
- [x] Build and type checking passes
- [x] Full postgres suite passes against real Postgres; billing/customer, core/event, core/prospect suites pass

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
- [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
- [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
- [x] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.
