### PR TITLE
refactor(server): serve unencrypted HTTP/2 natively

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,9 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c" //nolint:staticcheck
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/raystack/salt/server/spa"
 
@@ -220,21 +217,23 @@ func ServeConnect(ctx context.Context, logger *slog.Logger, cfg Config, deps api
 	})
 
 	// Configure and create the server
-	h2s := &http2.Server{}
-	handler := h2c.NewHandler(mux, h2s) //nolint:staticcheck
-	handler = connectinterceptors.WithConnectCORS(handler, cfg.ConnectCors)
+	handler := connectinterceptors.WithConnectCORS(mux, cfg.ConnectCors)
+
+	// Serve HTTP/1.1 and unencrypted HTTP/2. Unlike the x/net h2c wrapper
+	// this replaces, the server tracks these HTTP/2 connections itself, so
+	// Shutdown drains them like HTTP/1.1 ones. Unencrypted HTTP/2 is
+	// negotiated by prior knowledge only; the HTTP/1.1 Upgrade path is not
+	// supported. HTTP2 keeps HTTP/2 available over TLS should a TLS listener
+	// ever front this handler.
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	protocols.SetHTTP2(true)
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Connect.Port),
-		Handler: handler,
-	}
-
-	// Shutdown cannot reach h2c connections on its own: h2c hijacks them out
-	// of the server's connection tracking. This hook makes Shutdown send
-	// GOAWAY on them so clients finish up and reconnect elsewhere
-	// (golang/go#26682).
-	if err := http2.ConfigureServer(server, h2s); err != nil {
-		return fmt.Errorf("configure http2 server: %w", err)
+		Addr:      fmt.Sprintf(":%d", cfg.Connect.Port),
+		Handler:   handler,
+		Protocols: protocols,
 	}
 
 	// counts shutdown goroutines still draining their servers
@@ -280,10 +279,8 @@ func ServeConnect(ctx context.Context, logger *slog.Logger, cfg Config, deps api
 		return fmt.Errorf("connect server failed: %w", err)
 	}
 
-	// Wait for Shutdown to finish draining HTTP/1.1 requests before returning,
-	// so callers don't tear down the database under them. Hijacked h2c
-	// connections are not tracked by Shutdown and are not waited on; they get
-	// GOAWAY through the http2.ConfigureServer hook instead.
+	// Wait for Shutdown to finish draining requests before returning, so
+	// callers don't tear down the database under them.
 	shutdownWG.Wait()
 	return nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -77,6 +77,81 @@ func TestGracefulShutdownDrainsInflightRequests(t *testing.T) {
 	}
 }
 
+func TestGracefulShutdownDrainsInflightHTTP2Requests(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	entered := make(chan struct{})
+	requestDone := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		time.Sleep(300 * time.Millisecond)
+		close(requestDone)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	srv := &http.Server{Handler: mux, Protocols: protocols}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go gracefulShutdown(ctx, logger, &wg, srv, "test server", 5*time.Second, make(chan struct{}))
+
+	serveReturned := make(chan struct{})
+	go func() {
+		defer close(serveReturned)
+		if err := srv.Serve(l); err != nil && err != http.ErrServerClosed {
+			t.Errorf("serve failed: %v", err)
+		}
+	}()
+
+	requestErr := make(chan error, 1)
+	go func() {
+		resp, err := unencryptedHTTP2Client().Get(fmt.Sprintf("http://%s/slow", l.Addr()))
+		if err == nil {
+			resp.Body.Close()
+			if resp.Proto != "HTTP/2.0" {
+				err = fmt.Errorf("expected HTTP/2.0, got %s", resp.Proto)
+			} else if resp.StatusCode != http.StatusOK {
+				err = fmt.Errorf("unexpected status %d", resp.StatusCode)
+			}
+		}
+		requestErr <- err
+	}()
+
+	<-entered
+	cancel()
+
+	<-serveReturned
+	wg.Wait()
+
+	select {
+	case <-requestDone:
+	default:
+		t.Fatal("shutdown wait released before the in-flight request finished")
+	}
+	if err := <-requestErr; err != nil {
+		t.Fatalf("in-flight request failed: %v", err)
+	}
+}
+
+// unencryptedHTTP2Client speaks HTTP/2 by prior knowledge on plain TCP, the
+// way gRPC and ConnectRPC clients reach the connect port.
+func unencryptedHTTP2Client() *http.Client {
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+	return &http.Client{Transport: &http.Transport{Protocols: protocols}}
+}
+
 func TestGracefulShutdownCutsOffRequestsAfterGracePeriod(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
@@ -154,6 +229,53 @@ func waitForHTTP(t *testing.T, url string) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("server did not respond at %s in time", url)
+}
+
+func TestServeConnectServesBothProtocols(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var cfg Config
+	cfg.Connect.Port = freePort(t)
+	cfg.ShutdownGracePeriod = 5 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	served := make(chan error, 1)
+	go func() {
+		served <- ServeConnect(ctx, logger, cfg, api.Deps{}, prometheus.NewRegistry())
+	}()
+
+	pingURL := fmt.Sprintf("http://127.0.0.1:%d/ping", cfg.Connect.Port)
+	waitForHTTP(t, pingURL)
+
+	resp, err := http.Get(pingURL)
+	if err != nil {
+		t.Fatalf("http/1.1 request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.Proto != "HTTP/1.1" || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP/1.1 200, got %s %d", resp.Proto, resp.StatusCode)
+	}
+
+	resp, err = unencryptedHTTP2Client().Get(pingURL)
+	if err != nil {
+		t.Fatalf("http/2 prior-knowledge request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.Proto != "HTTP/2.0" || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP/2.0 200, got %s %d", resp.Proto, resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("ServeConnect returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ServeConnect did not return after context cancel")
+	}
 }
 
 func TestServeConnectReturnsAfterShutdownOnContextCancel(t *testing.T) {


### PR DESCRIPTION
## Summary
Replaces the deprecated `golang.org/x/net/http2/h2c` wrapper with the `http.Server` Protocols field (native since Go 1.24). The server serves HTTP/1.1 and unencrypted HTTP/2 itself and tracks the HTTP/2 connections, so graceful shutdown drains them the same way as HTTP/1.1 ones — the `http2.ConfigureServer` GOAWAY workaround (golang/go#26682) is removed.

## Changes
- pkg/server: set `Protocols` (HTTP1, HTTP2, UnencryptedHTTP2) on the connect server; drop `h2c.NewHandler` and the `http2.ConfigureServer` hook
- Cleartext HTTP/2 is negotiated by prior knowledge only; the HTTP/1.1 Upgrade mechanism is not supported. gRPC and ConnectRPC clients use prior knowledge; for manual checks use `curl --http2-prior-knowledge`
- HTTP2 keeps HTTP/2 enabled over TLS should a TLS listener ever front the handler
- New tests: `TestGracefulShutdownDrainsInflightHTTP2Requests` (an in-flight HTTP/2 request survives shutdown to completion) and `TestServeConnectServesBothProtocols` (the real ServeConnect answers HTTP/1.1 and HTTP/2.0)
- `x/net/http2` is no longer imported by first-party code; the go.mod annotation cleanup rides in a follow-up

## Technical Details
Verified against a running server: plain request → HTTP/1.1 200; `curl --http2` (Upgrade dance) → HTTP/1.1 200 with the upgrade quietly declined; `curl --http2-prior-knowledge` → HTTP/2 200; grpcurl reflection works over plaintext HTTP/2; SIGTERM logs a complete graceful shutdown. HTTP/1.1 clients are unaffected.

## Test Plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (race detector, -count 2)
- [x] `make e2e-test` passes against live Postgres + SpiceDB containers
- [x] Live probes on a running server: HTTP/1.1, HTTP/2 prior knowledge, Upgrade declined, gRPC reflection, SIGTERM graceful drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)