### PR TITLE
feat(billing): manage product prices through UpdateProduct

### DIFF
--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -164,6 +164,20 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 		return Product{}, err
 	}
 
+	// read and validate the desired prices before mutating anything, so an
+	// invalid price fails the whole update rather than leaving the product
+	// half-changed. An empty list leaves the prices untouched.
+	var currentPrices []Price
+	if len(product.Prices) > 0 {
+		currentPrices, err = s.GetPriceByProductID(ctx, existingProduct.ID)
+		if err != nil {
+			return Product{}, err
+		}
+		if err := validateDesiredPrices(currentPrices, product.Prices); err != nil {
+			return Product{}, err
+		}
+	}
+
 	// only following fields will be updated
 	if len(product.Title) > 0 {
 		existingProduct.Title = product.Title
@@ -217,10 +231,11 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 		return Product{}, err
 	}
 
-	// converge the product's prices to the desired list. An empty list leaves
-	// prices untouched; a non-empty list is authoritative for the product.
+	// apply the validated price convergence. The desired list is authoritative:
+	// a new name is created, a retired name listed again is reactivated, and an
+	// active price the list no longer names is retired.
 	if len(product.Prices) > 0 {
-		if err := s.convergePrices(ctx, updatedProduct.ID, product.Prices); err != nil {
+		if err := s.applyPriceConvergence(ctx, updatedProduct.ID, currentPrices, product.Prices); err != nil {
 			return Product{}, err
 		}
 	}
@@ -234,15 +249,84 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 	return updatedProduct, nil
 }
 
-// convergePrices makes a product's prices match the desired list. It is
-// authoritative: the caller passes the full set it wants, and a price is
-// identified by its name within the product. A name not yet on the product is
-// created. Adds are made before any removals.
-func (s *Service) convergePrices(ctx context.Context, productID string, desired []Price) error {
-	current, err := s.GetPriceByProductID(ctx, productID)
-	if err != nil {
-		return err
+// validateDesiredPrices checks the desired price list against the product's
+// current prices without touching anything, so an invalid list fails the update
+// before it mutates the product. Names must be present and unique, and a name
+// that already exists must keep its immutable fields, since provider prices
+// cannot be changed in place.
+func validateDesiredPrices(current, desired []Price) error {
+	currentByName := make(map[string]Price, len(current))
+	for _, p := range current {
+		currentByName[strings.ToLower(p.Name)] = p
 	}
+	seen := make(map[string]struct{}, len(desired))
+	for _, want := range desired {
+		name := strings.ToLower(strings.TrimSpace(want.Name))
+		if name == "" {
+			return fmt.Errorf("%w: a price must have a name", ErrInvalidDetail)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%w: price %q is listed more than once", ErrInvalidDetail, name)
+		}
+		seen[name] = struct{}{}
+		if existing, ok := currentByName[name]; ok {
+			if err := checkImmutablePriceFields(existing, want); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkImmutablePriceFields rejects a change to a field a provider price cannot
+// change in place. A new amount, currency, interval, billing scheme, or usage
+// type has to be a new price under a new name. Both sides are normalized first,
+// so a field that only differs because of a default does not read as a change.
+func checkImmutablePriceFields(existing, want Price) error {
+	e := normalizePrice(existing)
+	w := normalizePrice(want)
+	switch {
+	case e.Amount != w.Amount:
+		return fmt.Errorf("%w: price %q amount cannot change from %d to %d; provider prices are immutable, add a new price with a different name",
+			ErrInvalidDetail, w.Name, e.Amount, w.Amount)
+	case e.Currency != w.Currency:
+		return fmt.Errorf("%w: price %q currency cannot change from %q to %q; add a new price with a different name",
+			ErrInvalidDetail, w.Name, e.Currency, w.Currency)
+	case e.Interval != w.Interval:
+		return fmt.Errorf("%w: price %q interval cannot change from %q to %q; add a new price with a different name",
+			ErrInvalidDetail, w.Name, e.Interval, w.Interval)
+	case e.BillingScheme != w.BillingScheme:
+		return fmt.Errorf("%w: price %q billing scheme cannot change; add a new price with a different name", ErrInvalidDetail, w.Name)
+	case e.UsageType != w.UsageType:
+		return fmt.Errorf("%w: price %q usage type cannot change; add a new price with a different name", ErrInvalidDetail, w.Name)
+	}
+	return nil
+}
+
+// normalizePrice fills the defaults CreatePrice would apply and lowercases the
+// name and interval, so two prices compare the way they are stored.
+func normalizePrice(p Price) Price {
+	if p.BillingScheme == "" {
+		p.BillingScheme = BillingSchemeFlat
+	}
+	if p.Currency == "" {
+		p.Currency = "usd"
+	}
+	if p.UsageType == "" {
+		p.UsageType = PriceUsageTypeLicensed
+	}
+	p.Interval = strings.ToLower(p.Interval)
+	p.Name = strings.ToLower(p.Name)
+	return p
+}
+
+// applyPriceConvergence makes the product's prices match the desired list. The
+// list must already have passed validateDesiredPrices. A name the product does
+// not have is created, a retired name listed again is reactivated, and an active
+// price the list no longer names is retired. Adds and reactivations run before
+// retires, so the product always has the new price before an old one goes
+// inactive.
+func (s *Service) applyPriceConvergence(ctx context.Context, productID string, current, desired []Price) error {
 	currentByName := make(map[string]Price, len(current))
 	for _, p := range current {
 		currentByName[strings.ToLower(p.Name)] = p
@@ -252,34 +336,27 @@ func (s *Service) convergePrices(ctx context.Context, productID string, desired 
 		desiredNames[strings.ToLower(want.Name)] = struct{}{}
 	}
 
-	// reject an in-place amount change before touching anything. Provider
-	// prices are immutable, so a new amount has to be a new price name.
 	for _, want := range desired {
-		if existing, ok := currentByName[strings.ToLower(want.Name)]; ok && existing.Amount != want.Amount {
-			return fmt.Errorf("%w: price %q amount cannot change from %d to %d; provider prices are immutable, add a new price with a different name",
-				ErrInvalidDetail, strings.ToLower(want.Name), existing.Amount, want.Amount)
-		}
-	}
-
-	// add the prices the product does not have yet, before any removal, so the
-	// product always has the new price in place before an old one is retired.
-	for _, want := range desired {
-		if _, ok := currentByName[strings.ToLower(want.Name)]; ok {
+		existing, ok := currentByName[strings.ToLower(want.Name)]
+		if !ok {
+			want.ProductID = productID
+			if _, err := s.CreatePrice(ctx, want); err != nil {
+				return err
+			}
 			continue
 		}
-		want.ProductID = productID
-		if _, err := s.CreatePrice(ctx, want); err != nil {
-			return err
+		if !existing.IsActive() {
+			if err := s.reactivatePrice(ctx, existing); err != nil {
+				return err
+			}
 		}
 	}
 
-	// retire the active prices the desired list no longer names. A price that
-	// is already inactive is left alone, so re-applying the same list is a no-op.
 	for _, p := range current {
 		if _, wanted := desiredNames[strings.ToLower(p.Name)]; wanted {
 			continue
 		}
-		if p.State == PriceStateInactive {
+		if !p.IsActive() {
 			continue
 		}
 		if err := s.deactivatePrice(ctx, p); err != nil {
@@ -293,15 +370,33 @@ func (s *Service) convergePrices(ctx context.Context, productID string, desired 
 // deleted, so a superseded price is marked inactive in the provider and the
 // repo rather than removed.
 func (s *Service) deactivatePrice(ctx context.Context, price Price) error {
-	_, err := s.stripeClient.Prices.Update(price.ProviderID, &stripe.PriceParams{
-		Params: stripe.Params{Context: ctx},
-		Active: stripe.Bool(false),
-	})
-	if err != nil {
-		return err
+	return s.setPriceActive(ctx, price, false)
+}
+
+// reactivatePrice brings a retired price back into use when the desired list
+// names it again.
+func (s *Service) reactivatePrice(ctx context.Context, price Price) error {
+	return s.setPriceActive(ctx, price, true)
+}
+
+// setPriceActive flips a price's active flag in the provider and its state in
+// the repo. A price with no provider id (nothing was created upstream) skips the
+// provider call.
+func (s *Service) setPriceActive(ctx context.Context, price Price, active bool) error {
+	if price.ProviderID != "" {
+		if _, err := s.stripeClient.Prices.Update(price.ProviderID, &stripe.PriceParams{
+			Params: stripe.Params{Context: ctx},
+			Active: stripe.Bool(active),
+		}); err != nil {
+			return err
+		}
 	}
-	price.State = PriceStateInactive
-	_, err = s.priceRepository.UpdateByID(ctx, price)
+	if active {
+		price.State = PriceStateActive
+	} else {
+		price.State = PriceStateInactive
+	}
+	_, err := s.priceRepository.UpdateByID(ctx, price)
 	return err
 }
 
@@ -309,6 +404,10 @@ func (s *Service) AddPlan(ctx context.Context, productOb Product, planID string)
 	var err error
 	if !slices.Contains(productOb.PlanIDs, planID) {
 		productOb.PlanIDs = append(productOb.PlanIDs, planID)
+		// AddPlan only links a plan to the product. Clear the populated price
+		// list so Update leaves the product's prices untouched instead of
+		// re-converging them.
+		productOb.Prices = nil
 		_, err = s.Update(ctx, productOb)
 		if err != nil {
 			return err

--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -249,6 +249,14 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 	return updatedProduct, nil
 }
 
+// priceKey is the canonical lookup name for a price. Names are matched
+// case-insensitively and ignoring surrounding whitespace. Validation,
+// convergence, and the stored name all use this key, so the three never
+// disagree on what counts as the same price.
+func priceKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
 // validateDesiredPrices checks the desired price list against the product's
 // current prices without touching anything, so an invalid list fails the update
 // before it mutates the product. Names must be present and unique, and a name
@@ -257,11 +265,11 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 func validateDesiredPrices(current, desired []Price) error {
 	currentByName := make(map[string]Price, len(current))
 	for _, p := range current {
-		currentByName[strings.ToLower(p.Name)] = p
+		currentByName[priceKey(p.Name)] = p
 	}
 	seen := make(map[string]struct{}, len(desired))
 	for _, want := range desired {
-		name := strings.ToLower(strings.TrimSpace(want.Name))
+		name := priceKey(want.Name)
 		if name == "" {
 			return fmt.Errorf("%w: a price must have a name", ErrInvalidDetail)
 		}
@@ -299,12 +307,15 @@ func checkImmutablePriceFields(existing, want Price) error {
 		return fmt.Errorf("%w: price %q billing scheme cannot change; add a new price with a different name", ErrInvalidDetail, w.Name)
 	case e.UsageType != w.UsageType:
 		return fmt.Errorf("%w: price %q usage type cannot change; add a new price with a different name", ErrInvalidDetail, w.Name)
+	case e.UsageType == PriceUsageTypeMetered && e.MeteredAggregate != w.MeteredAggregate:
+		return fmt.Errorf("%w: price %q metered aggregate cannot change; add a new price with a different name", ErrInvalidDetail, w.Name)
 	}
 	return nil
 }
 
-// normalizePrice fills the defaults CreatePrice would apply and lowercases the
-// name and interval, so two prices compare the way they are stored.
+// normalizePrice fills the defaults CreatePrice would apply, trims and
+// lowercases the name, and lowercases the interval, so two prices compare the
+// way they are stored.
 func normalizePrice(p Price) Price {
 	if p.BillingScheme == "" {
 		p.BillingScheme = BillingSchemeFlat
@@ -316,7 +327,7 @@ func normalizePrice(p Price) Price {
 		p.UsageType = PriceUsageTypeLicensed
 	}
 	p.Interval = strings.ToLower(p.Interval)
-	p.Name = strings.ToLower(p.Name)
+	p.Name = priceKey(p.Name)
 	return p
 }
 
@@ -329,17 +340,18 @@ func normalizePrice(p Price) Price {
 func (s *Service) applyPriceConvergence(ctx context.Context, productID string, current, desired []Price) error {
 	currentByName := make(map[string]Price, len(current))
 	for _, p := range current {
-		currentByName[strings.ToLower(p.Name)] = p
+		currentByName[priceKey(p.Name)] = p
 	}
 	desiredNames := make(map[string]struct{}, len(desired))
 	for _, want := range desired {
-		desiredNames[strings.ToLower(want.Name)] = struct{}{}
+		desiredNames[priceKey(want.Name)] = struct{}{}
 	}
 
 	for _, want := range desired {
-		existing, ok := currentByName[strings.ToLower(want.Name)]
+		existing, ok := currentByName[priceKey(want.Name)]
 		if !ok {
 			want.ProductID = productID
+			want.Name = priceKey(want.Name)
 			if _, err := s.CreatePrice(ctx, want); err != nil {
 				return err
 			}
@@ -353,7 +365,7 @@ func (s *Service) applyPriceConvergence(ctx context.Context, productID string, c
 	}
 
 	for _, p := range current {
-		if _, wanted := desiredNames[strings.ToLower(p.Name)]; wanted {
+		if _, wanted := desiredNames[priceKey(p.Name)]; wanted {
 			continue
 		}
 		if !p.IsActive() {

--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -232,8 +232,8 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 	}
 
 	// apply the validated price convergence. The desired list is authoritative:
-	// a new name is created, a retired name listed again is reactivated, and an
-	// active price the list no longer names is retired.
+	// a new name is created, an inactive name listed again is activated, and an
+	// active price the list no longer names is deactivated.
 	if len(product.Prices) > 0 {
 		if err := s.applyPriceConvergence(ctx, updatedProduct.ID, currentPrices, product.Prices); err != nil {
 			return Product{}, err
@@ -322,9 +322,9 @@ func normalizePrice(p Price) Price {
 
 // applyPriceConvergence makes the product's prices match the desired list. The
 // list must already have passed validateDesiredPrices. A name the product does
-// not have is created, a retired name listed again is reactivated, and an active
-// price the list no longer names is retired. Adds and reactivations run before
-// retires, so the product always has the new price before an old one goes
+// not have is created, an inactive name listed again is activated, and an active
+// price the list no longer names is deactivated. Adds and activations run before
+// deactivations, so the product always has the new price before an old one goes
 // inactive.
 func (s *Service) applyPriceConvergence(ctx context.Context, productID string, current, desired []Price) error {
 	currentByName := make(map[string]Price, len(current))
@@ -346,7 +346,7 @@ func (s *Service) applyPriceConvergence(ctx context.Context, productID string, c
 			continue
 		}
 		if !existing.IsActive() {
-			if err := s.reactivatePrice(ctx, existing); err != nil {
+			if err := s.activatePrice(ctx, existing); err != nil {
 				return err
 			}
 		}
@@ -366,16 +366,16 @@ func (s *Service) applyPriceConvergence(ctx context.Context, productID string, c
 	return nil
 }
 
-// deactivatePrice retires a price. Provider prices are immutable and cannot be
-// deleted, so a superseded price is marked inactive in the provider and the
-// repo rather than removed.
+// deactivatePrice marks a price inactive. Provider prices are immutable and
+// cannot be deleted, so a price is taken out of use by setting it inactive in
+// the provider and the repo rather than removed.
 func (s *Service) deactivatePrice(ctx context.Context, price Price) error {
 	return s.setPriceActive(ctx, price, false)
 }
 
-// reactivatePrice brings a retired price back into use when the desired list
+// activatePrice brings an inactive price back into use when the desired list
 // names it again.
-func (s *Service) reactivatePrice(ctx context.Context, price Price) error {
+func (s *Service) activatePrice(ctx context.Context, price Price) error {
 	return s.setPriceActive(ctx, price, true)
 }
 

--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -217,6 +217,14 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 		return Product{}, err
 	}
 
+	// converge the product's prices to the desired list. An empty list leaves
+	// prices untouched; a non-empty list is authoritative for the product.
+	if len(product.Prices) > 0 {
+		if err := s.convergePrices(ctx, updatedProduct.ID, product.Prices); err != nil {
+			return Product{}, err
+		}
+	}
+
 	// populate product with price and features
 	updatedProduct, err = s.populateProduct(ctx, updatedProduct)
 	if err != nil {
@@ -224,6 +232,77 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 	}
 
 	return updatedProduct, nil
+}
+
+// convergePrices makes a product's prices match the desired list. It is
+// authoritative: the caller passes the full set it wants, and a price is
+// identified by its name within the product. A name not yet on the product is
+// created. Adds are made before any removals.
+func (s *Service) convergePrices(ctx context.Context, productID string, desired []Price) error {
+	current, err := s.GetPriceByProductID(ctx, productID)
+	if err != nil {
+		return err
+	}
+	currentByName := make(map[string]Price, len(current))
+	for _, p := range current {
+		currentByName[strings.ToLower(p.Name)] = p
+	}
+	desiredNames := make(map[string]struct{}, len(desired))
+	for _, want := range desired {
+		desiredNames[strings.ToLower(want.Name)] = struct{}{}
+	}
+
+	// reject an in-place amount change before touching anything. Provider
+	// prices are immutable, so a new amount has to be a new price name.
+	for _, want := range desired {
+		if existing, ok := currentByName[strings.ToLower(want.Name)]; ok && existing.Amount != want.Amount {
+			return fmt.Errorf("%w: price %q amount cannot change from %d to %d; provider prices are immutable, add a new price with a different name",
+				ErrInvalidDetail, strings.ToLower(want.Name), existing.Amount, want.Amount)
+		}
+	}
+
+	// add the prices the product does not have yet, before any removal, so the
+	// product always has the new price in place before an old one is retired.
+	for _, want := range desired {
+		if _, ok := currentByName[strings.ToLower(want.Name)]; ok {
+			continue
+		}
+		want.ProductID = productID
+		if _, err := s.CreatePrice(ctx, want); err != nil {
+			return err
+		}
+	}
+
+	// retire the active prices the desired list no longer names. A price that
+	// is already inactive is left alone, so re-applying the same list is a no-op.
+	for _, p := range current {
+		if _, wanted := desiredNames[strings.ToLower(p.Name)]; wanted {
+			continue
+		}
+		if p.State == PriceStateInactive {
+			continue
+		}
+		if err := s.deactivatePrice(ctx, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deactivatePrice retires a price. Provider prices are immutable and cannot be
+// deleted, so a superseded price is marked inactive in the provider and the
+// repo rather than removed.
+func (s *Service) deactivatePrice(ctx context.Context, price Price) error {
+	_, err := s.stripeClient.Prices.Update(price.ProviderID, &stripe.PriceParams{
+		Params: stripe.Params{Context: ctx},
+		Active: stripe.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+	price.State = PriceStateInactive
+	_, err = s.priceRepository.UpdateByID(ctx, price)
+	return err
 }
 
 func (s *Service) AddPlan(ctx context.Context, productOb Product, planID string) error {

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -630,6 +630,65 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 			t.Fatalf("Update() unexpected error = %v", err)
 		}
 	})
+
+	t.Run("a name with surrounding whitespace matches the existing price", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
+			Return([]product.Price{{ID: "price-monthly", Name: "monthly", Amount: 100, Currency: "usd", Interval: "month", State: "active"}}, nil)
+
+		// No Create/UpdateByID or Stripe price calls: "  monthly  " must resolve to
+		// the existing "monthly", not a new price plus a deactivation of the real one.
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		spaced := monthly
+		spaced.Name = "  monthly  "
+		if _, err := svc.Update(ctx, desired(spaced)); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("rejects a metered aggregate change on an existing price name", func(t *testing.T) {
+		stripeClient, _, pr, priceRepo, fr := mockService(t)
+		expectPriceRead(pr, priceRepo, []product.Price{
+			{Name: "usage", Currency: "usd", Interval: "month", UsageType: product.PriceUsageTypeMetered, MeteredAggregate: "sum"},
+		})
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		changed := product.Price{
+			Name: "usage", Currency: "usd", Interval: "month",
+			UsageType: product.PriceUsageTypeMetered, MeteredAggregate: "max",
+		}
+		if _, err := svc.Update(ctx, desired(changed)); err == nil {
+			t.Fatalf("Update() expected an error for a metered aggregate change, got nil")
+		}
+	})
+
+	t.Run("adds a price before it deactivates an omitted one", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{
+			{ID: "price-old", ProviderID: "stripe_old", Name: "old", Amount: 100, Currency: "usd", Interval: "month", State: "active"},
+		}, nil)
+
+		var order []string
+		be.EXPECT().Call("POST", "/v1/prices", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		priceRepo.EXPECT().Create(mock.Anything, mock.MatchedBy(func(p product.Price) bool { return p.Name == "new" })).
+			Run(func(_ context.Context, _ product.Price) { order = append(order, "add") }).
+			Return(product.Price{Name: "new"}, nil)
+		be.EXPECT().Call("POST", "/v1/prices/stripe_old", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		priceRepo.EXPECT().UpdateByID(mock.Anything, mock.MatchedBy(func(p product.Price) bool { return p.Name == "old" && p.State == "inactive" })).
+			Run(func(_ context.Context, _ product.Price) { order = append(order, "deactivate") }).
+			Return(product.Price{}, nil)
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		newPrice := product.Price{Name: "new", Amount: 200, Currency: "usd", BillingScheme: product.BillingSchemeFlat, UsageType: product.PriceUsageTypeLicensed, Interval: "month"}
+		if _, err := svc.Update(ctx, desired(newPrice)); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+		if len(order) != 2 || order[0] != "add" || order[1] != "deactivate" {
+			t.Fatalf("expected add before deactivate, got %v", order)
+		}
+	})
 }
 
 func TestService_CreatePrice(t *testing.T) {

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/raystack/frontier/billing/product"
 	"github.com/raystack/frontier/billing/product/mocks"
 	stripemock "github.com/raystack/frontier/billing/stripetest/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stripe/stripe-go/v79/client"
 )
 
@@ -458,6 +459,119 @@ func TestPrice_IsActive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestService_Update_ConvergesPrices(t *testing.T) {
+	ctx := context.Background()
+	existing := product.Product{
+		ID:          "prod-1",
+		Name:        "product1",
+		Description: "product 1",
+		Behavior:    product.BasicBehavior,
+	}
+
+	// expectProductNoise sets up the product-level mock calls every Update
+	// makes, so a price test asserts only on the price calls.
+	expectProductNoise := func(be *stripemock.Backend, pr *mocks.Repository, fr *mocks.FeatureRepository) {
+		pr.EXPECT().GetByID(mock.Anything, "prod-1").Return(existing, nil)
+		pr.EXPECT().UpdateByName(mock.Anything, mock.Anything).Return(existing, nil)
+		fr.EXPECT().List(mock.Anything, mock.Anything).Return([]product.Feature{}, nil)
+		be.EXPECT().Call("POST", "/v1/products/", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	}
+
+	desired := func(prices ...product.Price) product.Product {
+		return product.Product{
+			ID:          "prod-1",
+			Name:        "product1",
+			Description: "product 1",
+			Behavior:    product.BasicBehavior,
+			Prices:      prices,
+		}
+	}
+	monthly := product.Price{
+		Name:          "monthly",
+		Amount:        100,
+		Currency:      "usd",
+		BillingScheme: product.BillingSchemeFlat,
+		UsageType:     product.PriceUsageTypeLicensed,
+		Interval:      "month",
+	}
+
+	t.Run("adds a price when the desired list names one the product does not have", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{}, nil)
+		be.EXPECT().Call("POST", "/v1/prices", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		priceRepo.EXPECT().Create(mock.Anything, mock.MatchedBy(func(p product.Price) bool {
+			return p.Name == "monthly" && p.ProductID == "prod-1" && p.Amount == 100
+		})).Return(monthly, nil)
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		if _, err := svc.Update(ctx, desired(monthly)); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("rejects an in-place amount change on an existing price name", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
+			Return([]product.Price{{Name: "monthly", Amount: 100}}, nil)
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		changed := monthly
+		changed.Amount = 200
+		if _, err := svc.Update(ctx, desired(changed)); err == nil {
+			t.Fatalf("Update() expected an error for an in-place amount change, got nil")
+		}
+	})
+
+	t.Run("retires an active price the desired list omits", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{
+			{ID: "price-monthly", Name: "monthly", Amount: 100, State: "active"},
+			{ID: "price-old", ProviderID: "stripe_old", Name: "old_monthly", Amount: 100, State: "active"},
+		}, nil)
+		// the omitted active price is retired in provider and repo
+		be.EXPECT().Call("POST", "/v1/prices/stripe_old", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		priceRepo.EXPECT().UpdateByID(mock.Anything, mock.MatchedBy(func(p product.Price) bool {
+			return p.Name == "old_monthly" && p.State == "inactive"
+		})).Return(product.Price{}, nil)
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		if _, err := svc.Update(ctx, desired(monthly)); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("is a no-op when the desired price already exists unchanged", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
+			Return([]product.Price{{ID: "price-monthly", Name: "monthly", Amount: 100, State: "active"}}, nil)
+
+		// No price Create/UpdateByID or Stripe price calls are set up, so if
+		// convergePrices made any change the strict mocks would fail the test.
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		if _, err := svc.Update(ctx, desired(monthly)); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("empty price list leaves existing prices untouched", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		// populateProduct still lists prices for the return value; a product with
+		// an existing price must not have it retired just because none were sent.
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
+			Return([]product.Price{{ID: "price-monthly", Name: "monthly", Amount: 100, State: "active"}}, nil)
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		if _, err := svc.Update(ctx, desired()); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+	})
 }
 
 func TestService_CreatePrice(t *testing.T) {

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -479,6 +479,14 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		be.EXPECT().Call("POST", "/v1/products/", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	}
 
+	// expectPriceRead sets up only the reads a validation check needs. A
+	// validation error must return before any product or price mutation, so no
+	// other mock calls are set and a strict mock fails if the code mutates anything.
+	expectPriceRead := func(pr *mocks.Repository, priceRepo *mocks.PriceRepository, current []product.Price) {
+		pr.EXPECT().GetByID(mock.Anything, "prod-1").Return(existing, nil)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return(current, nil)
+	}
+
 	desired := func(prices ...product.Price) product.Product {
 		return product.Product{
 			ID:          "prod-1",
@@ -512,11 +520,9 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects an in-place amount change on an existing price name", func(t *testing.T) {
-		stripeClient, be, pr, priceRepo, fr := mockService(t)
-		expectProductNoise(be, pr, fr)
-		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
-			Return([]product.Price{{Name: "monthly", Amount: 100}}, nil)
+	t.Run("rejects an in-place amount change without mutating the product", func(t *testing.T) {
+		stripeClient, _, pr, priceRepo, fr := mockService(t)
+		expectPriceRead(pr, priceRepo, []product.Price{{Name: "monthly", Amount: 100, Currency: "usd", Interval: "month"}})
 
 		svc := product.NewService(stripeClient, pr, priceRepo, fr)
 		changed := monthly
@@ -526,11 +532,45 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects a currency change on an existing price name", func(t *testing.T) {
+		stripeClient, _, pr, priceRepo, fr := mockService(t)
+		expectPriceRead(pr, priceRepo, []product.Price{{Name: "monthly", Amount: 100, Currency: "usd", Interval: "month"}})
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		changed := monthly
+		changed.Currency = "eur"
+		if _, err := svc.Update(ctx, desired(changed)); err == nil {
+			t.Fatalf("Update() expected an error for a currency change, got nil")
+		}
+	})
+
+	t.Run("rejects a duplicate price name in the desired list", func(t *testing.T) {
+		stripeClient, _, pr, priceRepo, fr := mockService(t)
+		expectPriceRead(pr, priceRepo, []product.Price{})
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		if _, err := svc.Update(ctx, desired(monthly, monthly)); err == nil {
+			t.Fatalf("Update() expected an error for a duplicate price name, got nil")
+		}
+	})
+
+	t.Run("rejects an empty price name", func(t *testing.T) {
+		stripeClient, _, pr, priceRepo, fr := mockService(t)
+		expectPriceRead(pr, priceRepo, []product.Price{})
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		noName := monthly
+		noName.Name = ""
+		if _, err := svc.Update(ctx, desired(noName)); err == nil {
+			t.Fatalf("Update() expected an error for an empty price name, got nil")
+		}
+	})
+
 	t.Run("retires an active price the desired list omits", func(t *testing.T) {
 		stripeClient, be, pr, priceRepo, fr := mockService(t)
 		expectProductNoise(be, pr, fr)
 		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{
-			{ID: "price-monthly", Name: "monthly", Amount: 100, State: "active"},
+			{ID: "price-monthly", Name: "monthly", Amount: 100, Currency: "usd", Interval: "month", State: "active"},
 			{ID: "price-old", ProviderID: "stripe_old", Name: "old_monthly", Amount: 100, State: "active"},
 		}, nil)
 		// the omitted active price is retired in provider and repo
@@ -549,7 +589,7 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		stripeClient, be, pr, priceRepo, fr := mockService(t)
 		expectProductNoise(be, pr, fr)
 		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
-			Return([]product.Price{{ID: "price-monthly", Name: "monthly", Amount: 100, State: "active"}}, nil)
+			Return([]product.Price{{ID: "price-monthly", Name: "monthly", Amount: 100, Currency: "usd", Interval: "month", State: "active"}}, nil)
 
 		// No price Create/UpdateByID or Stripe price calls are set up, so if
 		// convergePrices made any change the strict mocks would fail the test.
@@ -569,6 +609,24 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 
 		svc := product.NewService(stripeClient, pr, priceRepo, fr)
 		if _, err := svc.Update(ctx, desired()); err != nil {
+			t.Fatalf("Update() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("reactivates a retired price the desired list names again", func(t *testing.T) {
+		stripeClient, be, pr, priceRepo, fr := mockService(t)
+		expectProductNoise(be, pr, fr)
+		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{
+			{ID: "price-monthly", ProviderID: "stripe_monthly", Name: "monthly", Amount: 100, Currency: "usd", Interval: "month", State: "inactive"},
+		}, nil)
+		// the retired price is reactivated in provider and repo, not recreated
+		be.EXPECT().Call("POST", "/v1/prices/stripe_monthly", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		priceRepo.EXPECT().UpdateByID(mock.Anything, mock.MatchedBy(func(p product.Price) bool {
+			return p.Name == "monthly" && p.State == "active"
+		})).Return(product.Price{}, nil)
+
+		svc := product.NewService(stripeClient, pr, priceRepo, fr)
+		if _, err := svc.Update(ctx, desired(monthly)); err != nil {
 			t.Fatalf("Update() unexpected error = %v", err)
 		}
 	})

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -566,14 +566,14 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		}
 	})
 
-	t.Run("retires an active price the desired list omits", func(t *testing.T) {
+	t.Run("deactivates an active price the desired list omits", func(t *testing.T) {
 		stripeClient, be, pr, priceRepo, fr := mockService(t)
 		expectProductNoise(be, pr, fr)
 		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{
 			{ID: "price-monthly", Name: "monthly", Amount: 100, Currency: "usd", Interval: "month", State: "active"},
 			{ID: "price-old", ProviderID: "stripe_old", Name: "old_monthly", Amount: 100, State: "active"},
 		}, nil)
-		// the omitted active price is retired in provider and repo
+		// the omitted active price is deactivated in provider and repo
 		be.EXPECT().Call("POST", "/v1/prices/stripe_old", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		priceRepo.EXPECT().UpdateByID(mock.Anything, mock.MatchedBy(func(p product.Price) bool {
 			return p.Name == "old_monthly" && p.State == "inactive"
@@ -603,7 +603,7 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		stripeClient, be, pr, priceRepo, fr := mockService(t)
 		expectProductNoise(be, pr, fr)
 		// populateProduct still lists prices for the return value; a product with
-		// an existing price must not have it retired just because none were sent.
+		// an existing price must not have it deactivated just because none were sent.
 		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).
 			Return([]product.Price{{ID: "price-monthly", Name: "monthly", Amount: 100, State: "active"}}, nil)
 
@@ -613,13 +613,13 @@ func TestService_Update_ConvergesPrices(t *testing.T) {
 		}
 	})
 
-	t.Run("reactivates a retired price the desired list names again", func(t *testing.T) {
+	t.Run("activates an inactive price the desired list names again", func(t *testing.T) {
 		stripeClient, be, pr, priceRepo, fr := mockService(t)
 		expectProductNoise(be, pr, fr)
 		priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{
 			{ID: "price-monthly", ProviderID: "stripe_monthly", Name: "monthly", Amount: 100, Currency: "usd", Interval: "month", State: "inactive"},
 		}, nil)
-		// the retired price is reactivated in provider and repo, not recreated
+		// the inactive price is activated in provider and repo, not recreated
 		be.EXPECT().Call("POST", "/v1/prices/stripe_monthly", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		priceRepo.EXPECT().UpdateByID(mock.Anything, mock.MatchedBy(func(p product.Price) bool {
 			return p.Name == "monthly" && p.State == "active"

--- a/internal/api/v1beta1connect/billing_product.go
+++ b/internal/api/v1beta1connect/billing_product.go
@@ -162,7 +162,13 @@ func (h *ConnectHandler) UpdateProduct(ctx context.Context, request *connect.Req
 		Metadata:    metaDataMap,
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("UpdateProduct.Update: product_id=%s product_name=%s product_title=%s behavior=%s price_count=%d feature_count=%d: %w",
+		// an invalid price (bad name, duplicate, or a change to an immutable
+		// field) is the caller's fault, so report it as an invalid argument.
+		code := connect.CodeInternal
+		if errors.Is(err, product.ErrInvalidDetail) {
+			code = connect.CodeInvalidArgument
+		}
+		return nil, connect.NewError(code, fmt.Errorf("UpdateProduct.Update: product_id=%s product_name=%s product_title=%s behavior=%s price_count=%d feature_count=%d: %w",
 			request.Msg.GetId(), request.Msg.GetBody().GetName(), request.Msg.GetBody().GetTitle(),
 			request.Msg.GetBody().GetBehavior(), len(productPrices), len(productFeatures), err))
 	}

--- a/internal/api/v1beta1connect/billing_product.go
+++ b/internal/api/v1beta1connect/billing_product.go
@@ -111,13 +111,23 @@ func (h *ConnectHandler) CreateProduct(ctx context.Context, request *connect.Req
 
 func (h *ConnectHandler) UpdateProduct(ctx context.Context, request *connect.Request[frontierv1beta1.UpdateProductRequest]) (*connect.Response[frontierv1beta1.UpdateProductResponse], error) {
 	metaDataMap := metadata.Build(request.Msg.GetBody().GetMetadata().AsMap())
-	// parse price
+	// parse price. The full price fields are carried so a price the product
+	// does not have yet can be created by product.Update's price convergence.
 	var productPrices []product.Price
 	for _, v := range request.Msg.GetBody().GetPrices() {
+		var priceMetadata metadata.Metadata
+		if v.GetMetadata() != nil {
+			priceMetadata = metadata.Build(v.GetMetadata().AsMap())
+		}
 		productPrices = append(productPrices, product.Price{
-			ID:       v.GetId(),
-			Name:     v.GetName(),
-			Metadata: metadata.Build(v.GetMetadata().AsMap()),
+			Name:             v.GetName(),
+			Amount:           v.GetAmount(),
+			Currency:         v.GetCurrency(),
+			UsageType:        product.BuildPriceUsageType(v.GetUsageType()),
+			BillingScheme:    product.BuildBillingScheme(v.GetBillingScheme()),
+			MeteredAggregate: v.GetMeteredAggregate(),
+			Interval:         v.GetInterval(),
+			Metadata:         priceMetadata,
 		})
 	}
 	// parse features

--- a/internal/store/postgres/billing_price_repository.go
+++ b/internal/store/postgres/billing_price_repository.go
@@ -185,9 +185,13 @@ func (r BillingPriceRepository) UpdateByID(ctx context.Context, toUpdate product
 	}
 	updateRecord := goqu.Record{
 		"name":       toUpdate.Name,
-		"state":      toUpdate.State,
 		"metadata":   marshaledMetadata,
 		"updated_at": goqu.L("now()"),
+	}
+	// only write state when set, so a caller that builds a sparse Price (no
+	// state) cannot blank the column and wrongly reactivate an inactive price.
+	if toUpdate.State != "" {
+		updateRecord["state"] = toUpdate.State
 	}
 	query, params, err := dialect.Update(TABLE_BILLING_PRICES).Set(updateRecord).Where(goqu.Ex{
 		"id": toUpdate.ID,

--- a/internal/store/postgres/billing_price_repository.go
+++ b/internal/store/postgres/billing_price_repository.go
@@ -185,6 +185,7 @@ func (r BillingPriceRepository) UpdateByID(ctx context.Context, toUpdate product
 	}
 	updateRecord := goqu.Record{
 		"name":       toUpdate.Name,
+		"state":      toUpdate.State,
 		"metadata":   marshaledMetadata,
 		"updated_at": goqu.L("now()"),
 	}


### PR DESCRIPTION
## What

Teach `UpdateProduct` to manage a product's prices. When the request carries a non-empty list of prices, `product.Update` converges the product's prices to that list. An empty list leaves prices untouched.

## Builds on #1811 (merged)

The consumer-side hardening in #1811 (ignore inactive prices in checkout, plan matching, and invoicing) is merged to main, so this PR now stands alone and its diff is only the UpdateProduct changes.

## How it behaves

The price list is authoritative when it is not empty. A price is identified by its name within the product.

- The list is validated before the product is touched, so an invalid price fails the whole update instead of half-applying the product's other changes.
- Names must be present and unique in the list.
- A name the product does not have yet is created.
- A name that already exists must keep its immutable fields (amount, currency, interval, billing scheme, usage type). A change to any of them is rejected with a clear error that tells you to add a new price under a new name, since provider prices cannot be changed in place.
- A retired price named again in the list is reactivated, not recreated.
- An active price the list no longer names is retired: marked inactive in the provider and the database, never deleted.
- Adds and reactivations run before retires, so the product always has the new price before an old one goes inactive.
- Applying the same list again makes no further changes.

## Changes

- `product.Update` reads and validates the desired prices up front (`validateDesiredPrices`), then applies convergence (`applyPriceConvergence`); `reactivatePrice` and `deactivatePrice` share one `setPriceActive` helper that skips the provider call when there is no provider id.
- The price repository `UpdateByID` persists the `state` column, so a price can be retired or reactivated.
- The `UpdateProduct` handler reads the full price fields and reports a rejected price as `InvalidArgument`.
- `AddPlan` no longer triggers price convergence when it only links a plan to a product.

## Tests

`Update` price convergence is covered: add a price, retire an omitted active price, reactivate a re-listed retired price, reject an in-place amount or currency change, reject a duplicate or empty name, an empty list leaves prices untouched, and applying an unchanged list makes no changes. Validation errors are asserted to happen before any product mutation.