### PR TITLE
feat(billing): reset product title, description, and config when update omits them

### DIFF
--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -178,24 +178,21 @@ func (s *Service) Update(ctx context.Context, product Product) (Product, error) 
 		}
 	}
 
-	// only following fields will be updated
-	if len(product.Title) > 0 {
-		existingProduct.Title = product.Title
-	}
-	if len(product.Description) > 0 {
-		existingProduct.Description = product.Description
-	}
+	// title, description, and the behavior config state the whole desired value,
+	// so they are written as given: omitting a title or zeroing a config field
+	// resets it rather than keeping the server's value. Behavior is never changed
+	// on update. Plan links and metadata are still merged (kept when empty),
+	// because they are managed through other calls (AddPlan) or set once on create
+	// rather than restated on every update.
+	existingProduct.Title = product.Title
+	existingProduct.Description = product.Description
+	existingProduct.Config.CreditAmount = product.Config.CreditAmount
+	existingProduct.Config.SeatLimit = product.Config.SeatLimit
+	existingProduct.Config.MinQuantity = product.Config.MinQuantity
+	existingProduct.Config.MaxQuantity = product.Config.MaxQuantity
 	if len(product.PlanIDs) > 0 {
 		existingProduct.PlanIDs = product.PlanIDs
 	}
-	if product.Config.CreditAmount > 0 {
-		existingProduct.Config.CreditAmount = product.Config.CreditAmount
-	}
-	if product.Config.SeatLimit > 0 {
-		existingProduct.Config.SeatLimit = product.Config.SeatLimit
-	}
-	existingProduct.Config.MinQuantity = product.Config.MinQuantity
-	existingProduct.Config.MaxQuantity = product.Config.MaxQuantity
 	if len(product.Metadata) > 0 {
 		existingProduct.Metadata = product.Metadata
 	}

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -440,6 +440,45 @@ func TestService_Update(t *testing.T) {
 	}
 }
 
+func TestService_Update_ResetsOmittedFields(t *testing.T) {
+	ctx := context.Background()
+	stripeClient, be, pr, priceRepo, fr := mockService(t)
+
+	// the product on the server carries a title, description, and a full config
+	existing := product.Product{
+		ID:          "prod-1",
+		Name:        "product1",
+		Title:       "Old title",
+		Description: "old description",
+		Behavior:    product.BasicBehavior,
+		Config:      product.BehaviorConfig{CreditAmount: 5, SeatLimit: 3, MinQuantity: 2, MaxQuantity: 9},
+	}
+	pr.EXPECT().GetByID(mock.Anything, "prod-1").Return(existing, nil)
+
+	// the update omits the title, description, and every config field, so each is
+	// written back as its zero value rather than kept from the server.
+	reset := existing
+	reset.Title = ""
+	reset.Description = ""
+	reset.Config = product.BehaviorConfig{}
+	pr.EXPECT().UpdateByName(mock.Anything, mock.MatchedBy(func(p product.Product) bool {
+		return p.Title == "" && p.Description == "" && p.Config == (product.BehaviorConfig{})
+	})).Return(reset, nil)
+
+	be.EXPECT().Call("POST", "/v1/products/", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	priceRepo.EXPECT().List(mock.Anything, product.Filter{ProductID: "prod-1"}).Return([]product.Price{}, nil)
+	fr.EXPECT().List(mock.Anything, mock.Anything).Return([]product.Feature{}, nil)
+
+	svc := product.NewService(stripeClient, pr, priceRepo, fr)
+	if _, err := svc.Update(ctx, product.Product{
+		ID:       "prod-1",
+		Name:     "product1",
+		Behavior: product.BasicBehavior,
+	}); err != nil {
+		t.Fatalf("Update() unexpected error = %v", err)
+	}
+}
+
 func TestPrice_IsActive(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## What

`UpdateProduct` now writes a product's `title`, `description`, and behavior `config` as
given. If the request leaves one of them out, the field is reset to its empty or zero value
instead of keeping the server's current value.

What does not change:

- `behavior` is still never changed on update.
- Plan links (`plan_ids`) and `metadata` are still kept when the request omits them, since
  they are set through other calls (`AddPlan`) or once on create, not restated on every
  update.
- Price convergence is unchanged.

## Why

We are building a declarative reconcile flow that manages billing products from a YAML file.
The file is meant to state the whole desired product. Before this change, `UpdateProduct`
merged `title`, `description`, and `config`: a field left out of the request kept its old
value. So you could not clear a title or reset a config value through the file, and a
reconcile plan could not converge those fields.

With this change the request states the full value, so the reconciler can plan and apply a
reset like any other change.

## Who is affected

- The reconcile `BillingProduct` kind, which sends the whole desired product. This change is
  what lets it fully converge scalar fields.
- The plan bootstrap (`UpsertPlans`) already sends the full product loaded from the plan
  file, so its behaviour does not change.
- No other caller. `UpdateProduct` is not used elsewhere, so this behaviour change is safe.

## Test

Added `TestService_Update_ResetsOmittedFields`: a product with a title, description, and full
config is updated with all of them omitted, and the repository write is asserted to carry the
reset zero values. Existing product and plan tests pass.
