### PR TITLE
refactor(membership): stop writing org owner/member relations

### DIFF
--- a/core/membership/service.go
+++ b/core/membership/service.go
@@ -146,8 +146,7 @@ func (s *Service) AddOrganizationMember(ctx context.Context, orgID, principalID,
 		return err
 	}
 
-	fetchedRole, err := s.validateOrgRole(ctx, roleID, orgID)
-	if err != nil {
+	if _, err := s.validateOrgRole(ctx, roleID, orgID); err != nil {
 		return err
 	}
 
@@ -167,26 +166,6 @@ func (s *Service) AddOrganizationMember(ctx context.Context, orgID, principalID,
 
 	createdPolicy, err := s.createPolicy(ctx, orgID, schema.OrganizationNamespace, principalID, principalType, roleID)
 	if err != nil {
-		return err
-	}
-
-	// PATs don't get relations.
-	if principalType == schema.PATPrincipal {
-		s.auditOrgMemberAdded(ctx, org, principal, roleID)
-		return nil
-	}
-
-	relationName := orgRoleToRelation(fetchedRole)
-	if err := s.createRelation(ctx, orgID, schema.OrganizationNamespace, principalID, principalType, relationName); err != nil {
-		// best-effort cleanup to avoid orphaned policy
-		if deleteErr := s.policyService.Delete(ctx, createdPolicy.ID); deleteErr != nil {
-			s.log.WarnContext(ctx, "orphaned policy: relation creation failed and policy cleanup also failed",
-				"policy_id", createdPolicy.ID,
-				"org_id", orgID,
-				"principal_id", principalID,
-				"policy_delete_error", deleteErr,
-			)
-		}
 		return err
 	}
 
@@ -263,27 +242,6 @@ func (s *Service) SetOrganizationMemberRole(ctx context.Context, orgID, principa
 	}
 
 	if err := s.replacePolicy(ctx, orgID, schema.OrganizationNamespace, principalID, principalType, resolvedRoleID, existing, ownerRoleID); err != nil {
-		return err
-	}
-
-	// PATs don't get relations.
-	if principalType == schema.PATPrincipal {
-		s.auditOrgMemberRoleChanged(ctx, org, principal, resolvedRoleID)
-		return nil
-	}
-
-	newRelation := orgRoleToRelation(fetchedRole)
-	oldRelations := []string{schema.OwnerRelationName, schema.MemberRelationName}
-	err = s.replaceRelation(ctx, orgID, schema.OrganizationNamespace, principalID, principalType, oldRelations, newRelation)
-	if err != nil {
-		s.log.ErrorContext(ctx, "membership state inconsistent: policy replaced but relation update failed, needs manual fix",
-			"org_id", orgID,
-			"principal_id", principalID,
-			"principal_type", principalType,
-			"new_role_id", resolvedRoleID,
-			"expected_relation", newRelation,
-			"error", err,
-		)
 		return err
 	}
 
@@ -592,6 +550,9 @@ func (s *Service) removeCustomResourceAccess(ctx context.Context, principalID, p
 }
 
 // removeRelations deletes owner and member relations for a principal on a resource.
+// New memberships only write the group member relation, but removal still clears
+// both names so members added before the owner/member writes were dropped leave
+// no stale tuples behind.
 func (s *Service) removeRelations(ctx context.Context, resourceID, resourceType, principalID, principalType string) error {
 	obj := relation.Object{ID: resourceID, Namespace: resourceType}
 	sub := relation.Subject{ID: principalID, Namespace: principalType}
@@ -802,15 +763,6 @@ func (s *Service) validatePrincipal(ctx context.Context, orgID, principalID, pri
 	default:
 		return principalInfo{}, ErrInvalidPrincipal
 	}
-}
-
-// orgRoleToRelation maps an org role to the corresponding SpiceDB relation name.
-// Owner role gets "owner" relation, everything else gets "member" relation.
-func orgRoleToRelation(r role.Role) string {
-	if r.Name == schema.RoleOrganizationOwner {
-		return schema.OwnerRelationName
-	}
-	return schema.MemberRelationName
 }
 
 func (s *Service) createPolicy(ctx context.Context, resourceID, resourceType, principalID, principalType, roleID string) (policy.Policy, error) {
@@ -1396,7 +1348,7 @@ func (s *Service) SetGroupMemberRole(ctx context.Context, groupID, principalID, 
 		if err != nil {
 			return err
 		}
-		if err := s.createRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, groupRoleToRelation(fetchedRole)); err != nil {
+		if err := s.createRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, schema.MemberRelationName); err != nil {
 			if deleteErr := s.policyService.Delete(ctx, createdPolicy.ID); deleteErr != nil {
 				s.log.WarnContext(ctx, "orphaned policy: relation creation failed and policy cleanup also failed",
 					"policy_id", createdPolicy.ID,
@@ -1430,15 +1382,15 @@ func (s *Service) SetGroupMemberRole(ctx context.Context, groupID, principalID, 
 		return err
 	}
 
-	newRelation := groupRoleToRelation(fetchedRole)
-	oldRelations := []string{schema.OwnerRelationName, schema.MemberRelationName}
-	if err := s.replaceRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, oldRelations, newRelation); err != nil {
+	// migrate any legacy owner relation to member; role changes never alter the
+	// relation shape anymore — every group member carries the member relation.
+	oldRelations := []string{schema.OwnerRelationName}
+	if err := s.replaceRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, oldRelations, schema.MemberRelationName); err != nil {
 		s.log.ErrorContext(ctx, "membership state inconsistent: policy replaced but group relation update failed, needs manual fix",
 			"group_id", groupID,
 			"principal_id", principalID,
 			"principal_type", principalType,
 			"new_role_id", resolvedRoleID,
-			"expected_relation", newRelation,
 			"error", err,
 		)
 		return err
@@ -1623,46 +1575,23 @@ func (s *Service) OnGroupCreated(ctx context.Context, groupID, orgID, creatorID,
 	return nil
 }
 
-// linkGroupToOrg creates the two hierarchy relations between a group and its org:
-//   - group#org@organization      (identity link from group to org)
-//   - organization#member@group#member (lets org#member traverse to group members)
-//
-// If the second relation fails, the first is best-effort rolled back so we
-// don't leave a one-way link.
+// linkGroupToOrg creates the group#org@organization identity link. It is what
+// resolves org-level synthetic group permissions (e.g. group delete = org->group_delete).
 func (s *Service) linkGroupToOrg(ctx context.Context, groupID, orgID string) error {
-	groupOrg := relation.Relation{
+	if _, err := s.relationService.Create(ctx, relation.Relation{
 		Object:       relation.Object{ID: groupID, Namespace: schema.GroupNamespace},
 		Subject:      relation.Subject{ID: orgID, Namespace: schema.OrganizationNamespace},
 		RelationName: schema.OrganizationRelationName,
-	}
-	if _, err := s.relationService.Create(ctx, groupOrg); err != nil {
+	}); err != nil {
 		return fmt.Errorf("link group to org: %w", err)
 	}
-
-	if _, err := s.relationService.Create(ctx, relation.Relation{
-		Object: relation.Object{ID: orgID, Namespace: schema.OrganizationNamespace},
-		Subject: relation.Subject{
-			ID:              groupID,
-			Namespace:       schema.GroupNamespace,
-			SubRelationName: schema.MemberRelationName,
-		},
-		RelationName: schema.MemberRelationName,
-	}); err != nil {
-		if delErr := s.relationService.Delete(ctx, groupOrg); delErr != nil && !errors.Is(delErr, relation.ErrNotExist) {
-			s.log.WarnContext(ctx, "group->org rollback failed after org member relation failure",
-				"group_id", groupID,
-				"org_id", orgID,
-				"error", delErr,
-			)
-		}
-		return fmt.Errorf("add group as org member: %w", err)
-	}
-
 	return nil
 }
 
-// unlinkGroupFromOrg removes both hierarchy relations between a group and its
+// unlinkGroupFromOrg removes the hierarchy relations between a group and its
 // org. Used as best-effort cleanup when group-create wiring fails partway.
+// The organization#member relation is no longer written but is still deleted
+// here to clean up groups created before that write was removed.
 // relation.ErrNotExist is ignored; any other error is returned.
 func (s *Service) unlinkGroupFromOrg(ctx context.Context, groupID, orgID string) error {
 	if err := s.relationService.Delete(ctx, relation.Relation{
@@ -1767,14 +1696,6 @@ func (s *Service) validateMinGroupOwnerConstraint(ctx context.Context, groupID, 
 		return "", ErrLastGroupOwnerRole
 	}
 	return ownerRole.ID, nil
-}
-
-// groupRoleToRelation maps a group role to the matching SpiceDB relation name.
-func groupRoleToRelation(r role.Role) string {
-	if r.Name == schema.GroupOwnerRole {
-		return schema.OwnerRelationName
-	}
-	return schema.MemberRelationName
 }
 
 func (s *Service) auditGroupMemberAdded(ctx context.Context, grp group.Group, p principalInfo, roleID string) {

--- a/core/membership/service.go
+++ b/core/membership/service.go
@@ -636,37 +636,6 @@ func (s *Service) deletePolicy(ctx context.Context, pol policy.Policy, ownerRole
 	return s.policyService.Delete(ctx, pol.ID)
 }
 
-// replaceRelation deletes the given old relations for the principal on the resource,
-// then creates a new relation with the given name.
-// Only relation.ErrNotExist is ignored on delete — any other error is returned.
-func (s *Service) replaceRelation(ctx context.Context, resourceID, resourceType, principalID, principalType string, oldRelations []string, newRelationName string) error {
-	obj := relation.Object{ID: resourceID, Namespace: resourceType}
-	sub := relation.Subject{ID: principalID, Namespace: principalType}
-
-	for _, name := range oldRelations {
-		err := s.relationService.Delete(ctx, relation.Relation{Object: obj, Subject: sub, RelationName: name})
-		if err != nil && !errors.Is(err, relation.ErrNotExist) {
-			return fmt.Errorf("delete relation %s: %w", name, err)
-		}
-	}
-
-	_, err := s.relationService.Create(ctx, relation.Relation{
-		Object: obj, Subject: sub, RelationName: newRelationName,
-	})
-	if err != nil {
-		s.log.ErrorContext(ctx, "membership state inconsistent: old relations deleted but new relation creation failed, needs manual fix",
-			"resource_id", resourceID,
-			"resource_type", resourceType,
-			"principal_id", principalID,
-			"principal_type", principalType,
-			"expected_relation", newRelationName,
-			"error", err,
-		)
-		return fmt.Errorf("create relation: %w", err)
-	}
-	return nil
-}
-
 // validateOrgRole checks that the role is valid for organization scope and returns it.
 // A role is valid if it is either:
 // - a platform-wide role scoped to organizations, or
@@ -1376,18 +1345,6 @@ func (s *Service) SetGroupMemberRole(ctx context.Context, groupID, principalID, 
 		if errors.Is(err, ErrLastOwnerRole) {
 			return ErrLastGroupOwnerRole
 		}
-		return err
-	}
-
-	oldRelations := []string{schema.OwnerRelationName}
-	if err := s.replaceRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, oldRelations, schema.MemberRelationName); err != nil {
-		s.log.ErrorContext(ctx, "membership state inconsistent: policy replaced but group relation update failed, needs manual fix",
-			"group_id", groupID,
-			"principal_id", principalID,
-			"principal_type", principalType,
-			"new_role_id", resolvedRoleID,
-			"error", err,
-		)
 		return err
 	}
 

--- a/core/membership/service.go
+++ b/core/membership/service.go
@@ -1379,7 +1379,6 @@ func (s *Service) SetGroupMemberRole(ctx context.Context, groupID, principalID, 
 		return err
 	}
 
-	// every group member carries the member relation; replace any owner relation with it
 	oldRelations := []string{schema.OwnerRelationName}
 	if err := s.replaceRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, oldRelations, schema.MemberRelationName); err != nil {
 		s.log.ErrorContext(ctx, "membership state inconsistent: policy replaced but group relation update failed, needs manual fix",

--- a/core/membership/service.go
+++ b/core/membership/service.go
@@ -550,9 +550,6 @@ func (s *Service) removeCustomResourceAccess(ctx context.Context, principalID, p
 }
 
 // removeRelations deletes owner and member relations for a principal on a resource.
-// New memberships only write the group member relation, but removal still clears
-// both names so members added before the owner/member writes were dropped leave
-// no stale tuples behind.
 func (s *Service) removeRelations(ctx context.Context, resourceID, resourceType, principalID, principalType string) error {
 	obj := relation.Object{ID: resourceID, Namespace: resourceType}
 	sub := relation.Subject{ID: principalID, Namespace: principalType}
@@ -1382,8 +1379,7 @@ func (s *Service) SetGroupMemberRole(ctx context.Context, groupID, principalID, 
 		return err
 	}
 
-	// migrate any legacy owner relation to member; role changes never alter the
-	// relation shape anymore — every group member carries the member relation.
+	// every group member carries the member relation; replace any owner relation with it
 	oldRelations := []string{schema.OwnerRelationName}
 	if err := s.replaceRelation(ctx, groupID, schema.GroupNamespace, principalID, principalType, oldRelations, schema.MemberRelationName); err != nil {
 		s.log.ErrorContext(ctx, "membership state inconsistent: policy replaced but group relation update failed, needs manual fix",
@@ -1588,10 +1584,8 @@ func (s *Service) linkGroupToOrg(ctx context.Context, groupID, orgID string) err
 	return nil
 }
 
-// unlinkGroupFromOrg removes the hierarchy relations between a group and its
+// unlinkGroupFromOrg removes both hierarchy relations between a group and its
 // org. Used as best-effort cleanup when group-create wiring fails partway.
-// The organization#member relation is no longer written but is still deleted
-// here to clean up groups created before that write was removed.
 // relation.ErrNotExist is ignored; any other error is returned.
 func (s *Service) unlinkGroupFromOrg(ctx context.Context, groupID, orgID string) error {
 	if err := s.relationService.Delete(ctx, relation.Relation{

--- a/core/membership/service_test.go
+++ b/core/membership/service_test.go
@@ -143,7 +143,7 @@ func TestService_AddOrganizationMember(t *testing.T) {
 		},
 		{
 			name: "should succeed adding a new member with viewer role",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
@@ -152,11 +152,6 @@ func TestService_AddOrganizationMember(t *testing.T) {
 					RoleID: viewerRoleID, ResourceID: orgID, ResourceType: schema.OrganizationNamespace,
 					PrincipalID: userID, PrincipalType: schema.UserPrincipal,
 				}).Return(policy.Policy{}, nil)
-				relSvc.EXPECT().Create(ctx, relation.Relation{
-					Object:       relation.Object{ID: orgID, Namespace: schema.OrganizationNamespace},
-					Subject:      relation.Subject{ID: userID, Namespace: schema.UserPrincipal},
-					RelationName: schema.MemberRelationName,
-				}).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			orgID:   orgID,
@@ -166,13 +161,12 @@ func TestService_AddOrganizationMember(t *testing.T) {
 		},
 		{
 			name: "should succeed even when the audit record write fails",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
 				policySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: userID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{}, nil)
 				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{}, nil)
-				relSvc.EXPECT().Create(ctx, mock.Anything).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, errors.New("audit store unavailable"))
 			},
 			orgID:   orgID,
@@ -181,8 +175,8 @@ func TestService_AddOrganizationMember(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "should succeed adding a new member with owner role and create owner relation",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			name: "should succeed adding a new member with owner role without any relation write",
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, ownerRoleID).Return(role.Role{ID: ownerRoleID, Name: schema.RoleOrganizationOwner, Scopes: []string{schema.OrganizationNamespace}}, nil)
@@ -191,11 +185,6 @@ func TestService_AddOrganizationMember(t *testing.T) {
 					RoleID: ownerRoleID, ResourceID: orgID, ResourceType: schema.OrganizationNamespace,
 					PrincipalID: userID, PrincipalType: schema.UserPrincipal,
 				}).Return(policy.Policy{}, nil)
-				relSvc.EXPECT().Create(ctx, relation.Relation{
-					Object:       relation.Object{ID: orgID, Namespace: schema.OrganizationNamespace},
-					Subject:      relation.Subject{ID: userID, Namespace: schema.UserPrincipal},
-					RelationName: schema.OwnerRelationName,
-				}).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			orgID:   orgID,
@@ -205,13 +194,12 @@ func TestService_AddOrganizationMember(t *testing.T) {
 		},
 		{
 			name: "should succeed with org-specific custom role",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, OrgID: orgID, Scopes: []string{schema.OrganizationNamespace}}, nil)
 				policySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: userID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{}, nil)
 				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{}, nil)
-				relSvc.EXPECT().Create(ctx, mock.Anything).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			orgID:   orgID,
@@ -245,23 +233,6 @@ func TestService_AddOrganizationMember(t *testing.T) {
 			userID:         userID,
 			roleID:         viewerRoleID,
 			wantErrContain: "policy create failed",
-		},
-		{
-			name: "should return error and cleanup policy if relation creation fails",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, _ *mocks.AuditRecordRepository) {
-				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
-				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
-				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
-				policySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: userID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{}, nil)
-				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{ID: "created-policy-1"}, nil)
-				relSvc.EXPECT().Create(ctx, mock.Anything).Return(relation.Relation{}, errors.New("spicedb unavailable"))
-				// compensating delete should be called
-				policySvc.EXPECT().Delete(ctx, "created-policy-1").Return(nil)
-			},
-			orgID:          orgID,
-			userID:         userID,
-			roleID:         viewerRoleID,
-			wantErrContain: "spicedb unavailable",
 		},
 	}
 
@@ -324,6 +295,27 @@ func TestService_AddOrganizationMember_ServiceUser(t *testing.T) {
 		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mockRoleSvc, mockOrgSvc, mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mockSuSvc, mockAuditRepo)
 		err := svc.AddOrganizationMember(ctx, orgID, suID, schema.ServiceUserPrincipal, viewerRoleID)
 		assert.NoError(t, err)
+	})
+
+	t.Run("should return error and cleanup policy if identity link creation fails", func(t *testing.T) {
+		mockPolicySvc := mocks.NewPolicyService(t)
+		mockRelSvc := mocks.NewRelationService(t)
+		mockRoleSvc := mocks.NewRoleService(t)
+		mockOrgSvc := mocks.NewOrgService(t)
+		mockSuSvc := mocks.NewServiceuserService(t)
+
+		mockOrgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
+		mockSuSvc.EXPECT().Get(ctx, suID).Return(serviceuser.ServiceUser{ID: suID, OrgID: orgID, Title: "test-su", State: string(serviceuser.Enabled)}, nil)
+		mockRoleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
+		mockPolicySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: suID, PrincipalType: schema.ServiceUserPrincipal}).Return([]policy.Policy{}, nil)
+		mockPolicySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{ID: "created-policy-1"}, nil)
+		mockRelSvc.EXPECT().Create(ctx, mock.Anything).Return(relation.Relation{}, errors.New("spicedb unavailable"))
+		// compensating delete should be called
+		mockPolicySvc.EXPECT().Delete(ctx, "created-policy-1").Return(nil)
+
+		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mockRoleSvc, mockOrgSvc, mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mockSuSvc, mocks.NewAuditRecordRepository(t))
+		err := svc.AddOrganizationMember(ctx, orgID, suID, schema.ServiceUserPrincipal, viewerRoleID)
+		assert.ErrorContains(t, err, "spicedb unavailable")
 	})
 
 	t.Run("should reject service user from different org", func(t *testing.T) {
@@ -454,14 +446,6 @@ func TestService_SetOrganizationMemberRole(t *testing.T) {
 	enabledUser := user.User{ID: userID, Title: "test-user", Email: "test@acme.dev", State: user.Enabled}
 	enabledOrg := organization.Organization{ID: orgID, Title: "Test Org"}
 
-	orgRelation := func(name string) relation.Relation {
-		return relation.Relation{
-			Object:       relation.Object{ID: orgID, Namespace: schema.OrganizationNamespace},
-			Subject:      relation.Subject{ID: userID, Namespace: schema.UserPrincipal},
-			RelationName: name,
-		}
-	}
-
 	tests := []struct {
 		name           string
 		setup          func(*mocks.PolicyService, *mocks.RelationService, *mocks.RoleService, *mocks.OrgService, *mocks.UserService, *mocks.AuditRecordRepository)
@@ -534,7 +518,7 @@ func TestService_SetOrganizationMemberRole(t *testing.T) {
 		},
 		{
 			name: "should succeed demoting owner to viewer with multiple owners",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
@@ -547,10 +531,6 @@ func TestService_SetOrganizationMemberRole(t *testing.T) {
 					RoleID: viewerRoleID, ResourceID: orgID, ResourceType: schema.OrganizationNamespace,
 					PrincipalID: userID, PrincipalType: schema.UserPrincipal,
 				}).Return(policy.Policy{ID: "new-p"}, nil)
-				// replace relation: delete both owner and member, then create member
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.OwnerRelationName)).Return(nil)
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.MemberRelationName)).Return(nil)
-				relSvc.EXPECT().Create(ctx, orgRelation(schema.MemberRelationName)).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			roleID:  viewerRoleID,
@@ -558,7 +538,7 @@ func TestService_SetOrganizationMemberRole(t *testing.T) {
 		},
 		{
 			name: "should succeed promoting viewer to owner",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, ownerRoleID).Return(role.Role{ID: ownerRoleID, Name: schema.RoleOrganizationOwner, Scopes: []string{schema.OrganizationNamespace}}, nil)
@@ -571,50 +551,9 @@ func TestService_SetOrganizationMemberRole(t *testing.T) {
 					RoleID: ownerRoleID, ResourceID: orgID, ResourceType: schema.OrganizationNamespace,
 					PrincipalID: userID, PrincipalType: schema.UserPrincipal,
 				}).Return(policy.Policy{ID: "new-p"}, nil)
-				// replace relation: delete both, create owner
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.OwnerRelationName)).Return(nil)
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.MemberRelationName)).Return(nil)
-				relSvc.EXPECT().Create(ctx, orgRelation(schema.OwnerRelationName)).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			roleID:  ownerRoleID,
-			wantErr: nil,
-		},
-		{
-			name: "should return error and log if relation delete fails",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, _ *mocks.AuditRecordRepository) {
-				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
-				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
-				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
-				policySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: userID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{{ID: "p1", RoleID: ownerRoleID}}, nil)
-				roleSvc.EXPECT().Get(ctx, schema.RoleOrganizationOwner).Return(role.Role{ID: ownerRoleID, Name: schema.RoleOrganizationOwner}, nil)
-				policySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, RoleID: ownerRoleID}).Return([]policy.Policy{{ID: "p1"}, {ID: "p2"}}, nil)
-				policySvc.EXPECT().DeleteWithMinRoleGuard(ctx, "p1", ownerRoleID).Return(nil)
-				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{}, nil)
-				// relation delete fails with a real error — logged, no rollback
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.OwnerRelationName)).Return(errors.New("spicedb connection error"))
-			},
-			roleID:         viewerRoleID,
-			wantErrContain: "delete relation owner",
-		},
-		{
-			name: "should ignore not-found on relation delete",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, orgSvc *mocks.OrgService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
-				orgSvc.EXPECT().Get(ctx, orgID).Return(enabledOrg, nil)
-				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
-				roleSvc.EXPECT().Get(ctx, viewerRoleID).Return(role.Role{ID: viewerRoleID, Scopes: []string{schema.OrganizationNamespace}}, nil)
-				policySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: userID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{{ID: "p1", RoleID: managerRoleID}}, nil)
-				roleSvc.EXPECT().Get(ctx, schema.RoleOrganizationOwner).Return(role.Role{ID: ownerRoleID, Name: schema.RoleOrganizationOwner}, nil)
-				// existing policy is manager (non-owner), uses plain Delete
-				policySvc.EXPECT().Delete(ctx, "p1").Return(nil)
-				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{}, nil)
-				// both relation deletes return not-found — that's fine, should continue
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.OwnerRelationName)).Return(relation.ErrNotExist)
-				relSvc.EXPECT().Delete(ctx, orgRelation(schema.MemberRelationName)).Return(relation.ErrNotExist)
-				relSvc.EXPECT().Create(ctx, orgRelation(schema.MemberRelationName)).Return(relation.Relation{}, nil)
-				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
-			},
-			roleID:  viewerRoleID,
 			wantErr: nil,
 		},
 	}
@@ -674,8 +613,6 @@ func TestService_SetOrganizationMemberRole_ServiceUser(t *testing.T) {
 		mockPolicySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: suID, PrincipalType: schema.ServiceUserPrincipal}).Return([]policy.Policy{{ID: "p1", RoleID: ownerRoleID}}, nil)
 		mockPolicySvc.EXPECT().Delete(ctx, "p1").Return(nil)
 		mockPolicySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{}, nil)
-		mockRelSvc.EXPECT().Delete(ctx, mock.Anything).Return(relation.ErrNotExist).Times(2)
-		mockRelSvc.EXPECT().Create(ctx, mock.Anything).Return(relation.Relation{}, nil)
 		mockAuditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 
 		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mockRoleSvc, mockOrgSvc, mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mockSuSvc, mockAuditRepo)
@@ -2044,7 +1981,7 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 			wantErr: membership.ErrLastGroupOwnerRole,
 		},
 		{
-			name: "should succeed demoting owner to member with multiple owners (relation flips owner->member)",
+			name: "should succeed demoting owner to member with multiple owners",
 			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, grpSvc *mocks.GroupService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				grpSvc.EXPECT().Get(ctx, groupID).Return(grp, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
@@ -2058,8 +1995,8 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 					RoleID: memberRoleID, ResourceID: groupID, ResourceType: schema.GroupNamespace,
 					PrincipalID: userID, PrincipalType: schema.UserPrincipal,
 				}).Return(policy.Policy{ID: "new-p"}, nil)
+				// legacy owner relation is migrated to member
 				relSvc.EXPECT().Delete(ctx, groupMemberRelation(schema.OwnerRelationName)).Return(nil)
-				relSvc.EXPECT().Delete(ctx, groupMemberRelation(schema.MemberRelationName)).Return(relation.ErrNotExist)
 				relSvc.EXPECT().Create(ctx, groupMemberRelation(schema.MemberRelationName)).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
@@ -2083,7 +2020,7 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 			wantErr: membership.ErrLastGroupOwnerRole,
 		},
 		{
-			name: "should succeed promoting member to owner (relation flips member->owner)",
+			name: "should succeed promoting member to owner keeping the member relation",
 			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, grpSvc *mocks.GroupService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				grpSvc.EXPECT().Get(ctx, groupID).Return(grp, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
@@ -2093,8 +2030,7 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 				policySvc.EXPECT().Delete(ctx, "p1").Return(nil)
 				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{ID: "new-p"}, nil)
 				relSvc.EXPECT().Delete(ctx, groupMemberRelation(schema.OwnerRelationName)).Return(relation.ErrNotExist)
-				relSvc.EXPECT().Delete(ctx, groupMemberRelation(schema.MemberRelationName)).Return(nil)
-				relSvc.EXPECT().Create(ctx, groupMemberRelation(schema.OwnerRelationName)).Return(relation.Relation{}, nil)
+				relSvc.EXPECT().Create(ctx, groupMemberRelation(schema.MemberRelationName)).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			roleID:  ownerRoleID,
@@ -2158,13 +2094,13 @@ func TestService_OnGroupCreated(t *testing.T) {
 		},
 		RelationName: schema.MemberRelationName,
 	}
-	creatorOwnerRelation := relation.Relation{
+	creatorMemberRelation := relation.Relation{
 		Object:       relation.Object{ID: groupID, Namespace: schema.GroupNamespace},
 		Subject:      relation.Subject{ID: creatorID, Namespace: schema.UserPrincipal},
-		RelationName: schema.OwnerRelationName,
+		RelationName: schema.MemberRelationName,
 	}
 
-	t.Run("should link group<->org and add creator as owner", func(t *testing.T) {
+	t.Run("should link group to org and add creator as owner", func(t *testing.T) {
 		mockPolicySvc := mocks.NewPolicyService(t)
 		mockRelSvc := mocks.NewRelationService(t)
 		mockRoleSvc := mocks.NewRoleService(t)
@@ -2173,7 +2109,6 @@ func TestService_OnGroupCreated(t *testing.T) {
 		mockAuditRepo := mocks.NewAuditRecordRepository(t)
 
 		mockRelSvc.EXPECT().Create(ctx, groupOrgRelation).Return(relation.Relation{}, nil)
-		mockRelSvc.EXPECT().Create(ctx, orgGroupMemberRelation).Return(relation.Relation{}, nil)
 
 		mockGrpSvc.EXPECT().Get(ctx, groupID).Return(grp, nil)
 		mockUserSvc.EXPECT().GetByID(ctx, creatorID).Return(enabledUser, nil)
@@ -2182,7 +2117,7 @@ func TestService_OnGroupCreated(t *testing.T) {
 		mockPolicySvc.EXPECT().List(ctx, policy.Filter{OrgID: orgID, PrincipalID: creatorID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{{ID: "org-p1"}}, nil)
 		mockPolicySvc.EXPECT().List(ctx, policy.Filter{GroupID: groupID, PrincipalID: creatorID, PrincipalType: schema.UserPrincipal}).Return([]policy.Policy{}, nil)
 		mockPolicySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{ID: "new-p"}, nil)
-		mockRelSvc.EXPECT().Create(ctx, creatorOwnerRelation).Return(relation.Relation{}, nil)
+		mockRelSvc.EXPECT().Create(ctx, creatorMemberRelation).Return(relation.Relation{}, nil)
 		mockAuditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 
 		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mockRoleSvc, mocks.NewOrgService(t), mockUserSvc, mocks.NewProjectService(t), mockGrpSvc, mocks.NewServiceuserService(t), mockAuditRepo)
@@ -2203,22 +2138,7 @@ func TestService_OnGroupCreated(t *testing.T) {
 		assert.ErrorContains(t, err, "link group to org")
 	})
 
-	t.Run("should rollback first hierarchy relation if second fails", func(t *testing.T) {
-		mockPolicySvc := mocks.NewPolicyService(t)
-		mockRelSvc := mocks.NewRelationService(t)
-
-		mockRelSvc.EXPECT().Create(ctx, groupOrgRelation).Return(relation.Relation{}, nil)
-		mockRelSvc.EXPECT().Create(ctx, orgGroupMemberRelation).Return(relation.Relation{}, errors.New("spicedb unavailable"))
-		// rollback: delete the first hierarchy relation
-		mockRelSvc.EXPECT().Delete(ctx, groupOrgRelation).Return(nil)
-
-		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mocks.NewRoleService(t), mocks.NewOrgService(t), mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mocks.NewServiceuserService(t), mocks.NewAuditRecordRepository(t))
-
-		err := svc.OnGroupCreated(ctx, groupID, orgID, creatorID, schema.UserPrincipal)
-		assert.ErrorContains(t, err, "add group as org member")
-	})
-
-	t.Run("should rollback both hierarchy relations if owner add fails", func(t *testing.T) {
+	t.Run("should rollback hierarchy relations if owner add fails", func(t *testing.T) {
 		mockPolicySvc := mocks.NewPolicyService(t)
 		mockRelSvc := mocks.NewRelationService(t)
 		mockRoleSvc := mocks.NewRoleService(t)
@@ -2227,7 +2147,6 @@ func TestService_OnGroupCreated(t *testing.T) {
 
 		// linkGroupToOrg succeeds
 		mockRelSvc.EXPECT().Create(ctx, groupOrgRelation).Return(relation.Relation{}, nil)
-		mockRelSvc.EXPECT().Create(ctx, orgGroupMemberRelation).Return(relation.Relation{}, nil)
 
 		// AddGroupMember fails before policy creation (group fetch fails)
 		mockGrpSvc.EXPECT().Get(ctx, groupID).Return(group.Group{}, errors.New("db down"))
@@ -2236,9 +2155,9 @@ func TestService_OnGroupCreated(t *testing.T) {
 		_ = mockRoleSvc
 		_ = mockUserSvc
 
-		// rollback: delete both hierarchy relations
+		// rollback: delete the identity link plus any legacy org-member relation
 		mockRelSvc.EXPECT().Delete(ctx, groupOrgRelation).Return(nil)
-		mockRelSvc.EXPECT().Delete(ctx, orgGroupMemberRelation).Return(nil)
+		mockRelSvc.EXPECT().Delete(ctx, orgGroupMemberRelation).Return(relation.ErrNotExist)
 
 		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mockRoleSvc, mocks.NewOrgService(t), mockUserSvc, mocks.NewProjectService(t), mockGrpSvc, mocks.NewServiceuserService(t), mocks.NewAuditRecordRepository(t))
 

--- a/core/membership/service_test.go
+++ b/core/membership/service_test.go
@@ -1995,9 +1995,6 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 					RoleID: memberRoleID, ResourceID: groupID, ResourceType: schema.GroupNamespace,
 					PrincipalID: userID, PrincipalType: schema.UserPrincipal,
 				}).Return(policy.Policy{ID: "new-p"}, nil)
-				// legacy owner relation is migrated to member
-				relSvc.EXPECT().Delete(ctx, groupMemberRelation(schema.OwnerRelationName)).Return(nil)
-				relSvc.EXPECT().Create(ctx, groupMemberRelation(schema.MemberRelationName)).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			roleID:  memberRoleID,
@@ -2020,8 +2017,8 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 			wantErr: membership.ErrLastGroupOwnerRole,
 		},
 		{
-			name: "should succeed promoting member to owner keeping the member relation",
-			setup: func(policySvc *mocks.PolicyService, relSvc *mocks.RelationService, roleSvc *mocks.RoleService, grpSvc *mocks.GroupService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
+			name: "should succeed promoting member to owner",
+			setup: func(policySvc *mocks.PolicyService, _ *mocks.RelationService, roleSvc *mocks.RoleService, grpSvc *mocks.GroupService, userSvc *mocks.UserService, auditRepo *mocks.AuditRecordRepository) {
 				grpSvc.EXPECT().Get(ctx, groupID).Return(grp, nil)
 				userSvc.EXPECT().GetByID(ctx, userID).Return(enabledUser, nil)
 				roleSvc.EXPECT().Get(ctx, ownerRoleID).Return(role.Role{ID: ownerRoleID, Name: schema.GroupOwnerRole, Scopes: []string{schema.GroupNamespace}}, nil)
@@ -2029,8 +2026,6 @@ func TestService_SetGroupMemberRole(t *testing.T) {
 				roleSvc.EXPECT().Get(ctx, schema.GroupOwnerRole).Return(role.Role{ID: ownerRoleID, Name: schema.GroupOwnerRole}, nil)
 				policySvc.EXPECT().Delete(ctx, "p1").Return(nil)
 				policySvc.EXPECT().Create(ctx, mock.Anything).Return(policy.Policy{ID: "new-p"}, nil)
-				relSvc.EXPECT().Delete(ctx, groupMemberRelation(schema.OwnerRelationName)).Return(relation.ErrNotExist)
-				relSvc.EXPECT().Create(ctx, groupMemberRelation(schema.MemberRelationName)).Return(relation.Relation{}, nil)
 				auditRepo.EXPECT().Create(ctx, mock.Anything).Return(auditrecord.AuditRecord{}, nil)
 			},
 			roleID:  ownerRoleID,


### PR DESCRIPTION
## What this is

Part 2 of removing relation-based ownership, following #1809. That PR made the schema stop *reading* the `owner` and `member` links on orgs and groups; this one makes the membership paths stop *writing* them. The split was planned from the start: reading had to stop first so that a rollback of either PR never leaves anyone without access.

## Changes

- Adding an org member or changing their role writes only the policy — no org link. (The service-user identity link stays; the schema still reads it for the `manage` permission.)
- A group member's permissions come from their group role (Team Owner or Team Member), granted through a policy like everywhere else. Joining a group also writes the `member` link, whatever the role. That link is not a permission grant — it is how roles granted *to the group* (e.g. a project role) fan out to the people in it, which is why it stays. A role change inside the group touches only the policy.
- This fixes a bug that #1809 surfaced: the group's own owner used to get an `owner` link *instead of* `member`, so roles granted to the group never reached the group's own owner. Group owners now receive group-granted roles like every other member.
- Removal paths still delete the old links, so members from before this change leave no stale data behind.

Behavior change to be aware of: group owners gain access through roles granted to their group. They were wrongly excluded before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)