### PR TITLE
fix(billing): ignore inactive prices in checkout, plan matching, and invoicing

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -269,6 +269,10 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 			}
 
 			for _, productPrice := range planProduct.Prices {
+				// skip retired prices; they cannot be used for a new checkout
+				if !productPrice.IsActive() {
+					continue
+				}
 				// only work with plan interval prices
 				if productPrice.Interval != plan.Interval {
 					continue
@@ -394,6 +398,10 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 		}
 		amountSubtotal := int64(0)
 		for _, productPrice := range chProduct.Prices {
+			// skip retired prices; they cannot be used for a new checkout
+			if !productPrice.IsActive() {
+				continue
+			}
 			itemParams := &stripe.CheckoutSessionLineItemParams{
 				Price: stripe.String(productPrice.ProviderID),
 				AdjustableQuantity: &stripe.CheckoutSessionLineItemAdjustableQuantityParams{
@@ -896,6 +904,10 @@ func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscri
 			}
 
 			for _, productPrice := range planProduct.Prices {
+				// skip retired prices; they cannot be used for a new subscription
+				if !productPrice.IsActive() {
+					continue
+				}
 				// only work with plan interval prices
 				if productPrice.Interval != plan.Interval {
 					continue

--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -257,11 +257,13 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 			return Checkout{}, fmt.Errorf("failed to get member count: %w", err)
 		}
 
+		hasBillableProduct := false
 		for _, planProduct := range plan.Products {
 			// if it's credit, skip
 			if planProduct.Behavior == product.CreditBehavior {
 				continue
 			}
+			hasBillableProduct = true
 
 			// if per seat, check if there is a limit of seats, if it breaches limit, fail
 			if planProduct.IsSeatLimitBreached(userCount) {
@@ -288,6 +290,9 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 				}
 				subsItems = append(subsItems, itemParams)
 			}
+		}
+		if hasBillableProduct && len(subsItems) == 0 {
+			return Checkout{}, fmt.Errorf("plan %s has no active prices for interval %s", plan.Name, plan.Interval)
 		}
 
 		var trialDays *int64 = nil
@@ -421,6 +426,9 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 			}
 
 			subsItems = append(subsItems, itemParams)
+		}
+		if len(subsItems) == 0 {
+			return Checkout{}, fmt.Errorf("product %s has no active prices", chProduct.Name)
 		}
 
 		// plan payment methods on the basis of amount subtotal
@@ -893,11 +901,13 @@ func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscri
 		}
 
 		var totalExpectedPrice int64
+		hasBillableProduct := false
 		for _, planProduct := range plan.Products {
 			// if it's credit, skip, they are handled separately
 			if planProduct.Behavior == product.CreditBehavior {
 				continue
 			}
+			hasBillableProduct = true
 			// if per seat, check if there is a limit of seats, if it breaches limit, fail
 			if planProduct.IsSeatLimitBreached(userCount) {
 				return nil, nil, fmt.Errorf("member count exceeds allowed limit of the plan: %w", product.ErrPerSeatLimitReached)
@@ -929,6 +939,9 @@ func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscri
 				subsItems = append(subsItems, itemParams)
 				totalExpectedPrice += productPrice.Amount * quantity
 			}
+		}
+		if hasBillableProduct && len(subsItems) == 0 {
+			return nil, nil, fmt.Errorf("plan %s has no active prices for interval %s", plan.Name, plan.Interval)
 		}
 
 		var trialDays *int64 = nil

--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -271,7 +271,7 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 			}
 
 			for _, productPrice := range planProduct.Prices {
-				// skip retired prices; they cannot be used for a new checkout
+				// skip inactive prices; they cannot be used for a new checkout
 				if !productPrice.IsActive() {
 					continue
 				}
@@ -403,7 +403,7 @@ func (s *Service) Create(ctx context.Context, ch Checkout) (Checkout, error) {
 		}
 		amountSubtotal := int64(0)
 		for _, productPrice := range chProduct.Prices {
-			// skip retired prices; they cannot be used for a new checkout
+			// skip inactive prices; they cannot be used for a new checkout
 			if !productPrice.IsActive() {
 				continue
 			}
@@ -914,7 +914,7 @@ func (s *Service) Apply(ctx context.Context, ch Checkout) (*subscription.Subscri
 			}
 
 			for _, productPrice := range planProduct.Prices {
-				// skip retired prices; they cannot be used for a new subscription
+				// skip inactive prices; they cannot be used for a new subscription
 				if !productPrice.IsActive() {
 					continue
 				}

--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -129,11 +129,19 @@ func (s *Service) Init(ctx context.Context) error {
 		if creditProduct.Behavior != product.CreditBehavior {
 			return errors.New("credit overdraft product must have credit behavior")
 		}
-		// get first price
-		if len(creditProduct.Prices) == 0 {
-			return errors.New("credit overdraft product must have at least one price")
+		// use the first active price. A retired price must not set the overdraft rate.
+		var creditPrice product.Price
+		foundActivePrice := false
+		for _, p := range creditProduct.Prices {
+			if p.IsActive() {
+				creditPrice = p
+				foundActivePrice = true
+				break
+			}
 		}
-		creditPrice := creditProduct.Prices[0]
+		if !foundActivePrice {
+			return errors.New("credit overdraft product must have at least one active price")
+		}
 		if creditPrice.Currency == "" {
 			return errors.New("credit overdraft product price must have a currency")
 		}

--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -129,7 +129,7 @@ func (s *Service) Init(ctx context.Context) error {
 		if creditProduct.Behavior != product.CreditBehavior {
 			return errors.New("credit overdraft product must have credit behavior")
 		}
-		// use the first active price. A retired price must not set the overdraft rate.
+		// use the first active price. An inactive price must not set the overdraft rate.
 		var creditPrice product.Price
 		foundActivePrice := false
 		for _, p := range creditProduct.Prices {

--- a/billing/plan/plan.go
+++ b/billing/plan/plan.go
@@ -60,6 +60,10 @@ func (p Plan) GetUserSeatProduct() (product.Product, bool) {
 func (p Plan) IsFree() bool {
 	for _, prod := range p.Products {
 		for _, price := range prod.Prices {
+			// a retired price is not charged, so it must not make the plan paid
+			if !price.IsActive() {
+				continue
+			}
 			if price.Amount > 0 {
 				return false
 			}

--- a/billing/plan/plan.go
+++ b/billing/plan/plan.go
@@ -60,7 +60,7 @@ func (p Plan) GetUserSeatProduct() (product.Product, bool) {
 func (p Plan) IsFree() bool {
 	for _, prod := range p.Products {
 		for _, price := range prod.Prices {
-			// a retired price is not charged, so it must not make the plan paid
+			// an inactive price is not charged, so it must not make the plan paid
 			if !price.IsActive() {
 				continue
 			}

--- a/billing/plan/plan_test.go
+++ b/billing/plan/plan_test.go
@@ -24,7 +24,7 @@ func TestPlan_IsFree(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "a retired paid price does not make the plan paid",
+			name: "an inactive paid price does not make the plan paid",
 			plan: plan.Plan{Products: []product.Product{{Prices: []product.Price{{Amount: 100, State: product.PriceStateInactive}}}}},
 			want: true,
 		},

--- a/billing/plan/plan_test.go
+++ b/billing/plan/plan_test.go
@@ -1,0 +1,44 @@
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/raystack/frontier/billing/plan"
+	"github.com/raystack/frontier/billing/product"
+)
+
+func TestPlan_IsFree(t *testing.T) {
+	tests := []struct {
+		name string
+		plan plan.Plan
+		want bool
+	}{
+		{
+			name: "a plan with no products is free",
+			plan: plan.Plan{},
+			want: true,
+		},
+		{
+			name: "an active paid price is not free",
+			plan: plan.Plan{Products: []product.Product{{Prices: []product.Price{{Amount: 100}}}}},
+			want: false,
+		},
+		{
+			name: "a retired paid price does not make the plan paid",
+			plan: plan.Plan{Products: []product.Product{{Prices: []product.Price{{Amount: 100, State: product.PriceStateInactive}}}}},
+			want: true,
+		},
+		{
+			name: "an active zero price is free",
+			plan: plan.Plan{Products: []product.Product{{Prices: []product.Price{{Amount: 0}}}}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.plan.IsFree(); got != tt.want {
+				t.Errorf("IsFree() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/billing/plan/service.go
+++ b/billing/plan/service.go
@@ -311,7 +311,7 @@ func (s Service) UpsertPlans(ctx context.Context, planFile File) error {
 
 			// ensure plan can be added to product
 			hasMatchingPrice := utils.ContainsFunc(productOb.Prices, func(p product.Price) bool {
-				return p.Interval == planOb.Interval
+				return p.IsActive() && p.Interval == planOb.Interval
 			})
 			if !hasMatchingPrice {
 				return fmt.Errorf("product %s has no prices registered with this interval, plan %s has interval %s",

--- a/billing/plan/service.go
+++ b/billing/plan/service.go
@@ -314,7 +314,7 @@ func (s Service) UpsertPlans(ctx context.Context, planFile File) error {
 				return p.IsActive() && p.Interval == planOb.Interval
 			})
 			if !hasMatchingPrice {
-				return fmt.Errorf("product %s has no prices registered with this interval, plan %s has interval %s",
+				return fmt.Errorf("product %s has no active prices registered with this interval, plan %s has interval %s",
 					productOb.Name, planOb.Name, planOb.Interval)
 			}
 			if err = s.productService.AddPlan(ctx, productOb, planOb.ID); err != nil {

--- a/billing/product/product.go
+++ b/billing/product/product.go
@@ -117,10 +117,12 @@ const (
 
 // IsActive reports whether the price can be used for new purchases. A retired
 // price is marked inactive, so an inactive price must be left out of checkout
-// line items, plan matching, and invoicing. An empty state is treated as active,
-// since that is the database default for a newly created price.
+// line items, plan matching, and invoicing. Only the active state counts as
+// usable, along with an empty state, which an in-memory price carries before it
+// is stored (the stored default is active). Any other value is treated as not
+// active, so an unexpected state fails closed rather than being billed.
 func (price Price) IsActive() bool {
-	return price.State != PriceStateInactive
+	return price.State == "" || price.State == PriceStateActive
 }
 
 type BillingScheme string

--- a/billing/product/product.go
+++ b/billing/product/product.go
@@ -108,6 +108,21 @@ func (price Price) IsLicensed() bool {
 	return price.UsageType == PriceUsageTypeLicensed
 }
 
+// Price states. A new price is active. A superseded price is retired by marking
+// it inactive rather than deleting it, since provider prices are immutable.
+const (
+	PriceStateActive   = "active"
+	PriceStateInactive = "inactive"
+)
+
+// IsActive reports whether the price can be used for new purchases. A retired
+// price is marked inactive, so an inactive price must be left out of checkout
+// line items, plan matching, and invoicing. An empty state is treated as active,
+// since that is the database default for a newly created price.
+func (price Price) IsActive() bool {
+	return price.State != PriceStateInactive
+}
+
 type BillingScheme string
 
 const (

--- a/billing/product/product.go
+++ b/billing/product/product.go
@@ -108,19 +108,19 @@ func (price Price) IsLicensed() bool {
 	return price.UsageType == PriceUsageTypeLicensed
 }
 
-// Price states. A new price is active. A superseded price is retired by marking
-// it inactive rather than deleting it, since provider prices are immutable.
+// Price states. A new price is active. A price is deactivated by setting it
+// inactive rather than deleting it, since provider prices cannot be deleted.
 const (
 	PriceStateActive   = "active"
 	PriceStateInactive = "inactive"
 )
 
-// IsActive reports whether the price can be used for new purchases. A retired
-// price is marked inactive, so an inactive price must be left out of checkout
-// line items, plan matching, and invoicing. Only the active state counts as
-// usable, along with an empty state, which an in-memory price carries before it
-// is stored (the stored default is active). Any other value is treated as not
-// active, so an unexpected state fails closed rather than being billed.
+// IsActive reports whether the price can be used for new purchases. An inactive
+// price must be left out of checkout line items, plan matching, and invoicing.
+// Only the active state counts as usable, along with an empty state, which an
+// in-memory price carries before it is stored (the stored default is active).
+// Any other value is treated as not active, so an unexpected state fails closed
+// rather than being billed.
 func (price Price) IsActive() bool {
 	return price.State == "" || price.State == PriceStateActive
 }

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -439,6 +439,26 @@ func TestService_Update(t *testing.T) {
 	}
 }
 
+func TestPrice_IsActive(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{name: "explicit active state is active", state: "active", want: true},
+		{name: "empty state is treated as active", state: "", want: true},
+		{name: "inactive state is not active", state: "inactive", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := product.Price{State: tt.state}
+			if got := p.IsActive(); got != tt.want {
+				t.Errorf("IsActive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestService_CreatePrice(t *testing.T) {
 	ctx := context.Background()
 	type args struct {

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -448,6 +448,7 @@ func TestPrice_IsActive(t *testing.T) {
 		{name: "explicit active state is active", state: "active", want: true},
 		{name: "empty state is treated as active", state: "", want: true},
 		{name: "inactive state is not active", state: "inactive", want: false},
+		{name: "unknown state is not active", state: "archived", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -648,11 +648,13 @@ func (s *Service) ChangePlan(ctx context.Context, id string, changeRequest Chang
 	}
 
 	var nextPhaseItems []*stripe.SubscriptionSchedulePhaseItemParams
+	hasBillableProduct := false
 	for _, planProduct := range planObj.Products {
 		// if it's credit, skip
 		if planProduct.Behavior == product.CreditBehavior {
 			continue
 		}
+		hasBillableProduct = true
 
 		// if per seat, check if there is a limit of seats, if it breaches limit, fail
 		if planProduct.Behavior == product.PerSeatBehavior {
@@ -661,6 +663,10 @@ func (s *Service) ChangePlan(ctx context.Context, id string, changeRequest Chang
 			}
 		}
 		for _, planProductPrice := range planProduct.Prices {
+			// skip retired prices; they cannot be used for a new subscription phase
+			if !planProductPrice.IsActive() {
+				continue
+			}
 			// only work with plan interval prices
 			if planProductPrice.Interval != planObj.Interval {
 				continue
@@ -679,6 +685,11 @@ func (s *Service) ChangePlan(ctx context.Context, id string, changeRequest Chang
 				},
 			})
 		}
+	}
+	// a non-credit product with no active price for the interval means the plan
+	// cannot be billed; fail loudly instead of silently dropping the next phase
+	if hasBillableProduct && len(nextPhaseItems) == 0 {
+		return change, fmt.Errorf("plan %s has no active prices for interval %s", planObj.Name, planObj.Interval)
 	}
 
 	// find current phase out of list of phases

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -663,7 +663,7 @@ func (s *Service) ChangePlan(ctx context.Context, id string, changeRequest Chang
 			}
 		}
 		for _, planProductPrice := range planProduct.Prices {
-			// skip retired prices; they cannot be used for a new subscription phase
+			// skip inactive prices; they cannot be used for a new subscription phase
 			if !planProductPrice.IsActive() {
 				continue
 			}


### PR DESCRIPTION
## What

Make every purchase and billing path ignore prices that are marked inactive. An inactive price is a retired one, and it must never be used for a new checkout, subscription, plan change, plan match, or invoice.

## Why

A price can be retired by marking it inactive rather than deleted, since provider (Stripe) prices are immutable and cannot be removed. But nothing in the code filtered by state, so a retired price would still flow into checkout line items, plan changes, and plan matching. Stripe rejects an archived price in a new checkout, so a product with a retired price could fail to sell or bill the wrong amount. This change makes the system safe to hold inactive prices, which is a prerequisite for managing a product's prices over time.

## Changes

- New `Price.IsActive()` helper and `PriceStateActive` / `PriceStateInactive` constants. Only the active state (or an empty state, which an in-memory price carries before it is stored) counts as usable; any other value fails closed.
- Checkout: plan checkout, one-time product checkout, and subscription sync skip inactive prices when building line items.
- Subscription: `ChangePlan` skips inactive prices when building the next subscription phase.
- Plan matching: `hasMatchingPrice` no longer counts an inactive price, and its error now says "no active prices".
- `Plan.IsFree()` ignores retired prices, so retiring a paid price can make a plan free.
- Credit overdraft invoice: the rate comes from the first active price, and the product must have at least one active price.
- Empty guards: if a plan or product has billable products but no active price to bill, the flow fails with a clear error instead of sending an empty request to Stripe. A credit-only plan still passes, since it has nothing to bill by design.

## Tests

`Price.IsActive()` and `Plan.IsFree()` are unit-tested, including the retired-price and unknown-state cases. The call-site changes apply those helpers as guards, and the existing billing test suites pass.

## Notes

- Behavior is unchanged today, since nothing sets a price inactive yet. This is groundwork for a follow-up that lets `UpdateProduct` retire a price.
- Two items are intentionally out of this PR and must land before any price is actually retired: the web SDK still reads `prices[0]` and would show a retired rate to users, and the plan boot loader matches a price by name including retired ones. Both belong with the retire feature.