### PR TITLE
fix(sdk): disable native browser validation on react-hook-form forms

### DIFF
--- a/web/apps/client-demo/src/App.tsx
+++ b/web/apps/client-demo/src/App.tsx
@@ -5,8 +5,8 @@ import { Toast } from '@raystack/apsara';
 import Router from './Router';
 import { v4 as uuid } from 'uuid';
 import './styles.css';
-import '@raystack/apsara/style.css'
 import '@raystack/apsara/normalize.css';
+import '@raystack/apsara/style.css'
 
 const customHeaders = {
   'X-Request-ID': () => `client-demo:${uuid()}`

--- a/web/sdk/client/views/auth/magic-link-verify/magic-link-verify-view.tsx
+++ b/web/sdk/client/views/auth/magic-link-verify/magic-link-verify-view.tsx
@@ -94,7 +94,7 @@ export const MagicLinkVerifyView = ({
         )}
       </Flex>
 
-      <form onSubmit={OTPVerifyHandler} className={styles.form}>
+      <form noValidate onSubmit={OTPVerifyHandler} className={styles.form}>
         <Flex direction="column" gap={2} className={styles.otpInputContainer}>
           <Input
             data-test-id="enter-code"

--- a/web/sdk/client/views/auth/magic-link-verify/magic-link-verify-view.tsx
+++ b/web/sdk/client/views/auth/magic-link-verify/magic-link-verify-view.tsx
@@ -94,7 +94,7 @@ export const MagicLinkVerifyView = ({
         )}
       </Flex>
 
-      <form noValidate onSubmit={OTPVerifyHandler} className={styles.form}>
+      <form onSubmit={OTPVerifyHandler} className={styles.form}>
         <Flex direction="column" gap={2} className={styles.otpInputContainer}>
           <Input
             data-test-id="enter-code"

--- a/web/sdk/client/views/auth/magic-link/magic-link-view.tsx
+++ b/web/sdk/client/views/auth/magic-link/magic-link-view.tsx
@@ -112,7 +112,7 @@ export const MagicLinkView = ({
       Continue with Email
     </Button>
   ) : (
-    <form className={styles.form} onSubmit={handleSubmit(magicLinkHandler)}>
+    <form noValidate className={styles.form} onSubmit={handleSubmit(magicLinkHandler)}>
       {!open && <Separator />}
       <Flex direction="column" align="start" className={styles.field}>
         <Input

--- a/web/sdk/client/views/auth/subscribe/subscribe-view.tsx
+++ b/web/sdk/client/views/auth/subscribe/subscribe-view.tsx
@@ -152,7 +152,7 @@ export const SubscribeView = ({
 
   return (
     <Flex direction="column" gap={9} align="center" justify="center">
-      <form onSubmit={handleSubmit(onFormSubmit)}>
+      <form noValidate onSubmit={handleSubmit(onFormSubmit)}>
         <Flex
           className={styles.subscribeContainer}
           direction="column"

--- a/web/sdk/client/views/auth/updates/updates-view.tsx
+++ b/web/sdk/client/views/auth/updates/updates-view.tsx
@@ -64,7 +64,7 @@ export const UpdatesView = ({
   return (
     <Flex direction="column" gap={9}>
       <AuthHeader logo={logo} title={title} />
-      <form onSubmit={handleSubmit(onFormSubmit)}>
+      <form noValidate onSubmit={handleSubmit(onFormSubmit)}>
         <AuthContainer className={styles.updatesContainer}>
           <Flex direction="column" gap={5}>
             <Flex justify="between">

--- a/web/sdk/client/views/create-organization/create-organization-view.tsx
+++ b/web/sdk/client/views/create-organization/create-organization-view.tsx
@@ -93,7 +93,7 @@ export const CreateOrganizationView = ({
           {description}
         </Text>
       </Flex>
-      <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      <form noValidate onSubmit={handleSubmit(onSubmit)} className={styles.form}>
         <Flex direction="column" align="center" gap={9} className={styles.card}>
           <Field
             label={`${t.organization({ case: 'capital' })} name`}

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -92,7 +92,7 @@ export const DeleteOrganizationDialog = ({
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialog.Content width={480}>
-        <form onSubmit={handleSubmit(onDeleteSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onDeleteSubmit)}>
           <AlertDialog.Header>
             <AlertDialog.Title>Delete {orgLabel}</AlertDialog.Title>
           </AlertDialog.Header>

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -174,7 +174,7 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
         description={`Basic configurations for the ${orgLabelLower}`}
       />
 
-      <form onSubmit={handleSubmit(onUpdateSubmit)}>
+      <form noValidate onSubmit={handleSubmit(onUpdateSubmit)}>
         <Flex direction="column">
           {/* Logo section */}
           <Flex direction="column" gap={5} className={styles.section}>

--- a/web/sdk/client/views/members/components/invite-member-dialog.tsx
+++ b/web/sdk/client/views/members/components/invite-member-dialog.tsx
@@ -162,7 +162,7 @@ export function InviteMemberDialog({ handle, showTeamField = true, refetch }: In
         <Dialog.Header>
           <Dialog.Title>Invite people</Dialog.Title>
         </Dialog.Header>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <Dialog.Body>
             <Flex direction="column" gap={7}>
               <Field label="Email" error={errors?.emails?.message}>
@@ -214,7 +214,7 @@ export function InviteMemberDialog({ handle, showTeamField = true, refetch }: In
                 )}
               </Field>
               {showTeamField && (
-                <Field label="Add to team (optional)">
+                <Field label="Add to team" required={false}>
                   {isLoading ? (
                     <Skeleton height="36px" />
                   ) : (

--- a/web/sdk/client/views/pat/components/pat-form-dialog.tsx
+++ b/web/sdk/client/views/pat/components/pat-form-dialog.tsx
@@ -399,7 +399,7 @@ export function PATFormDialog({
   return (
     <Dialog handle={handle} onOpenChange={handleOpenChange}>
       <Dialog.Content>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <Dialog.Header>
             <Dialog.Title>
               {isUpdateMode ? 'Update PAT' : 'Create new PAT'}

--- a/web/sdk/client/views/profile/profile-view.tsx
+++ b/web/sdk/client/views/profile/profile-view.tsx
@@ -110,7 +110,7 @@ export function ProfileView() {
         description="Manage your profile information and settings."
       />
 
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form noValidate onSubmit={handleSubmit(onSubmit)}>
         <Flex direction="column">
           {/* Avatar section */}
           <Flex direction="column" gap={5} className={styles.section}>

--- a/web/sdk/client/views/projects/components/add-project-dialog.tsx
+++ b/web/sdk/client/views/projects/components/add-project-dialog.tsx
@@ -93,7 +93,7 @@ export function AddProjectDialog({ handle, refetch }: AddProjectDialogProps) {
         <Dialog.Header>
           <Dialog.Title>Add Project</Dialog.Title>
         </Dialog.Header>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <Dialog.Body>
             <Flex direction="column" gap={5}>
               <Field

--- a/web/sdk/client/views/projects/components/edit-project-dialog.tsx
+++ b/web/sdk/client/views/projects/components/edit-project-dialog.tsx
@@ -119,7 +119,7 @@ function EditProjectForm({ payload, handle, refetch }: EditProjectFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form noValidate onSubmit={handleSubmit(onSubmit)}>
       <Dialog.Header>
         <Dialog.Title>Edit project details</Dialog.Title>
       </Dialog.Header>

--- a/web/sdk/client/views/security/components/add-domain-dialog.tsx
+++ b/web/sdk/client/views/security/components/add-domain-dialog.tsx
@@ -111,7 +111,7 @@ export function AddDomainDialog({
           <Dialog.Header>
             <Dialog.Title>Add domain</Dialog.Title>
           </Dialog.Header>
-          <form onSubmit={handleSubmit(onSubmit)}>
+          <form noValidate onSubmit={handleSubmit(onSubmit)}>
             <Dialog.Body>
               <Flex direction="column" gap={5}>
                 <Text size="small">

--- a/web/sdk/client/views/security/components/delete-domain-dialog.tsx
+++ b/web/sdk/client/views/security/components/delete-domain-dialog.tsx
@@ -142,7 +142,7 @@ function DeleteDomainContent({
 
   return (
     <AlertDialog.Content>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form noValidate onSubmit={handleSubmit(onSubmit)}>
         <AlertDialog.Header>
           <AlertDialog.Title>Delete Domain</AlertDialog.Title>
         </AlertDialog.Header>

--- a/web/sdk/client/views/service-accounts/components/add-service-account-dialog.tsx
+++ b/web/sdk/client/views/service-accounts/components/add-service-account-dialog.tsx
@@ -241,7 +241,7 @@ export function AddServiceAccountDialog({
   return (
     <Dialog handle={handle} onOpenChange={handleOpenChange}>
       <Dialog.Content>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <Dialog.Header>
             <Dialog.Title>New Service Account</Dialog.Title>
           </Dialog.Header>

--- a/web/sdk/client/views/service-accounts/components/add-token-form.tsx
+++ b/web/sdk/client/views/service-accounts/components/add-token-form.tsx
@@ -82,7 +82,7 @@ export function AddTokenForm({
   );
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form noValidate onSubmit={handleSubmit(onSubmit)}>
       <Flex className={styles.addTokenRow} align="start">
         <Field
           error={errors.title && String(errors.title?.message)}

--- a/web/sdk/client/views/teams/components/add-team-dialog.tsx
+++ b/web/sdk/client/views/teams/components/add-team-dialog.tsx
@@ -94,7 +94,7 @@ export function AddTeamDialog({ handle, refetch }: AddTeamDialogProps) {
         <Dialog.Header>
           <Dialog.Title>Add Team</Dialog.Title>
         </Dialog.Header>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <Dialog.Body>
             <Flex direction="column" gap={5}>
               <Field

--- a/web/sdk/client/views/teams/components/edit-team-dialog.tsx
+++ b/web/sdk/client/views/teams/components/edit-team-dialog.tsx
@@ -118,7 +118,7 @@ function EditTeamForm({ payload, handle, refetch }: EditTeamFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form noValidate onSubmit={handleSubmit(onSubmit)}>
       <Dialog.Header>
         <Dialog.Title>Edit team</Dialog.Title>
       </Dialog.Header>

--- a/web/sdk/client/views/tokens/components/add-tokens-dialog.tsx
+++ b/web/sdk/client/views/tokens/components/add-tokens-dialog.tsx
@@ -132,7 +132,7 @@ export function AddTokensDialog({ handle }: AddTokensDialogProps) {
   return (
     <Dialog handle={handle}>
       <Dialog.Content showCloseButton={false}>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form noValidate onSubmit={handleSubmit(onSubmit)}>
           <Dialog.Header>
             <Dialog.Title>Add tokens</Dialog.Title>
           </Dialog.Header>


### PR DESCRIPTION
## Summary
- Apsara's `Field` defaults to `required=true` and now stamps the native `required` attribute on its controls, so browsers showed built-in validation bubbles before react-hook-form/yup could run and render errors in the `Field` error slot
- Added `noValidate` to all SDK client forms that submit via react-hook-form's `handleSubmit`, restoring schema-driven validation with errors shown inline