### PR TITLE
fix(subscription): make billing account teardown retryable

### DIFF
--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -304,9 +304,18 @@ func (s *Service) Cancel(ctx context.Context, id string, immediate bool) (Subscr
 	}
 
 	// check if schedule exists
-	_, stripeSchedule, err := s.createOrGetSchedule(ctx, sub)
+	stripeSubscription, stripeSchedule, err := s.createOrGetSchedule(ctx, sub)
 	if err != nil {
 		return sub, err
+	}
+
+	if stripeSubscription != nil && stripeSubscription.Status == stripe.SubscriptionStatusCanceled {
+		// already canceled on the provider, just sync the local state
+		sub.State = string(stripeSubscription.Status)
+		if stripeSubscription.CanceledAt > 0 {
+			sub.CanceledAt = utils.AsTimeFromEpoch(stripeSubscription.CanceledAt)
+		}
+		return s.repository.UpdateByID(ctx, sub)
 	}
 
 	if immediate || stripeSchedule == nil {
@@ -1076,6 +1085,11 @@ func (s *Service) ensureCreditsForPlan(ctx context.Context, sub Subscription, su
 	return nil
 }
 
+// DeleteByCustomer tears down all subscriptions of a billing account. Active
+// subscriptions are canceled on the billing provider first. A subscription
+// that is already gone or canceled on the provider counts as canceled, so a
+// teardown that failed midway can be run again. Offline accounts have nothing
+// on the provider; only their local records are removed.
 func (s *Service) DeleteByCustomer(ctx context.Context, customr customer.Customer) error {
 	subs, err := s.List(ctx, Filter{
 		CustomerID: customr.ID,
@@ -1083,12 +1097,9 @@ func (s *Service) DeleteByCustomer(ctx context.Context, customr customer.Custome
 	if err != nil {
 		return err
 	}
-	if err := s.SyncWithProvider(ctx, customr); err != nil {
-		return err
-	}
 	for _, sub := range subs {
-		if sub.IsActive() {
-			if _, err := s.Cancel(ctx, sub.ID, true); err != nil {
+		if !customr.IsOffline() && sub.IsActive() {
+			if _, err := s.Cancel(ctx, sub.ID, true); err != nil && !errors.Is(err, ErrSubscriptionOnProviderNotFound) {
 				return err
 			}
 		}

--- a/billing/subscription/service.go
+++ b/billing/subscription/service.go
@@ -309,8 +309,11 @@ func (s *Service) Cancel(ctx context.Context, id string, immediate bool) (Subscr
 		return sub, err
 	}
 
-	if stripeSubscription != nil && stripeSubscription.Status == stripe.SubscriptionStatusCanceled {
-		// already canceled on the provider, just sync the local state
+	if stripeSubscription != nil && (stripeSubscription.Status == stripe.SubscriptionStatusCanceled ||
+		stripeSubscription.Status == stripe.SubscriptionStatusIncompleteExpired) {
+		// nothing to cancel on the provider: canceled is already done and
+		// incomplete_expired is terminal, a cancel call would be rejected.
+		// Just sync the local state
 		sub.State = string(stripeSubscription.Status)
 		if stripeSubscription.CanceledAt > 0 {
 			sub.CanceledAt = utils.AsTimeFromEpoch(stripeSubscription.CanceledAt)


### PR DESCRIPTION
Part of #1835. Stacked on the kyc delete PR.

`DeleteByCustomer` failed and could not be run again when the provider side was already gone. That mattered for org delete: after a halfway failure, the Stripe customer was deleted but local rows remained, and every retry died on the first provider call.

## Changes

- A subscription already canceled on the provider now just syncs the local state instead of failing the cancel call.
- A subscription missing on the provider counts as canceled.
- Offline accounts skip the provider entirely; only local records are removed.
- Dropped the `SyncWithProvider` call, which failed outright when the provider customer was already deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)