### PR TITLE
feat(auth): add auth_via claim to minted access tokens

### DIFF
--- a/core/authenticate/service.go
+++ b/core/authenticate/service.go
@@ -738,6 +738,7 @@ func isInvalidGrantErr(err error) bool {
 // BuildToken creates an access token for the given subjectID
 func (s Service) BuildToken(ctx context.Context, principal Principal, metadata map[string]string) ([]byte, error) {
 	metadata[token.SubTypeClaimsKey] = principal.Type
+	metadata[token.AuthViaClaimKey] = principal.AuthVia.String()
 	if principal.Type == schema.UserPrincipal && s.config.Token.Claims.AddUserEmailClaim {
 		metadata[token.SubEmailClaimsKey] = principal.User.Email
 	}

--- a/core/authenticate/service_test.go
+++ b/core/authenticate/service_test.go
@@ -863,3 +863,80 @@ func TestService_GetPrincipal_OrgStateGate(t *testing.T) {
 		})
 	}
 }
+
+func TestService_BuildToken(t *testing.T) {
+	userID := uuid.NewString()
+
+	tests := []struct {
+		name       string
+		principal  authenticate.Principal
+		config     authenticate.Config
+		wantClaims map[string]string
+	}{
+		{
+			name: "user via session gets sub_type, auth_via and email claims",
+			principal: authenticate.Principal{
+				ID:      userID,
+				Type:    schema.UserPrincipal,
+				AuthVia: authenticate.SessionClientAssertion,
+				User:    &user.User{ID: userID, Email: "jane@acme.org"},
+			},
+			config: authenticate.Config{Token: authenticate.TokenConfig{
+				Claims: authenticate.TokenClaimConfig{AddUserEmailClaim: true},
+			}},
+			wantClaims: map[string]string{
+				token.SubTypeClaimsKey:  schema.UserPrincipal,
+				token.AuthViaClaimKey:   authenticate.SessionClientAssertion.String(),
+				token.SubEmailClaimsKey: "jane@acme.org",
+			},
+		},
+		{
+			name: "service user via client credentials gets auth_via claim",
+			principal: authenticate.Principal{
+				ID:      userID,
+				Type:    schema.ServiceUserPrincipal,
+				AuthVia: authenticate.ClientCredentialsClientAssertion,
+			},
+			wantClaims: map[string]string{
+				token.SubTypeClaimsKey: schema.ServiceUserPrincipal,
+				token.AuthViaClaimKey:  authenticate.ClientCredentialsClientAssertion.String(),
+			},
+		},
+		{
+			name: "pat principal gets auth_via and user_id claims",
+			principal: authenticate.Principal{
+				ID:      "pat-token-id",
+				Type:    schema.PATPrincipal,
+				AuthVia: authenticate.PATClientAssertion,
+				User:    &user.User{ID: userID},
+			},
+			wantClaims: map[string]string{
+				token.SubTypeClaimsKey: schema.PATPrincipal,
+				token.AuthViaClaimKey:  authenticate.PATClientAssertion.String(),
+				token.UserIDClaimKey:   userID,
+			},
+		},
+		{
+			name: "principal without auth via gets empty auth_via claim",
+			principal: authenticate.Principal{
+				ID:   userID,
+				Type: schema.UserPrincipal,
+			},
+			wantClaims: map[string]string{
+				token.SubTypeClaimsKey: schema.UserPrincipal,
+				token.AuthViaClaimKey:  "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockToken := mocks.NewTokenService(t)
+			mockToken.EXPECT().Build(tt.principal.ID, tt.wantClaims).Return([]byte("signed-token"), nil)
+			s := authenticate.NewService(nil, tt.config, nil, nil, mockToken, nil, nil, nil, nil, nil)
+
+			got, err := s.BuildToken(context.Background(), tt.principal, map[string]string{})
+			assert.NoError(t, err)
+			assert.Equal(t, []byte("signed-token"), got)
+		})
+	}
+}

--- a/core/authenticate/token/service.go
+++ b/core/authenticate/token/service.go
@@ -25,6 +25,7 @@ const (
 	SubEmailClaimsKey   = "email"
 	SessionIDClaimKey   = "sid"
 	UserIDClaimKey      = "user_id"
+	AuthViaClaimKey     = "auth_via"
 )
 
 type Service struct {

--- a/test/e2e/regression/authentication_test.go
+++ b/test/e2e/regression/authentication_test.go
@@ -354,6 +354,9 @@ func (s *AuthenticationRegressionTestSuite) TestUserSession() {
 		subType, ok := parsed.Get(token.SubTypeClaimsKey)
 		s.Assert().True(ok)
 		s.Assert().Equal(schema.PATPrincipal, subType)
+		authVia, ok := parsed.Get(token.AuthViaClaimKey)
+		s.Assert().True(ok)
+		s.Assert().Equal(authenticate.PATClientAssertion.String(), authVia)
 
 		// and the minted jwt authenticates
 		ctxWithMinted := testbench.ContextWithHeaders(context.Background(), map[string]string{

--- a/test/e2e/regression/serviceusers_test.go
+++ b/test/e2e/regression/serviceusers_test.go
@@ -666,6 +666,9 @@ func (s *ServiceUsersRegressionTestSuite) TestServiceUserWithSecret() {
 		orgIDs, ok := insecureToken.Get("org_ids")
 		s.Assert().True(ok)
 		s.Assert().Equal(existingOrgID, orgIDs)
+		authVia, ok := insecureToken.Get("auth_via")
+		s.Assert().True(ok)
+		s.Assert().Equal("client_credentials", authVia)
 	})
 }
 


### PR DESCRIPTION
## Summary
Tokens minted by `AuthToken` now carry an `auth_via` claim that records how
the caller authenticated: `session`, `pat`, `client_credentials`, or `jwt_grant`.

## Changes
- Add `AuthViaClaimKey` (`auth_via`) to the token claim key constants.
- `BuildToken` copies `principal.AuthVia` into the claims of every minted token.
- Unit test for `BuildToken`: user, service user, PAT, and unset-`AuthVia` cases,
  asserting the exact claim map handed to the signer.
- e2e assertions: the PAT exchange flow expects `auth_via=pat`; the
  client-credentials flow expects `auth_via=client_credentials`.

## Technical Details
`Principal.AuthVia` is stamped by `GetPrincipal` when authentication succeeds.
The claim is set unconditionally; a principal without `AuthVia` yields an empty
claim value.

## Test Plan
- [x] `go test -race ./core/authenticate/...` passes
- [x] e2e regression suites for authentication and service users pass (36 tests)
- [x] `golangci-lint run ./core/authenticate/...` — 0 issues
- [x] Build and type checking passes
- [x] Manual testing completed (live `AuthToken` call; minted JWT contains `auth_via: session`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)