### PR TITLE
feat(checkout): add delete of checkout records by billing account

### DIFF
--- a/billing/checkout/service.go
+++ b/billing/checkout/service.go
@@ -63,6 +63,7 @@ type Repository interface {
 	Create(ctx context.Context, ch Checkout) (Checkout, error)
 	UpdateByID(ctx context.Context, ch Checkout) (Checkout, error)
 	List(ctx context.Context, filter Filter) ([]Checkout, error)
+	DeleteByCustomerID(ctx context.Context, customerID string) error
 }
 
 type CustomerService interface {
@@ -766,6 +767,12 @@ func (s *Service) ensureSubscription(ctx context.Context, ch Checkout) (string, 
 
 func (s *Service) List(ctx context.Context, filter Filter) ([]Checkout, error) {
 	return s.repository.List(ctx, filter)
+}
+
+// DeleteByCustomer removes all checkout records of a billing account. Checkout
+// sessions on the billing provider are not touched as they expire on their own.
+func (s *Service) DeleteByCustomer(ctx context.Context, customerID string) error {
+	return s.repository.DeleteByCustomerID(ctx, customerID)
 }
 
 func (s *Service) CreateSessionForPaymentMethod(ctx context.Context, ch Checkout) (Checkout, error) {

--- a/internal/store/postgres/billing_checkout_repository.go
+++ b/internal/store/postgres/billing_checkout_repository.go
@@ -304,6 +304,23 @@ func (r BillingCheckoutRepository) UpdateByID(ctx context.Context, toUpdate chec
 	return customerModel.transform()
 }
 
+func (r BillingCheckoutRepository) DeleteByCustomerID(ctx context.Context, customerID string) error {
+	query, params, err := dialect.Delete(TABLE_BILLING_CHECKOUTS).Where(goqu.Ex{
+		"customer_id": customerID,
+	}).ToSQL()
+	if err != nil {
+		return fmt.Errorf("%w: %s", errParse, err)
+	}
+
+	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_CHECKOUTS, "DeleteByCustomerID", func(ctx context.Context) error {
+		_, err := r.dbc.ExecContext(ctx, query, params...)
+		return err
+	}); err != nil {
+		return fmt.Errorf("%w: %s", errDB, err)
+	}
+	return nil
+}
+
 func (r BillingCheckoutRepository) List(ctx context.Context, flt checkout.Filter) ([]checkout.Checkout, error) {
 	stmt := dialect.Select().From(TABLE_BILLING_CHECKOUTS).Order(goqu.I("created_at").Desc())
 	if flt.CustomerID != "" {

--- a/internal/store/postgres/billing_checkout_repository.go
+++ b/internal/store/postgres/billing_checkout_repository.go
@@ -309,14 +309,14 @@ func (r BillingCheckoutRepository) DeleteByCustomerID(ctx context.Context, custo
 		"customer_id": customerID,
 	}).ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %s", errParse, err)
+		return fmt.Errorf("%w: %w", errParse, err)
 	}
 
 	if err = r.dbc.WithTimeout(ctx, TABLE_BILLING_CHECKOUTS, "DeleteByCustomerID", func(ctx context.Context) error {
 		_, err := r.dbc.ExecContext(ctx, query, params...)
 		return err
 	}); err != nil {
-		return fmt.Errorf("%w: %s", errDB, err)
+		return fmt.Errorf("%w: %w", errDB, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Part of #1835. Bottom of the org-delete cleanup stack.

Checkout rows hold a foreign key to the billing customer row, and nothing could remove them. That FK is what blocks the hard delete of a billing account during org delete.

## Changes

- `DeleteByCustomerID` on the checkout Postgres repository.
- `DeleteByCustomer` on the checkout service.

No behavior change: nothing calls these yet. The deleter starts using them later in the stack. Checkout sessions on the billing provider are not touched; they expire on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)