### PR TITLE
fix(billing): include plans without products in plan listings

### DIFF
--- a/internal/store/postgres/billing_plan_repository.go
+++ b/internal/store/postgres/billing_plan_repository.go
@@ -54,20 +54,22 @@ type PlanProductRow struct {
 	PlanUpdatedAt time.Time  `db:"plan_updated_at"`
 	PlanDeletedAt *time.Time `db:"plan_deleted_at"`
 
-	ProductID          string         `db:"product_id"`
-	ProductProviderID  string         `db:"product_provider_id"`
+	// product columns are pointers because a left join leaves them null for a
+	// plan that has no products
+	ProductID          *string        `db:"product_id"`
+	ProductProviderID  *string        `db:"product_provider_id"`
 	ProductPlanIDs     pq.StringArray `db:"product_plan_ids"`
-	ProductName        string         `db:"product_name"`
+	ProductName        *string        `db:"product_name"`
 	ProductTitle       *string        `db:"product_title"`
 	ProductDescription *string        `db:"product_description"`
 
-	ProductBehavior string             `db:"product_behavior"`
+	ProductBehavior *string            `db:"product_behavior"`
 	ProductConfig   BehaviorConfig     `db:"product_config"`
-	ProductState    string             `db:"product_state"`
+	ProductState    *string            `db:"product_state"`
 	ProductMetadata types.NullJSONText `db:"product_metadata"`
 
-	ProductCreatedAt time.Time  `db:"product_created_at"`
-	ProductUpdatedAt time.Time  `db:"product_updated_at"`
+	ProductCreatedAt *time.Time `db:"product_created_at"`
+	ProductUpdatedAt *time.Time `db:"product_updated_at"`
 	ProductDeletedAt *time.Time `db:"product_deleted_at"`
 }
 
@@ -91,20 +93,34 @@ func (pr PlanProductRow) getPlan() (plan.Plan, error) {
 	return pln.transform()
 }
 
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefTime(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
 func (pr PlanProductRow) getProduct() (product.Product, error) {
 	prod := Product{
-		ID:          pr.ProductID,
-		ProviderID:  pr.ProductProviderID,
+		ID:          derefString(pr.ProductID),
+		ProviderID:  derefString(pr.ProductProviderID),
 		PlanIDs:     pr.ProductPlanIDs,
-		Name:        pr.ProductName,
+		Name:        derefString(pr.ProductName),
 		Title:       pr.ProductTitle,
 		Description: pr.ProductDescription,
-		Behavior:    pr.ProductBehavior,
+		Behavior:    derefString(pr.ProductBehavior),
 		Config:      pr.ProductConfig,
-		State:       pr.ProductState,
+		State:       derefString(pr.ProductState),
 		Metadata:    pr.ProductMetadata,
-		CreatedAt:   pr.ProductCreatedAt,
-		UpdatedAt:   pr.ProductUpdatedAt,
+		CreatedAt:   derefTime(pr.ProductCreatedAt),
+		UpdatedAt:   derefTime(pr.ProductUpdatedAt),
 		DeletedAt:   pr.ProductDeletedAt,
 	}
 
@@ -353,8 +369,9 @@ func (r BillingPlanRepository) List(ctx context.Context, filter plan.Filter) ([]
 func (r BillingPlanRepository) ListWithProducts(ctx context.Context, filter plan.Filter) ([]plan.Plan, error) {
 	pln := goqu.T(TABLE_BILLING_PLANS).As("plan")
 	prd := goqu.T(TABLE_BILLING_PRODUCTS).As("product")
+	// a left join keeps plans that have no products; an inner join would drop them
 	stmt := dialect.From(pln).
-		Join(
+		LeftJoin(
 			prd,
 			goqu.On(
 				goqu.L("CAST(plan.id AS text)").Eq(goqu.L("ANY(product.plan_ids)")),
@@ -437,19 +454,19 @@ func (r BillingPlanRepository) ListWithProducts(ctx context.Context, filter plan
 		if err != nil {
 			return nil, err
 		}
-
-		prod, err := row.getProduct()
-		if err != nil {
-			return nil, err
+		if existing, ok := planMap[pln.ID]; ok {
+			pln = existing
 		}
 
-		planInMap, exists := planMap[pln.ID]
-		if exists {
-			planInMap.Products = append(planInMap.Products, prod)
-		} else {
+		// a left join gives a null product id for a plan that has no products
+		if row.ProductID != nil {
+			prod, err := row.getProduct()
+			if err != nil {
+				return nil, err
+			}
 			pln.Products = append(pln.Products, prod)
-			planMap[pln.ID] = pln
 		}
+		planMap[pln.ID] = pln
 	}
 
 	plans := []plan.Plan{}

--- a/internal/store/postgres/billing_plan_repository.go
+++ b/internal/store/postgres/billing_plan_repository.go
@@ -388,7 +388,7 @@ func (r BillingPlanRepository) ListWithProducts(ctx context.Context, filter plan
 		pln.Col("metadata").As("plan_metadata"),
 		pln.Col("created_at").As("plan_created_at"),
 		pln.Col("updated_at").As("plan_updated_at"),
-		prd.Col("deleted_at").As("plan_deleted_at"),
+		pln.Col("deleted_at").As("plan_deleted_at"),
 		prd.Col("id").As("product_id"),
 		prd.Col("provider_id").As("product_provider_id"),
 		prd.Col("name").As("product_name"),

--- a/internal/store/postgres/billing_plan_repository.go
+++ b/internal/store/postgres/billing_plan_repository.go
@@ -93,34 +93,20 @@ func (pr PlanProductRow) getPlan() (plan.Plan, error) {
 	return pln.transform()
 }
 
-func derefString(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
-func derefTime(t *time.Time) time.Time {
-	if t == nil {
-		return time.Time{}
-	}
-	return *t
-}
-
 func (pr PlanProductRow) getProduct() (product.Product, error) {
 	prod := Product{
-		ID:          derefString(pr.ProductID),
-		ProviderID:  derefString(pr.ProductProviderID),
+		ID:          ptrToString(pr.ProductID),
+		ProviderID:  ptrToString(pr.ProductProviderID),
 		PlanIDs:     pr.ProductPlanIDs,
-		Name:        derefString(pr.ProductName),
+		Name:        ptrToString(pr.ProductName),
 		Title:       pr.ProductTitle,
 		Description: pr.ProductDescription,
-		Behavior:    derefString(pr.ProductBehavior),
+		Behavior:    ptrToString(pr.ProductBehavior),
 		Config:      pr.ProductConfig,
-		State:       derefString(pr.ProductState),
+		State:       ptrToString(pr.ProductState),
 		Metadata:    pr.ProductMetadata,
-		CreatedAt:   derefTime(pr.ProductCreatedAt),
-		UpdatedAt:   derefTime(pr.ProductUpdatedAt),
+		CreatedAt:   ptrToTime(pr.ProductCreatedAt),
+		UpdatedAt:   ptrToTime(pr.ProductUpdatedAt),
 		DeletedAt:   pr.ProductDeletedAt,
 	}
 

--- a/internal/store/postgres/null_converters.go
+++ b/internal/store/postgres/null_converters.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 
 	"github.com/jmoiron/sqlx/types"
 	"github.com/raystack/frontier/pkg/metadata"
@@ -72,6 +73,14 @@ func ptrToString(ptr *string) string {
 		return *ptr
 	}
 	return ""
+}
+
+// ptrToTime safely converts a time pointer to a time.Time, returning zero time if nil
+func ptrToTime(ptr *time.Time) time.Time {
+	if ptr != nil {
+		return *ptr
+	}
+	return time.Time{}
 }
 
 // unmarshalNullJSONText unmarshals NullJSONText to map[string]any


### PR DESCRIPTION
## What

`BillingPlanRepository.ListWithProducts` INNER JOINed `billing_products` on `plan.id = ANY(product.plan_ids)`, so any plan with no products was dropped from the result. `UpsertPlans` allows creating a plan with an empty product set, so such plans can exist. This switches the join to a LEFT JOIN so those plans are returned.

- INNER JOIN -> LEFT JOIN in `ListWithProducts`.
- The product columns on `PlanProductRow` become pointers, because a left join leaves them null for a plan with no products. `getProduct` dereferences them.
- The row loop skips appending a product when `product_id` is null, and always stores the accumulated plan back into the map (this also fixes a latent store-back bug where a multi-product plan could lose products after the first).
- `plan_deleted_at` was selected from the product table by mistake, so a plan could report its product's deletion time as its own. It now comes from the plans table.

## Why

This affects both `FrontierService.ListPlans` and, once raystack/frontier#1830 lands, `AdminService.ListAllPlans`. An admin listing (and the future BillingPlan reconcile export) must be able to see every plan, including a misconfigured one with no products, so it can be reported or fixed.

## Testing

- `go build ./...`, `go vet`, and `golangci-lint` are clean.
- The SQL change needs a live Postgres, so it is not exercised by unit tests. A repository test that creates a product-less plan and asserts it is listed should follow (the harness exists in `billing_product_repository_test.go`).

Closes #1832.