### PR TITLE
refactor: rename service user variables

### DIFF
--- a/core/serviceuser/service.go
+++ b/core/serviceuser/service.go
@@ -132,15 +132,15 @@ func (s Service) GetByIDs(ctx context.Context, ids []string) ([]ServiceUser, err
 }
 
 func (s Service) ListByOrg(ctx context.Context, orgID string) ([]ServiceUser, error) {
-	userIDs, err := s.membershipService.ListPrincipalIDsByResource(ctx, orgID, schema.OrganizationNamespace, schema.ServiceUserPrincipal)
+	serviceUserIDs, err := s.membershipService.ListPrincipalIDsByResource(ctx, orgID, schema.OrganizationNamespace, schema.ServiceUserPrincipal)
 	if err != nil {
 		return nil, err
 	}
-	if len(userIDs) == 0 {
-		// no users
+	if len(serviceUserIDs) == 0 {
+		// no service users
 		return []ServiceUser{}, nil
 	}
-	return s.repo.GetByIDs(ctx, userIDs)
+	return s.repo.GetByIDs(ctx, serviceUserIDs)
 }
 
 func (s Service) Delete(ctx context.Context, id string) error {
@@ -456,7 +456,7 @@ func (s Service) FilterSudos(ctx context.Context, ids []string) ([]string, error
 
 // Sudo add platform permissions to user
 func (s Service) Sudo(ctx context.Context, id string, relationName string) error {
-	currentUser, err := s.Get(ctx, id)
+	serviceUser, err := s.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -471,7 +471,7 @@ func (s Service) Sudo(ctx context.Context, id string, relationName string) error
 	// Act on the exact relation, not the permission it grants: admin and member both
 	// grant `check`, so a permission check would skip adding member to an existing
 	// admin and break the admin->member downgrade. Safe to run again.
-	if ok, err := s.IsSudo(ctx, currentUser.ID, relationName); err != nil {
+	if ok, err := s.IsSudo(ctx, serviceUser.ID, relationName); err != nil {
 		return err
 	} else if ok {
 		return nil
@@ -483,7 +483,7 @@ func (s Service) Sudo(ctx context.Context, id string, relationName string) error
 			Namespace: schema.PlatformNamespace,
 		},
 		Subject: relation.Subject{
-			ID:        currentUser.ID,
+			ID:        serviceUser.ID,
 			Namespace: schema.ServiceUserPrincipal,
 		},
 		RelationName: relationName,
@@ -497,7 +497,7 @@ func (s Service) Sudo(ctx context.Context, id string, relationName string) error
 	if relationName == schema.MemberRelationName {
 		event = pkgAuditRecord.PlatformMemberAddedEvent
 	}
-	return s.recordPlatformAuditRecord(ctx, currentUser, event, relationName)
+	return s.recordPlatformAuditRecord(ctx, serviceUser, event, relationName)
 }
 
 // UnSudo removes a platform relation (admin or member) from a service user.
@@ -510,7 +510,7 @@ func (s Service) UnSudo(ctx context.Context, id, relationName string) error {
 		return fmt.Errorf("invalid relation name, possible options are: %s, %s", schema.MemberRelationName, schema.AdminRelationName)
 	}
 
-	currentUser, err := s.Get(ctx, id)
+	serviceUser, err := s.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -518,7 +518,7 @@ func (s Service) UnSudo(ctx context.Context, id, relationName string) error {
 	// Only act (and audit) when the specific relation actually exists, so the
 	// revoke event reflects a real state change. Checking the relation directly
 	// is precise for both admin and member.
-	present, err := s.IsSudo(ctx, currentUser.ID, relationName)
+	present, err := s.IsSudo(ctx, serviceUser.ID, relationName)
 	if err != nil {
 		return err
 	}
@@ -533,7 +533,7 @@ func (s Service) UnSudo(ctx context.Context, id, relationName string) error {
 			Namespace: schema.PlatformNamespace,
 		},
 		Subject: relation.Subject{
-			ID:        currentUser.ID,
+			ID:        serviceUser.ID,
 			Namespace: schema.ServiceUserPrincipal,
 		},
 		RelationName: relationName,
@@ -545,7 +545,7 @@ func (s Service) UnSudo(ctx context.Context, id, relationName string) error {
 	if relationName == schema.MemberRelationName {
 		event = pkgAuditRecord.PlatformMemberRemovedEvent
 	}
-	return s.recordPlatformAuditRecord(ctx, currentUser, event, relationName)
+	return s.recordPlatformAuditRecord(ctx, serviceUser, event, relationName)
 }
 
 // recordPlatformAuditRecord logs a platform admin/member grant or revoke on a service

--- a/internal/api/v1beta1connect/project.go
+++ b/internal/api/v1beta1connect/project.go
@@ -252,23 +252,23 @@ func (h *ConnectHandler) ListProjectServiceUsers(ctx context.Context, request *c
 	}
 
 	suIDs := utils.Map(members, func(m membership.Member) string { return m.PrincipalID })
-	var users []serviceuser.ServiceUser
+	var serviceUsers []serviceuser.ServiceUser
 	if len(suIDs) > 0 {
-		users, err = h.serviceUserService.GetByIDs(ctx, suIDs)
+		serviceUsers, err = h.serviceUserService.GetByIDs(ctx, suIDs)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListProjectServiceUsers.GetByIDs: project_id=%s: %w", prj.ID, err))
 		}
 	}
 
-	var transformedUsers []*frontierv1beta1.ServiceUser
+	var transformedServiceUsers []*frontierv1beta1.ServiceUser
 	rolePairPBs := []*frontierv1beta1.ListProjectServiceUsersResponse_RolePair{}
-	for _, a := range users {
-		u, err := transformServiceUserToPB(a)
+	for _, su := range serviceUsers {
+		serviceUserPB, err := transformServiceUserToPB(su)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListProjectServiceUsers: entity_id=%s: %w", a.ID, err))
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListProjectServiceUsers: entity_id=%s: %w", su.ID, err))
 		}
 
-		transformedUsers = append(transformedUsers, u)
+		transformedServiceUsers = append(transformedServiceUsers, serviceUserPB)
 	}
 
 	for _, m := range members {
@@ -289,7 +289,7 @@ func (h *ConnectHandler) ListProjectServiceUsers(ctx context.Context, request *c
 	}
 
 	return connect.NewResponse(&frontierv1beta1.ListProjectServiceUsersResponse{
-		Serviceusers: transformedUsers,
+		Serviceusers: transformedServiceUsers,
 		RolePairs:    rolePairPBs,
 	}), nil
 }

--- a/internal/api/v1beta1connect/serviceuser.go
+++ b/internal/api/v1beta1connect/serviceuser.go
@@ -40,8 +40,8 @@ func toJSONWebKey(keySet jwk.Set) (*JsonWebKeySet, error) {
 }
 
 func (h *ConnectHandler) ListServiceUsers(ctx context.Context, request *connect.Request[frontierv1beta1.ListServiceUsersRequest]) (*connect.Response[frontierv1beta1.ListServiceUsersResponse], error) {
-	var users []*frontierv1beta1.ServiceUser
-	usersList, err := h.serviceUserService.List(ctx, serviceuser.Filter{
+	var serviceUsers []*frontierv1beta1.ServiceUser
+	serviceUsersList, err := h.serviceUserService.List(ctx, serviceuser.Filter{
 		OrgID: request.Msg.GetOrgId(),
 		State: serviceuser.State(request.Msg.GetState()),
 	})
@@ -49,16 +49,16 @@ func (h *ConnectHandler) ListServiceUsers(ctx context.Context, request *connect.
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListServiceUsers: org_id=%s state=%s: %w", request.Msg.GetOrgId(), request.Msg.GetState(), err))
 	}
 
-	for _, user := range usersList {
-		userPB, err := transformServiceUserToPB(user)
+	for _, su := range serviceUsersList {
+		serviceUserPB, err := transformServiceUserToPB(su)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListServiceUsers: entity_id=%s: %w", user.ID, err))
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ListServiceUsers: entity_id=%s: %w", su.ID, err))
 		}
-		users = append(users, userPB)
+		serviceUsers = append(serviceUsers, serviceUserPB)
 	}
 
 	return connect.NewResponse(&frontierv1beta1.ListServiceUsersResponse{
-		Serviceusers: users,
+		Serviceusers: serviceUsers,
 	}), nil
 }
 

--- a/internal/store/postgres/serviceuser_repository.go
+++ b/internal/store/postgres/serviceuser_repository.go
@@ -206,9 +206,9 @@ func (s ServiceUserRepository) GetByIDs(ctx context.Context, ids []string) ([]se
 		return nil, fmt.Errorf("%w: %s", errQuery, err)
 	}
 
-	var fetchedUsers []ServiceUser
+	var fetchedServiceUsers []ServiceUser
 	if err = s.dbc.WithTimeout(ctx, TABLE_SERVICEUSER, "Get", func(ctx context.Context) error {
-		return s.dbc.SelectContext(ctx, &fetchedUsers, query, params...)
+		return s.dbc.SelectContext(ctx, &fetchedServiceUsers, query, params...)
 	}); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, serviceuser.ErrNotExist
@@ -216,15 +216,15 @@ func (s ServiceUserRepository) GetByIDs(ctx context.Context, ids []string) ([]se
 		return nil, fmt.Errorf("%w: %s", errDB, err)
 	}
 
-	var transformedUsers []serviceuser.ServiceUser
-	for _, u := range fetchedUsers {
-		transformedUser, err := u.transform()
+	var transformedServiceUsers []serviceuser.ServiceUser
+	for _, su := range fetchedServiceUsers {
+		transformedServiceUser, err := su.transform()
 		if err != nil {
-			return nil, fmt.Errorf("failed to transform user: %w", err)
+			return nil, fmt.Errorf("failed to transform service user: %w", err)
 		}
-		transformedUsers = append(transformedUsers, transformedUser)
+		transformedServiceUsers = append(transformedServiceUsers, transformedServiceUser)
 	}
-	return transformedUsers, nil
+	return transformedServiceUsers, nil
 }
 
 // ListMissingOrgPolicy returns service users whose owning org has no matching

--- a/test/e2e/regression/serviceusers_test.go
+++ b/test/e2e/regression/serviceusers_test.go
@@ -783,8 +783,8 @@ func (s *ServiceUsersRegressionTestSuite) TestServiceUserAsPlatformMember() {
 		// check if we have su permissions by listing users
 		listUsersBeforeResp, err := s.testBench.AdminClient.ListPlatformUsers(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.ListPlatformUsersRequest{}))
 		s.Assert().NoError(err)
-		s.Assert().False(utils.ContainsFunc(listUsersBeforeResp.Msg.GetServiceusers(), func(user *frontierv1beta1.ServiceUser) bool {
-			return user.GetId() == createServiceUserResp.Msg.GetServiceuser().GetId()
+		s.Assert().False(utils.ContainsFunc(listUsersBeforeResp.Msg.GetServiceusers(), func(serviceUser *frontierv1beta1.ServiceUser) bool {
+			return serviceUser.GetId() == createServiceUserResp.Msg.GetServiceuser().GetId()
 		}))
 
 		// make service user platform member
@@ -799,8 +799,8 @@ func (s *ServiceUsersRegressionTestSuite) TestServiceUserAsPlatformMember() {
 		s.Assert().NoError(err)
 		s.Assert().NotNil(listUsersResp)
 		s.Assert().Len(listUsersResp.Msg.GetUsers(), 1)
-		s.Assert().True(utils.ContainsFunc(listUsersResp.Msg.GetServiceusers(), func(user *frontierv1beta1.ServiceUser) bool {
-			return user.GetId() == createServiceUserResp.Msg.GetServiceuser().GetId()
+		s.Assert().True(utils.ContainsFunc(listUsersResp.Msg.GetServiceusers(), func(serviceUser *frontierv1beta1.ServiceUser) bool {
+			return serviceUser.GetId() == createServiceUserResp.Msg.GetServiceuser().GetId()
 		}))
 	})
 	s.Run("4. remove a service user in an org which was platform member", func() {
@@ -906,8 +906,8 @@ func (s *ServiceUsersRegressionTestSuite) TestServiceUserAsPlatformMember() {
 		listUsersResp, err := s.testBench.AdminClient.ListPlatformUsers(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.ListPlatformUsersRequest{}))
 		s.Assert().NoError(err)
 		s.Assert().NotNil(listUsersResp)
-		s.Assert().True(utils.ContainsFunc(listUsersResp.Msg.GetServiceusers(), func(user *frontierv1beta1.ServiceUser) bool {
-			return user.GetId() == createServiceUserResp.Msg.GetServiceuser().GetId()
+		s.Assert().True(utils.ContainsFunc(listUsersResp.Msg.GetServiceusers(), func(serviceUser *frontierv1beta1.ServiceUser) bool {
+			return serviceUser.GetId() == createServiceUserResp.Msg.GetServiceuser().GetId()
 		}))
 
 		// superusers shouldn't be listed in non admin calls even if they have access


### PR DESCRIPTION
## Summary
Renames variables that hold service users to use explicit service user naming, avoiding confusion with human users.

Closes #1726

## Changes

- Renamed `user`, `users`, and `currentUser` variables that represent service users.
- Used `serviceUser`/`serviceUsers` naming and `su` in short loops.
- Updated additional occurrences found during the repo-wide sweep.
- No behavior changes.


## Technical Details

This is a naming-only refactor. No application logic or SQL queries were changed.


## Test Plan
<!-- Describe how you tested these changes -->
- [ ] Manual testing completed
- [ ] Build and type checking passes

- Verified the repo-wide sweep for remaining service-user naming occurrences.

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)

No SQL/query logic was changed.

- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.
- [x] `ToSQL()` callers capture and forward params (`query, params, err := stmt.ToSQL(); db.…Context(ctx, …, query, params...)`). Never `query, _, err := …`.
- [x] No `?` placeholders inside single-quoted SQL literals in `goqu.L` (use `make_interval(hours => ?)`-style functions instead).
- [ ] Any `//nolint:forbidigo` or `// #nosec G20x` annotation has a one-line justification on the same line that a reviewer can verify.

