### PR TITLE
fix(resource): use resource title as audit record target name

### DIFF
--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -152,6 +152,10 @@ func (s Service) Create(ctx context.Context, res Resource) (Resource, error) {
 }
 
 func (s Service) createAuditRecord(ctx context.Context, event pkgauditrecord.Event, res Resource, proj project.Project) {
+	targetName := res.Title
+	if targetName == "" {
+		targetName = res.Name
+	}
 	if _, err := s.auditRecordRepository.Create(ctx, auditmodels.AuditRecord{
 		Event: event,
 		Resource: auditmodels.Resource{
@@ -162,7 +166,7 @@ func (s Service) createAuditRecord(ctx context.Context, event pkgauditrecord.Eve
 		Target: &auditmodels.Target{
 			ID:   res.ID,
 			Type: pkgauditrecord.EntityType(res.NamespaceID),
-			Name: res.Name,
+			Name: targetName,
 		},
 		OrgID:      proj.Organization.ID,
 		OrgName:    proj.Organization.Title,

--- a/core/resource/service_test.go
+++ b/core/resource/service_test.go
@@ -420,6 +420,56 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, schema.UserPrincipal, got.PrincipalType)
 	})
 
+	t.Run("audit record target name uses title when set", func(t *testing.T) {
+		repo, relationSvc, _, projectSvc, _, _, auditRepo, _, svc := newTestService(t)
+		userID := uuid.New().String()
+
+		projectSvc.EXPECT().Get(mock.Anything, testProject.ID).Return(testProject, nil)
+
+		repo.EXPECT().Create(mock.Anything, mock.Anything).Return(resource.Resource{
+			ID: uuid.New().String(), Name: "aoi-uuid-1", Title: "My AOI", NamespaceID: "resource/item",
+			ProjectID: testProject.ID, PrincipalID: userID, PrincipalType: schema.UserPrincipal,
+		}, nil)
+
+		relationSvc.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil)
+		relationSvc.EXPECT().Create(mock.Anything, mock.Anything).Return(relation.Relation{}, nil).Times(2)
+
+		auditRepo.EXPECT().Create(mock.Anything, mock.MatchedBy(func(r auditmodels.AuditRecord) bool {
+			return r.Target != nil && r.Target.Name == "My AOI"
+		})).Return(auditmodels.AuditRecord{}, nil)
+
+		_, err := svc.Create(ctx, resource.Resource{
+			Name: "aoi-uuid-1", Title: "My AOI", NamespaceID: "resource/item", ProjectID: testProject.ID,
+			PrincipalID: userID, PrincipalType: schema.UserPrincipal,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("audit record target name falls back to name when title empty", func(t *testing.T) {
+		repo, relationSvc, _, projectSvc, _, _, auditRepo, _, svc := newTestService(t)
+		userID := uuid.New().String()
+
+		projectSvc.EXPECT().Get(mock.Anything, testProject.ID).Return(testProject, nil)
+
+		repo.EXPECT().Create(mock.Anything, mock.Anything).Return(resource.Resource{
+			ID: uuid.New().String(), Name: "res-slug", NamespaceID: "resource/item",
+			ProjectID: testProject.ID, PrincipalID: userID, PrincipalType: schema.UserPrincipal,
+		}, nil)
+
+		relationSvc.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil)
+		relationSvc.EXPECT().Create(mock.Anything, mock.Anything).Return(relation.Relation{}, nil).Times(2)
+
+		auditRepo.EXPECT().Create(mock.Anything, mock.MatchedBy(func(r auditmodels.AuditRecord) bool {
+			return r.Target != nil && r.Target.Name == "res-slug"
+		})).Return(auditmodels.AuditRecord{}, nil)
+
+		_, err := svc.Create(ctx, resource.Resource{
+			Name: "res-slug", NamespaceID: "resource/item", ProjectID: testProject.ID,
+			PrincipalID: userID, PrincipalType: schema.UserPrincipal,
+		})
+		assert.NoError(t, err)
+	})
+
 	t.Run("explicit principal skips authn lookup", func(t *testing.T) {
 		repo, relationSvc, _, projectSvc, _, _, auditRepo, _, svc := newTestService(t)
 		userID := uuid.New().String()


### PR DESCRIPTION
## Summary
Audit records for resource creation stored the resource's machine name, which callers often set to an ID. The record now stores the resource title as the target name and falls back to the name when the title is empty.

## Changes
- `core/resource/service.go`: `createAuditRecord` sets the target name from `Title`, falling back to `Name` when the title is empty.
- `core/resource/service_test.go`: subtests covering the title case and the empty-title fallback.

## Test Plan
- [ ] Manual testing completed
- [x] Build and type checking passes
- [x] `go test -race ./core/resource/...` passes
- [x] `golangci-lint run ./core/resource/...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)