### PR TITLE
refactor(schema): grant org and group access through roles only

### DIFF
--- a/core/organization/organization.go
+++ b/core/organization/organization.go
@@ -19,7 +19,6 @@ const (
 	Disabled State = "disabled"
 
 	AdminPermission = schema.UpdatePermission
-	AdminRelation   = schema.OwnerRelationName
 	AdminRole       = schema.RoleOrganizationOwner
 	MemberRole      = schema.RoleOrganizationViewer
 )

--- a/internal/bootstrap/generator.go
+++ b/internal/bootstrap/generator.go
@@ -139,7 +139,6 @@ func ApplyServiceDefinitionOverAZSchema(serviceDef *schema.ServiceDefinition, ex
 			{
 				// for org
 				nsRel, err := aznamespace.Relation(fqPermissionName, aznamespace.Union(
-					aznamespace.ComputedUserset("owner"),
 					aznamespace.TupleToUserset("platform", "superuser"),
 					aznamespace.TupleToUserset("granted", "app_organization_administer"),
 					aznamespace.TupleToUserset("granted", fqPermissionName),

--- a/internal/bootstrap/schema/base_schema.zed
+++ b/internal/bootstrap/schema/base_schema.zed
@@ -35,34 +35,32 @@ definition app/organization {
 
 	// permissions
     // org
-    permission membership = member + owner
-
-    permission delete = platform->superuser + granted->app_organization_administer + granted->app_organization_delete + owner
-    permission update = platform->superuser + granted->app_organization_administer + granted->app_organization_update + owner
-    permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update + owner + member
-    permission rolemanage = platform->superuser + granted->app_organization_administer + granted->app_organization_rolemanage + owner
-    permission policymanage = platform->superuser + granted->app_organization_administer + granted->app_organization_policymanage + owner
-    permission projectlist = platform->superuser + granted->app_organization_administer + granted->app_organization_projectlist + owner
-    permission grouplist = platform->superuser + granted->app_organization_administer + granted->app_organization_grouplist + owner
-    permission projectcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_projectcreate + owner
-    permission groupcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_groupcreate + owner
-	permission invitationlist = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationlist + owner
-	permission invitationcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationcreate + owner
-    permission serviceusermanage = platform->superuser + granted->app_organization_administer + granted->app_organization_serviceusermanage + owner
-    permission billingmanage = platform->superuser + granted->app_organization_administer + granted->app_organization_billingmanage + owner
-    permission billingview = platform->superuser + granted->app_organization_administer + granted->app_organization_billingview + owner
+    permission delete = platform->superuser + granted->app_organization_administer + granted->app_organization_delete
+    permission update = platform->superuser + granted->app_organization_administer + granted->app_organization_update
+    permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update
+    permission rolemanage = platform->superuser + granted->app_organization_administer + granted->app_organization_rolemanage
+    permission policymanage = platform->superuser + granted->app_organization_administer + granted->app_organization_policymanage
+    permission projectlist = platform->superuser + granted->app_organization_administer + granted->app_organization_projectlist
+    permission grouplist = platform->superuser + granted->app_organization_administer + granted->app_organization_grouplist
+    permission projectcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_projectcreate
+    permission groupcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_groupcreate
+	permission invitationlist = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationlist
+	permission invitationcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationcreate
+    permission serviceusermanage = platform->superuser + granted->app_organization_administer + granted->app_organization_serviceusermanage
+    permission billingmanage = platform->superuser + granted->app_organization_administer + granted->app_organization_billingmanage
+    permission billingview = platform->superuser + granted->app_organization_administer + granted->app_organization_billingview
 
     // synthetic permissions - project
-    permission project_delete = platform->superuser + granted->app_organization_administer + granted->app_project_delete + pat_granted->app_project_administer + pat_granted->app_project_delete + owner
-    permission project_update = platform->superuser + granted->app_organization_administer + granted->app_project_update + pat_granted->app_project_administer + pat_granted->app_project_update + owner
-    permission project_get = platform->superuser + granted->app_organization_administer + granted->app_project_get + pat_granted->app_project_administer + pat_granted->app_project_get + owner
-    permission project_policymanage = platform->superuser + granted->app_organization_administer + granted->app_project_policymanage + pat_granted->app_project_administer + pat_granted->app_project_policymanage + owner
-	permission project_resourcelist = platform->superuser + granted->app_organization_administer + granted->app_project_resourcelist + pat_granted->app_project_administer + pat_granted->app_project_resourcelist + owner
+    permission project_delete = platform->superuser + granted->app_organization_administer + granted->app_project_delete + pat_granted->app_project_administer + pat_granted->app_project_delete
+    permission project_update = platform->superuser + granted->app_organization_administer + granted->app_project_update + pat_granted->app_project_administer + pat_granted->app_project_update
+    permission project_get = platform->superuser + granted->app_organization_administer + granted->app_project_get + pat_granted->app_project_administer + pat_granted->app_project_get
+    permission project_policymanage = platform->superuser + granted->app_organization_administer + granted->app_project_policymanage + pat_granted->app_project_administer + pat_granted->app_project_policymanage
+	permission project_resourcelist = platform->superuser + granted->app_organization_administer + granted->app_project_resourcelist + pat_granted->app_project_administer + pat_granted->app_project_resourcelist
 
     // synthetic permissions - group
-    permission group_delete = platform->superuser + granted->app_organization_administer + granted->app_group_delete + owner
-    permission group_update = platform->superuser + granted->app_organization_administer + granted->app_group_update + owner
-    permission group_get = platform->superuser + granted->app_organization_administer + granted->app_group_get + owner
+    permission group_delete = platform->superuser + granted->app_organization_administer + granted->app_group_delete
+    permission group_update = platform->superuser + granted->app_organization_administer + granted->app_group_update
+    permission group_get = platform->superuser + granted->app_organization_administer + granted->app_group_get
 }
 
 definition app/group {
@@ -73,10 +71,9 @@ definition app/group {
 	relation owner: app/user | app/serviceuser
 
 	// permissions
-	permission membership = member + owner
-    permission delete = org->group_delete + granted->app_group_administer + granted->app_group_delete + owner
-    permission update = org->group_update + granted->app_group_administer + granted->app_group_update + owner
-    permission get = org->group_get + granted->app_group_administer + granted->app_group_get + member + owner
+    permission delete = org->group_delete + granted->app_group_administer + granted->app_group_delete
+    permission update = org->group_update + granted->app_group_administer + granted->app_group_update
+    permission get = org->group_get + granted->app_group_administer + granted->app_group_get
 }
 
 definition app/project {

--- a/internal/bootstrap/schema/schema.go
+++ b/internal/bootstrap/schema/schema.go
@@ -70,9 +70,6 @@ const (
 	PlatformSudoPermission  = "superuser"
 	PlatformCheckPermission = "check"
 
-	// synthetic permission
-	MembershipPermission = "membership"
-
 	// principals
 	UserPrincipal        = "app/user"
 	ServiceUserPrincipal = "app/serviceuser"

--- a/internal/bootstrap/testdata/compiled_schema.zed
+++ b/internal/bootstrap/testdata/compiled_schema.zed
@@ -1,18 +1,16 @@
 
 
 definition app/group {
-	permission delete = org->group_delete + granted->app_group_administer + granted->app_group_delete + owner
-	permission get = org->group_get + granted->app_group_administer + granted->app_group_get + member + owner
+	// permissions
+	permission delete = org->group_delete + granted->app_group_administer + granted->app_group_delete
+	permission get = org->group_get + granted->app_group_administer + granted->app_group_get
 	relation granted: app/rolebinding
 	relation member: app/user
-
-	// permissions
-	permission membership = member + owner
 
 	// relations
 	relation org: app/organization
 	relation owner: app/user | app/serviceuser
-	permission update = org->group_update + granted->app_group_administer + granted->app_group_update + owner
+	permission update = org->group_update + granted->app_group_administer + granted->app_group_update
 }
 
 definition app/invitation {
@@ -24,49 +22,48 @@ definition app/invitation {
 }
 
 definition app/organization {
-	permission billingmanage = platform->superuser + granted->app_organization_administer + granted->app_organization_billingmanage + owner
-	permission billingview = platform->superuser + granted->app_organization_administer + granted->app_organization_billingview + owner
-	permission compute_order_create = owner + platform->superuser + granted->app_organization_administer + granted->compute_order_create + pat_granted->app_project_administer + pat_granted->compute_order_create
-	permission compute_order_delete = owner + platform->superuser + granted->app_organization_administer + granted->compute_order_delete + pat_granted->app_project_administer + pat_granted->compute_order_delete
-	permission compute_order_get = owner + platform->superuser + granted->app_organization_administer + granted->compute_order_get + pat_granted->app_project_administer + pat_granted->compute_order_get
-	permission compute_order_update = owner + platform->superuser + granted->app_organization_administer + granted->compute_order_update + pat_granted->app_project_administer + pat_granted->compute_order_update
-	permission compute_receipt_get = owner + platform->superuser + granted->app_organization_administer + granted->compute_receipt_get + pat_granted->app_project_administer + pat_granted->compute_receipt_get
-	permission compute_receipt_update = owner + platform->superuser + granted->app_organization_administer + granted->compute_receipt_update + pat_granted->app_project_administer + pat_granted->compute_receipt_update
-	permission delete = platform->superuser + granted->app_organization_administer + granted->app_organization_delete + owner
-	permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update + owner + member
-	relation granted: app/rolebinding
-
-	// synthetic permissions - group
-	permission group_delete = platform->superuser + granted->app_organization_administer + granted->app_group_delete + owner
-	permission group_get = platform->superuser + granted->app_organization_administer + granted->app_group_get + owner
-	permission group_update = platform->superuser + granted->app_organization_administer + granted->app_group_update + owner
-	permission groupcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_groupcreate + owner
-	permission grouplist = platform->superuser + granted->app_organization_administer + granted->app_organization_grouplist + owner
-	permission invitationcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationcreate + owner
-	permission invitationlist = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationlist + owner
-	relation member: app/user | app/group#member | app/serviceuser
+	permission billingmanage = platform->superuser + granted->app_organization_administer + granted->app_organization_billingmanage
+	permission billingview = platform->superuser + granted->app_organization_administer + granted->app_organization_billingview
+	permission compute_order_create = platform->superuser + granted->app_organization_administer + granted->compute_order_create + pat_granted->app_project_administer + pat_granted->compute_order_create
+	permission compute_order_delete = platform->superuser + granted->app_organization_administer + granted->compute_order_delete + pat_granted->app_project_administer + pat_granted->compute_order_delete
+	permission compute_order_get = platform->superuser + granted->app_organization_administer + granted->compute_order_get + pat_granted->app_project_administer + pat_granted->compute_order_get
+	permission compute_order_update = platform->superuser + granted->app_organization_administer + granted->compute_order_update + pat_granted->app_project_administer + pat_granted->compute_order_update
+	permission compute_receipt_get = platform->superuser + granted->app_organization_administer + granted->compute_receipt_get + pat_granted->app_project_administer + pat_granted->compute_receipt_get
+	permission compute_receipt_update = platform->superuser + granted->app_organization_administer + granted->compute_receipt_update + pat_granted->app_project_administer + pat_granted->compute_receipt_update
 
 	// permissions
 	// org
-	permission membership = member + owner
+	permission delete = platform->superuser + granted->app_organization_administer + granted->app_organization_delete
+	permission get = platform->superuser + granted->app_organization_administer + granted->app_organization_get + granted->app_organization_update
+	relation granted: app/rolebinding
+
+	// synthetic permissions - group
+	permission group_delete = platform->superuser + granted->app_organization_administer + granted->app_group_delete
+	permission group_get = platform->superuser + granted->app_organization_administer + granted->app_group_get
+	permission group_update = platform->superuser + granted->app_organization_administer + granted->app_group_update
+	permission groupcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_groupcreate
+	permission grouplist = platform->superuser + granted->app_organization_administer + granted->app_organization_grouplist
+	permission invitationcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationcreate
+	permission invitationlist = platform->superuser + granted->app_organization_administer + granted->app_organization_invitationlist
+	relation member: app/user | app/group#member | app/serviceuser
 	relation owner: app/user | app/serviceuser
 	relation pat_granted: app/rolebinding
 
 	// relations
 	relation platform: app/platform
-	permission policymanage = platform->superuser + granted->app_organization_administer + granted->app_organization_policymanage + owner
+	permission policymanage = platform->superuser + granted->app_organization_administer + granted->app_organization_policymanage
 
 	// synthetic permissions - project
-	permission project_delete = platform->superuser + granted->app_organization_administer + granted->app_project_delete + pat_granted->app_project_administer + pat_granted->app_project_delete + owner
-	permission project_get = platform->superuser + granted->app_organization_administer + granted->app_project_get + pat_granted->app_project_administer + pat_granted->app_project_get + owner
-	permission project_policymanage = platform->superuser + granted->app_organization_administer + granted->app_project_policymanage + pat_granted->app_project_administer + pat_granted->app_project_policymanage + owner
-	permission project_resourcelist = platform->superuser + granted->app_organization_administer + granted->app_project_resourcelist + pat_granted->app_project_administer + pat_granted->app_project_resourcelist + owner
-	permission project_update = platform->superuser + granted->app_organization_administer + granted->app_project_update + pat_granted->app_project_administer + pat_granted->app_project_update + owner
-	permission projectcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_projectcreate + owner
-	permission projectlist = platform->superuser + granted->app_organization_administer + granted->app_organization_projectlist + owner
-	permission rolemanage = platform->superuser + granted->app_organization_administer + granted->app_organization_rolemanage + owner
-	permission serviceusermanage = platform->superuser + granted->app_organization_administer + granted->app_organization_serviceusermanage + owner
-	permission update = platform->superuser + granted->app_organization_administer + granted->app_organization_update + owner
+	permission project_delete = platform->superuser + granted->app_organization_administer + granted->app_project_delete + pat_granted->app_project_administer + pat_granted->app_project_delete
+	permission project_get = platform->superuser + granted->app_organization_administer + granted->app_project_get + pat_granted->app_project_administer + pat_granted->app_project_get
+	permission project_policymanage = platform->superuser + granted->app_organization_administer + granted->app_project_policymanage + pat_granted->app_project_administer + pat_granted->app_project_policymanage
+	permission project_resourcelist = platform->superuser + granted->app_organization_administer + granted->app_project_resourcelist + pat_granted->app_project_administer + pat_granted->app_project_resourcelist
+	permission project_update = platform->superuser + granted->app_organization_administer + granted->app_project_update + pat_granted->app_project_administer + pat_granted->app_project_update
+	permission projectcreate = platform->superuser + granted->app_organization_administer + granted->app_organization_projectcreate
+	permission projectlist = platform->superuser + granted->app_organization_administer + granted->app_organization_projectlist
+	permission rolemanage = platform->superuser + granted->app_organization_administer + granted->app_organization_rolemanage
+	permission serviceusermanage = platform->superuser + granted->app_organization_administer + granted->app_organization_serviceusermanage
+	permission update = platform->superuser + granted->app_organization_administer + granted->app_organization_update
 }
 
 definition app/pat {}

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -1632,6 +1632,13 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(false, checkPermission.Msg.GetStatus())
 
+		checkReadPermission, err := s.testBench.Client.CheckResourcePermission(ctxOrgUserAuth, connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+			Resource:   schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
+			Permission: schema.GetPermission,
+		}))
+		s.Assert().NoError(err)
+		s.Assert().Equal(false, checkReadPermission.Msg.GetStatus())
+
 		// the owner role policy is what grants access
 		_, err = s.testBench.Client.CreatePolicy(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreatePolicyRequest{
 			Body: &frontierv1beta1.PolicyRequestBody{

--- a/test/e2e/regression/api_test.go
+++ b/test/e2e/regression/api_test.go
@@ -1593,7 +1593,7 @@ func (s *APIRegressionTestSuite) TestUserAPI() {
 func (s *APIRegressionTestSuite) TestRelationAPI() {
 	ctxOrgAdminAuth := testbench.ContextWithAuth(context.Background(), s.adminCookie)
 
-	s.Run("1. creating a new relation between org and user should give access to the org", func() {
+	s.Run("1. an owner relation alone gives no org access; an owner role policy does", func() {
 		existingOrg, err := s.testBench.Client.GetOrganization(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.GetOrganizationRequest{
 			Id: "org-relation-1",
 		}))
@@ -1614,10 +1614,11 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(1, len(orgUsersResp.Msg.GetUsers()))
 
+		// a raw owner relation grants nothing: permissions come from roles only
 		_, err = s.testBench.Client.CreateRelation(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreateRelationRequest{Body: &frontierv1beta1.RelationRequestBody{
 			Object:   schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
 			Subject:  schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
-			Relation: organization.AdminRelation,
+			Relation: schema.OwnerRelationName,
 		}}))
 		s.Assert().NoError(err)
 
@@ -1629,9 +1630,26 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 			Permission: schema.DeletePermission,
 		}))
 		s.Assert().NoError(err)
+		s.Assert().Equal(false, checkPermission.Msg.GetStatus())
+
+		// the owner role policy is what grants access
+		_, err = s.testBench.Client.CreatePolicy(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreatePolicyRequest{
+			Body: &frontierv1beta1.PolicyRequestBody{
+				RoleId:    schema.RoleOrganizationOwner,
+				Resource:  schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
+				Principal: schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
+			},
+		}))
+		s.Assert().NoError(err)
+
+		checkPermission, err = s.testBench.Client.CheckResourcePermission(ctxOrgUserAuth, connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+			Resource:   schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
+			Permission: schema.DeletePermission,
+		}))
+		s.Assert().NoError(err)
 		s.Assert().Equal(true, checkPermission.Msg.GetStatus())
 	})
-	s.Run("2. creating a relation between org and user with editor role should provide view & edit permission in that org", func() {
+	s.Run("2. a policy with the manager role should provide view & edit permission in that org", func() {
 		existingOrg, err := s.testBench.Client.GetOrganization(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.GetOrganizationRequest{
 			Id: "org-relation-2",
 		}))
@@ -1646,11 +1664,13 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		}))
 		s.Assert().NoError(err)
 
-		_, err = s.testBench.Client.CreateRelation(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreateRelationRequest{Body: &frontierv1beta1.RelationRequestBody{
-			Object:   schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
-			Subject:  schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
-			Relation: organization.AdminRelation,
-		}}))
+		_, err = s.testBench.Client.CreatePolicy(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreatePolicyRequest{
+			Body: &frontierv1beta1.PolicyRequestBody{
+				RoleId:    schema.RoleOrganizationManager,
+				Resource:  schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
+				Principal: schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
+			},
+		}))
 		s.Assert().NoError(err)
 
 		relUser2Cookie, err := testbench.AuthenticateUser(context.Background(), s.testBench.Client, createUserResp.Msg.GetUser().GetEmail())
@@ -1663,7 +1683,7 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(true, checkViewPermResp.Msg.GetStatus())
 
-		checkEditPermResp, err := s.testBench.Client.CheckResourcePermission(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
+		checkEditPermResp, err := s.testBench.Client.CheckResourcePermission(ctxOrgUserAuth, connect.NewRequest(&frontierv1beta1.CheckResourcePermissionRequest{
 			ObjectId:        existingOrg.Msg.GetOrganization().GetId(),
 			ObjectNamespace: schema.OrganizationNamespace,
 			Permission:      schema.UpdatePermission,
@@ -1671,7 +1691,7 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(true, checkEditPermResp.Msg.GetStatus())
 	})
-	s.Run("3. deleting a relation between user and org should remove user access from that org", func() {
+	s.Run("3. deleting a policy should remove user access from that org", func() {
 		existingOrg, err := s.testBench.Client.GetOrganization(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.GetOrganizationRequest{
 			Id: "org-relation-3",
 		}))
@@ -1686,11 +1706,13 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		}))
 		s.Assert().NoError(err)
 
-		_, err = s.testBench.Client.CreateRelation(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreateRelationRequest{Body: &frontierv1beta1.RelationRequestBody{
-			Object:   schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
-			Subject:  schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
-			Relation: schema.OwnerRelationName,
-		}}))
+		createPolicyResp, err := s.testBench.Client.CreatePolicy(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.CreatePolicyRequest{
+			Body: &frontierv1beta1.PolicyRequestBody{
+				RoleId:    schema.RoleOrganizationOwner,
+				Resource:  schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
+				Principal: schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
+			},
+		}))
 		s.Assert().NoError(err)
 
 		relUser3Cookie, err := testbench.AuthenticateUser(context.Background(), s.testBench.Client, createUserResp.Msg.GetUser().GetEmail())
@@ -1703,10 +1725,8 @@ func (s *APIRegressionTestSuite) TestRelationAPI() {
 		s.Assert().NoError(err)
 		s.Assert().Equal(true, checkBeforeDeletePermission.Msg.GetStatus())
 
-		_, err = s.testBench.Client.DeleteRelation(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.DeleteRelationRequest{
-			Object:   schema.JoinNamespaceAndResourceID(schema.OrganizationNamespace, existingOrg.Msg.GetOrganization().GetId()),
-			Subject:  schema.JoinNamespaceAndResourceID(schema.UserPrincipal, createUserResp.Msg.GetUser().GetId()),
-			Relation: schema.OwnerRelationName,
+		_, err = s.testBench.Client.DeletePolicy(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.DeletePolicyRequest{
+			Id: createPolicyResp.Msg.GetPolicy().GetId(),
 		}))
 		s.Assert().NoError(err)
 

--- a/web/sdk/utils/index.ts
+++ b/web/sdk/utils/index.ts
@@ -79,9 +79,6 @@ export const PERMISSIONS = {
   ServiceUserManagePermission: 'serviceusermanage',
   ManagePermission: 'manage',
 
-  // synthetic permission
-  MembershipPermission: 'membership',
-
   // principals
   UserPrincipal: 'app/user',
   ServiceUserPrincipal: 'app/serviceuser',


### PR DESCRIPTION
## Problem

An org owner gets their permissions in two ways at the same time:

1. **Through their role.** The Owner role holds the `app_organization_administer` permission.
2. **Through a direct `owner` link** between the user and the org, stored in SpiceDB. This link skips roles completely.

When someone joins an org or a group, Frontier writes both.

The second path is the problem. We can now change what a predefined role contains (using `frontier reconcile`). But shrinking the Owner role does nothing to real owners — their direct `owner` link still grants everything. The `member` link has the same issue. Custom permissions too: the schema generator adds the same `owner` shortcut to every custom permission it creates.

## Fix

Roles are now the only way to get org and group permissions.

- `base_schema.zed`: every org and group permission ended with `+ owner` (some also `+ member`). Removed those. Also deleted the `membership` permission — it was built only from these two links and nothing uses it.
- `generator.go`: custom permissions no longer get the `owner` shortcut at the org level. The creator of a single resource still keeps access to that resource — that is a different `owner` and is untouched.
- Deleted the unused `MembershipPermission` constants (Go and JS SDK).

Owners lose nothing: the Owner role has `app_organization_administer`, and every permission still accepts that.

**One real change:** the `member` link used to give every org member read access for free. Now a role must list `app_organization_get` for the user to see the org (`app_group_get` for groups).

The `owner` and `member` links are still declared in the schema and still written on every membership change. They just grant nothing now. Deleting them fully is a follow-up PR, because SpiceDB refuses to drop a relation while stored data still uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)