### PR TITLE
refactor(project): move project creation grants into membership

### DIFF
--- a/core/membership/service.go
+++ b/core/membership/service.go
@@ -954,6 +954,53 @@ func (s *Service) RemoveProjectMember(ctx context.Context, projectID, principalI
 	return nil
 }
 
+// OnProjectCreated runs right after a project is created. It links the project
+// to its parent org in SpiceDB and gives the creator the project owner role.
+// There is no org-membership check on the creator here: platform superusers
+// can create projects in orgs they are not members of.
+func (s *Service) OnProjectCreated(ctx context.Context, projectID, orgID, creatorID, creatorType string) error {
+	if err := s.linkProjectToOrg(ctx, projectID, orgID); err != nil {
+		return err
+	}
+	if _, err := s.createPolicy(ctx, projectID, schema.ProjectNamespace, creatorID, creatorType, schema.RoleProjectOwner); err != nil {
+		if cleanupErr := s.unlinkProjectFromOrg(ctx, projectID, orgID); cleanupErr != nil {
+			s.log.WarnContext(ctx, "project hierarchy cleanup failed after owner add failure",
+				"project_id", projectID,
+				"org_id", orgID,
+				"error", cleanupErr,
+			)
+		}
+		return err
+	}
+	return nil
+}
+
+// linkProjectToOrg creates the project->org relation in SpiceDB. Org-level
+// project permissions (e.g. project delete via the org) resolve through it.
+func (s *Service) linkProjectToOrg(ctx context.Context, projectID, orgID string) error {
+	if _, err := s.relationService.Create(ctx, relation.Relation{
+		Object:       relation.Object{ID: projectID, Namespace: schema.ProjectNamespace},
+		Subject:      relation.Subject{ID: orgID, Namespace: schema.OrganizationNamespace},
+		RelationName: schema.OrganizationRelationName,
+	}); err != nil {
+		return fmt.Errorf("link project to org: %w", err)
+	}
+	return nil
+}
+
+// unlinkProjectFromOrg removes the project->org relation. Used to clean up
+// when project creation fails partway.
+func (s *Service) unlinkProjectFromOrg(ctx context.Context, projectID, orgID string) error {
+	if err := s.relationService.Delete(ctx, relation.Relation{
+		Object:       relation.Object{ID: projectID, Namespace: schema.ProjectNamespace},
+		Subject:      relation.Subject{ID: orgID, Namespace: schema.OrganizationNamespace},
+		RelationName: schema.OrganizationRelationName,
+	}); err != nil && !errors.Is(err, relation.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
 // removeAllPolicies finds and deletes all policies for a principal on a resource.
 // Returns the number of policies deleted.
 func (s *Service) removeAllPolicies(ctx context.Context, resourceID, resourceType, principalID, principalType string) (int, error) {

--- a/core/membership/service_test.go
+++ b/core/membership/service_test.go
@@ -1369,6 +1369,65 @@ func TestService_RemoveProjectMember(t *testing.T) {
 	}
 }
 
+func TestService_OnProjectCreated(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New().String()
+	projectID := uuid.New().String()
+	creatorID := uuid.New().String()
+
+	projectOrgRelation := relation.Relation{
+		Object:       relation.Object{ID: projectID, Namespace: schema.ProjectNamespace},
+		Subject:      relation.Subject{ID: orgID, Namespace: schema.OrganizationNamespace},
+		RelationName: schema.OrganizationRelationName,
+	}
+	ownerPolicy := policy.Policy{
+		RoleID:        schema.RoleProjectOwner,
+		ResourceID:    projectID,
+		ResourceType:  schema.ProjectNamespace,
+		PrincipalID:   creatorID,
+		PrincipalType: schema.UserPrincipal,
+	}
+
+	t.Run("should link project to org and add creator as owner", func(t *testing.T) {
+		mockPolicySvc := mocks.NewPolicyService(t)
+		mockRelSvc := mocks.NewRelationService(t)
+
+		mockRelSvc.EXPECT().Create(ctx, projectOrgRelation).Return(relation.Relation{}, nil)
+		mockPolicySvc.EXPECT().Create(ctx, ownerPolicy).Return(policy.Policy{ID: "new-p"}, nil)
+
+		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mocks.NewRoleService(t), mocks.NewOrgService(t), mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mocks.NewServiceuserService(t), mocks.NewAuditRecordRepository(t))
+
+		err := svc.OnProjectCreated(ctx, projectID, orgID, creatorID, schema.UserPrincipal)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return error if hierarchy relation creation fails", func(t *testing.T) {
+		mockPolicySvc := mocks.NewPolicyService(t)
+		mockRelSvc := mocks.NewRelationService(t)
+
+		mockRelSvc.EXPECT().Create(ctx, projectOrgRelation).Return(relation.Relation{}, errors.New("spicedb unavailable"))
+
+		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mocks.NewRoleService(t), mocks.NewOrgService(t), mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mocks.NewServiceuserService(t), mocks.NewAuditRecordRepository(t))
+
+		err := svc.OnProjectCreated(ctx, projectID, orgID, creatorID, schema.UserPrincipal)
+		assert.ErrorContains(t, err, "link project to org")
+	})
+
+	t.Run("should remove the org link if owner policy creation fails", func(t *testing.T) {
+		mockPolicySvc := mocks.NewPolicyService(t)
+		mockRelSvc := mocks.NewRelationService(t)
+
+		mockRelSvc.EXPECT().Create(ctx, projectOrgRelation).Return(relation.Relation{}, nil)
+		mockPolicySvc.EXPECT().Create(ctx, ownerPolicy).Return(policy.Policy{}, errors.New("db down"))
+		mockRelSvc.EXPECT().Delete(ctx, projectOrgRelation).Return(nil)
+
+		svc := membership.NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockPolicySvc, mockRelSvc, mocks.NewRoleService(t), mocks.NewOrgService(t), mocks.NewUserService(t), mocks.NewProjectService(t), mocks.NewGroupService(t), mocks.NewServiceuserService(t), mocks.NewAuditRecordRepository(t))
+
+		err := svc.OnProjectCreated(ctx, projectID, orgID, creatorID, schema.UserPrincipal)
+		assert.ErrorContains(t, err, "db down")
+	})
+}
+
 func TestService_SetPATAllProjectsRole(t *testing.T) {
 	ctx := context.Background()
 	orgID := uuid.New().String()

--- a/core/project/mocks/membership_service.go
+++ b/core/project/mocks/membership_service.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 
 	authenticate "github.com/raystack/frontier/core/authenticate"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -80,6 +79,56 @@ func (_c *MembershipService_ListProjectsByPrincipal_Call) Return(_a0 []string, _
 }
 
 func (_c *MembershipService_ListProjectsByPrincipal_Call) RunAndReturn(run func(context.Context, authenticate.Principal, string, bool) ([]string, error)) *MembershipService_ListProjectsByPrincipal_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// OnProjectCreated provides a mock function with given fields: ctx, projectID, orgID, creatorID, creatorType
+func (_m *MembershipService) OnProjectCreated(ctx context.Context, projectID string, orgID string, creatorID string, creatorType string) error {
+	ret := _m.Called(ctx, projectID, orgID, creatorID, creatorType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OnProjectCreated")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
+		r0 = rf(ctx, projectID, orgID, creatorID, creatorType)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MembershipService_OnProjectCreated_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OnProjectCreated'
+type MembershipService_OnProjectCreated_Call struct {
+	*mock.Call
+}
+
+// OnProjectCreated is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - orgID string
+//   - creatorID string
+//   - creatorType string
+func (_e *MembershipService_Expecter) OnProjectCreated(ctx interface{}, projectID interface{}, orgID interface{}, creatorID interface{}, creatorType interface{}) *MembershipService_OnProjectCreated_Call {
+	return &MembershipService_OnProjectCreated_Call{Call: _e.mock.On("OnProjectCreated", ctx, projectID, orgID, creatorID, creatorType)}
+}
+
+func (_c *MembershipService_OnProjectCreated_Call) Run(run func(ctx context.Context, projectID string, orgID string, creatorID string, creatorType string)) *MembershipService_OnProjectCreated_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+	})
+	return _c
+}
+
+func (_c *MembershipService_OnProjectCreated_Call) Return(_a0 error) *MembershipService_OnProjectCreated_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MembershipService_OnProjectCreated_Call) RunAndReturn(run func(context.Context, string, string, string, string) error) *MembershipService_OnProjectCreated_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/project/mocks/relation_service.go
+++ b/core/project/mocks/relation_service.go
@@ -23,63 +23,6 @@ func (_m *RelationService) EXPECT() *RelationService_Expecter {
 	return &RelationService_Expecter{mock: &_m.Mock}
 }
 
-// Create provides a mock function with given fields: ctx, rel
-func (_m *RelationService) Create(ctx context.Context, rel relation.Relation) (relation.Relation, error) {
-	ret := _m.Called(ctx, rel)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Create")
-	}
-
-	var r0 relation.Relation
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, relation.Relation) (relation.Relation, error)); ok {
-		return rf(ctx, rel)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, relation.Relation) relation.Relation); ok {
-		r0 = rf(ctx, rel)
-	} else {
-		r0 = ret.Get(0).(relation.Relation)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, relation.Relation) error); ok {
-		r1 = rf(ctx, rel)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// RelationService_Create_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Create'
-type RelationService_Create_Call struct {
-	*mock.Call
-}
-
-// Create is a helper method to define mock.On call
-//   - ctx context.Context
-//   - rel relation.Relation
-func (_e *RelationService_Expecter) Create(ctx interface{}, rel interface{}) *RelationService_Create_Call {
-	return &RelationService_Create_Call{Call: _e.mock.On("Create", ctx, rel)}
-}
-
-func (_c *RelationService_Create_Call) Run(run func(ctx context.Context, rel relation.Relation)) *RelationService_Create_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(relation.Relation))
-	})
-	return _c
-}
-
-func (_c *RelationService_Create_Call) Return(_a0 relation.Relation, _a1 error) *RelationService_Create_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *RelationService_Create_Call) RunAndReturn(run func(context.Context, relation.Relation) (relation.Relation, error)) *RelationService_Create_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Delete provides a mock function with given fields: ctx, rel
 func (_m *RelationService) Delete(ctx context.Context, rel relation.Relation) error {
 	ret := _m.Called(ctx, rel)

--- a/core/project/service.go
+++ b/core/project/service.go
@@ -22,7 +22,6 @@ import (
 )
 
 type RelationService interface {
-	Create(ctx context.Context, rel relation.Relation) (relation.Relation, error)
 	LookupSubjects(ctx context.Context, rel relation.Relation) ([]string, error)
 	Delete(ctx context.Context, rel relation.Relation) error
 }
@@ -59,6 +58,7 @@ type GroupService interface {
 
 type MembershipService interface {
 	ListProjectsByPrincipal(ctx context.Context, principal authenticate.Principal, orgID string, nonInherited bool) ([]string, error)
+	OnProjectCreated(ctx context.Context, projectID, orgID, creatorID, creatorType string) error
 }
 
 type Service struct {
@@ -112,21 +112,13 @@ func (s Service) Create(ctx context.Context, prj Project) (Project, error) {
 		return Project{}, err
 	}
 
-	if err = s.addProjectToOrg(ctx, newProject, prj.Organization.ID); err != nil {
-		return Project{}, err
-	}
-
-	// make user administrator of the project
 	// PAT → resolve to underlying user so ownership is on the user, not the token
 	subjectID, subjectType := currentPrincipal.ResolveSubject()
-	if _, err = s.policyService.Create(ctx, policy.Policy{
-		RoleID:        OwnerRole,
-		ResourceID:    newProject.ID,
-		ResourceType:  schema.ProjectNamespace,
-		PrincipalID:   subjectID,
-		PrincipalType: subjectType,
-	}); err != nil {
-		return Project{}, fmt.Errorf("failed to create owner policy for project %s: %w", newProject.ID, err)
+	if err = s.membershipService.OnProjectCreated(ctx, newProject.ID, prj.Organization.ID, subjectID, subjectType); err != nil {
+		if cleanupErr := s.repository.Delete(ctx, newProject.ID); cleanupErr != nil {
+			return Project{}, errors.Join(err, fmt.Errorf("rollback project create: %w", cleanupErr))
+		}
+		return Project{}, err
 	}
 	return newProject, nil
 }
@@ -186,25 +178,6 @@ func (s Service) Update(ctx context.Context, prj Project) (Project, error) {
 		return s.repository.UpdateByID(ctx, prj)
 	}
 	return s.repository.UpdateByName(ctx, prj)
-}
-
-func (s Service) addProjectToOrg(ctx context.Context, prj Project, orgID string) error {
-	rel := relation.Relation{
-		Object: relation.Object{
-			ID:        prj.ID,
-			Namespace: schema.ProjectNamespace,
-		},
-		Subject: relation.Subject{
-			ID:        orgID,
-			Namespace: schema.OrganizationNamespace,
-		},
-		RelationName: schema.OrganizationRelationName,
-	}
-
-	if _, err := s.relationService.Create(ctx, rel); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (s Service) Enable(ctx context.Context, id string) error {

--- a/core/project/service.go
+++ b/core/project/service.go
@@ -102,6 +102,10 @@ func (s Service) Get(ctx context.Context, idOrName string) (Project, error) {
 }
 
 func (s Service) Create(ctx context.Context, prj Project) (Project, error) {
+	if s.membershipService == nil {
+		return Project{}, fmt.Errorf("project: membership service is not set")
+	}
+
 	currentPrincipal, err := s.authnService.GetPrincipal(ctx)
 	if err != nil {
 		return Project{}, err
@@ -132,7 +136,7 @@ func (s Service) List(ctx context.Context, f Filter) ([]Project, error) {
 			return nil, ErrInvalidPrincipalType
 		}
 		if s.membershipService == nil {
-			return nil, fmt.Errorf("project: membership service not wired")
+			return nil, fmt.Errorf("project: membership service is not set")
 		}
 		ids, err := s.membershipService.ListProjectsByPrincipal(ctx, *f.Principal, f.OrgID, f.NonInherited)
 		if err != nil {

--- a/core/project/service_test.go
+++ b/core/project/service_test.go
@@ -125,7 +125,7 @@ func TestService_Create(t *testing.T) {
 			},
 		},
 		{
-			name:    "create project successfully with it's respective policies",
+			name:    "create project successfully and add creator as owner via membership",
 			prj:     testProj,
 			wantErr: false,
 			want: project.Project{
@@ -151,26 +151,41 @@ func TestService_Create(t *testing.T) {
 					},
 				}, nil)
 
-				relationService.EXPECT().Create(ctx, relation.Relation{
-					Object: relation.Object{
-						ID:        "project-id",
-						Namespace: schema.ProjectNamespace,
-					},
-					Subject: relation.Subject{
-						ID:        "org-id",
-						Namespace: schema.OrganizationNamespace,
-					},
-					RelationName: schema.OrganizationRelationName,
-				}).Return(relation.Relation{}, nil)
+				membershipService := mocks.NewMembershipService(t)
+				membershipService.EXPECT().OnProjectCreated(ctx, "project-id", "org-id", "test-user", schema.UserPrincipal).Return(nil)
 
-				policyService.EXPECT().Create(ctx, policy.Policy{
-					RoleID:        project.OwnerRole,
-					ResourceID:    "project-id",
-					ResourceType:  schema.ProjectNamespace,
-					PrincipalID:   "test-user",
-					PrincipalType: schema.UserPrincipal,
-				}).Return(policy.Policy{}, nil)
-				return project.NewService(repo, relationService, userService, policyService, authnService, suserService, groupService, roleService)
+				svc := project.NewService(repo, relationService, userService, policyService, authnService, suserService, groupService, roleService)
+				svc.SetMembershipService(membershipService)
+				return svc
+			},
+		},
+		{
+			name:    "delete the project row when membership setup fails",
+			prj:     testProj,
+			wantErr: true,
+			setup: func() *project.Service {
+				repo, userService, suserService, relationService, policyService, authnService, groupService, roleService := mockService(t)
+				_ = roleService
+				authnService.EXPECT().GetPrincipal(ctx).Return(authenticate.Principal{
+					ID:   "test-user",
+					Type: schema.UserPrincipal,
+				}, nil)
+
+				repo.EXPECT().Create(ctx, testProj).Return(project.Project{
+					ID:   "project-id",
+					Name: "test",
+					Organization: organization.Organization{
+						ID: "org-id",
+					},
+				}, nil)
+
+				membershipService := mocks.NewMembershipService(t)
+				membershipService.EXPECT().OnProjectCreated(ctx, "project-id", "org-id", "test-user", schema.UserPrincipal).Return(errors.New("spicedb unavailable"))
+				repo.EXPECT().Delete(ctx, "project-id").Return(nil)
+
+				svc := project.NewService(repo, relationService, userService, policyService, authnService, suserService, groupService, roleService)
+				svc.SetMembershipService(membershipService)
+				return svc
 			},
 		},
 	}

--- a/core/project/service_test.go
+++ b/core/project/service_test.go
@@ -114,6 +114,17 @@ func TestService_Create(t *testing.T) {
 		setup   func() *project.Service
 	}{
 		{
+			name:    "fail to create project when membership service is not set",
+			prj:     testProj,
+			wantErr: true,
+			setup: func() *project.Service {
+				repo, userService, suserService, relationService, policyService, authnService, groupService, roleService := mockService(t)
+				_ = roleService
+				// Intentionally skip SetMembershipService.
+				return project.NewService(repo, relationService, userService, policyService, authnService, suserService, groupService, roleService)
+			},
+		},
+		{
 			name:    "fail to create project if no principal found",
 			prj:     testProj,
 			wantErr: true,
@@ -121,7 +132,9 @@ func TestService_Create(t *testing.T) {
 				repo, userService, suserService, relationService, policyService, authnService, groupService, roleService := mockService(t)
 				_ = roleService
 				authnService.EXPECT().GetPrincipal(ctx).Return(authenticate.Principal{}, errors.New("not found"))
-				return project.NewService(repo, relationService, userService, policyService, authnService, suserService, groupService, roleService)
+				svc := project.NewService(repo, relationService, userService, policyService, authnService, suserService, groupService, roleService)
+				svc.SetMembershipService(mocks.NewMembershipService(t))
+				return svc
 			},
 		},
 		{


### PR DESCRIPTION
## What

Project creation used to write two things directly: the project→org relation and the creator's owner policy. This moves both writes behind a new `membership.OnProjectCreated`, the same way group creation already goes through `membership.OnGroupCreated`.

## Why

Membership grants were still written by hand in the project service. With this change, the membership package handles all of them, and the project service no longer creates policies or relations for access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)