### PR TITLE
feat(db): block deleting an org that still has service users

### DIFF
--- a/internal/store/postgres/migrations/20260723120000_restrict_org_delete_with_serviceusers.down.sql
+++ b/internal/store/postgres/migrations/20260723120000_restrict_org_delete_with_serviceusers.down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS trg_serviceusers_block_org_delete ON organizations;
+DROP FUNCTION IF EXISTS serviceusers_block_org_delete();

--- a/internal/store/postgres/migrations/20260723120000_restrict_org_delete_with_serviceusers.up.sql
+++ b/internal/store/postgres/migrations/20260723120000_restrict_org_delete_with_serviceusers.up.sql
@@ -1,0 +1,26 @@
+-- Block deleting an organization that still has service users.
+
+-- A plain foreign key to organizations(id) cannot be used here. The bootstrap
+-- superuser lives under the virtual platform org (00000000-0000-0000-0000-000000000000),
+-- which has no row in organizations by design. A BEFORE DELETE trigger only
+-- fires when a real org is deleted, so the virtual platform org and its
+-- bootstrap service account are never in scope.
+--
+-- Existing orphaned rows (if any) are left untouched; they are cleaned up out
+-- of band, not by this migration.
+CREATE OR REPLACE FUNCTION serviceusers_block_org_delete()
+    RETURNS trigger AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM serviceusers WHERE org_id = OLD.id) THEN
+        RAISE EXCEPTION 'cannot delete organization %: service users still reference it', OLD.id
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_serviceusers_block_org_delete ON organizations;
+CREATE TRIGGER trg_serviceusers_block_org_delete
+    BEFORE DELETE ON organizations
+    FOR EACH ROW
+    EXECUTE FUNCTION serviceusers_block_org_delete();


### PR DESCRIPTION
## What

Adds a `BEFORE DELETE` trigger on `organizations`. If any `serviceusers` row still points at the org, the delete fails.

## Why

Deleting an org used to leave its service users behind, with an `org_id` pointing at a row that no longer exists. Those leftover accounts kept authenticating. The app deleter now removes service users before the org, but the database had no fallback. This trigger is that fallback: if the app-level cleanup ever breaks, or a row is removed out of band, the org delete fails loudly instead of silently orphaning service users.

Normal deletes are unaffected — the deleter clears the service users first, so by the time the org row is deleted, the trigger has nothing to block.

## Why a trigger and not a foreign key

The obvious fix is a foreign key on `serviceusers.org_id` with `ON DELETE RESTRICT`. That does not work here.

The bootstrap superuser service account lives under the **virtual platform org** (`00000000-0000-0000-0000-000000000000`). That org id is never inserted into the `organizations` table by design. A foreign key checks every row, so it would reject the bootstrap account and also fail on every server boot, which re-creates that account.

A trigger only runs when a **real** org is deleted. The platform org is never deleted, so the bootstrap account is never in scope. Same "fail loud" behaviour, no conflict with the special org id.

## Testing

Verified locally against a running server:

- Service user authenticates before the org is deleted → 200.
- Raw `DELETE FROM organizations` while a service user still exists → blocked by the trigger.
- API `DeleteOrganization` → succeeds, and the service user rows are gone.
- Service user auth after the delete → 401.
- Server restart with the trigger in place → boots fine, bootstrap account re-created as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)