### PR TITLE
fix(authenticate): read otp attempt counter from json-decoded metadata

### DIFF
--- a/core/authenticate/service.go
+++ b/core/authenticate/service.go
@@ -363,6 +363,20 @@ func (s Service) FinishFlow(ctx context.Context, request RegistrationFinishReque
 	return nil, ErrUnsupportedMethod
 }
 
+// otpAttempts reads the wrong-code attempt counter from flow metadata.
+// The counter is written as an int, but flow metadata is stored as JSON
+// in the database, and JSON unmarshaling returns numbers as float64.
+func otpAttempts(md metadata.Metadata) int {
+	switch attempts := md[otpAttemptKey].(type) {
+	case int:
+		return attempts
+	case float64:
+		return int(attempts)
+	default:
+		return 0
+	}
+}
+
 // applyMailOTP actions when user submitted otp from the email
 // user can be considered as verified if code is valid
 // create a new user if required
@@ -384,12 +398,9 @@ func (s Service) applyMailOTP(ctx context.Context, request RegistrationFinishReq
 
 	if bcrypt.CompareHashAndPassword([]byte(flow.Nonce), []byte(request.Code)) != nil {
 		// avoid brute forcing otp
-		attemptInt := 0
-		if attempts, ok := flow.Metadata[otpAttemptKey]; ok {
-			attemptInt, _ = attempts.(int)
-		}
+		attemptInt := otpAttempts(flow.Metadata) + 1
 		if attemptInt < maxOTPAttempt {
-			flow.Metadata[otpAttemptKey] = attemptInt + 1
+			flow.Metadata[otpAttemptKey] = attemptInt
 			if err = s.flowRepo.Set(ctx, flow); err != nil {
 				return nil, fmt.Errorf("failed to process flow code missmatch")
 			}

--- a/core/authenticate/service_test.go
+++ b/core/authenticate/service_test.go
@@ -3,6 +3,7 @@ package authenticate_test
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -575,7 +576,7 @@ func TestService_FinishFlow(t *testing.T) {
 			},
 		},
 		{
-			name: "destroy the flow if the code is wrong past the attempt cap",
+			name: "destroy the flow if the wrong code reaches the attempt cap",
 			args: args{
 				ctx: context.Background(),
 				request: authenticate.RegistrationFinishRequest{
@@ -590,7 +591,7 @@ func TestService_FinishFlow(t *testing.T) {
 				mockFlowRepo, _, _, _, _ := createMocks(t)
 				ctx := context.Background()
 				mockFlowRepo.EXPECT().Get(ctx, flowID).
-					Return(mailOTPFlow(flowID, timeNow, string(otpHash), pkgMetadata.Metadata{"callback_url": "", "attempt": 3}), nil)
+					Return(mailOTPFlow(flowID, timeNow, string(otpHash), pkgMetadata.Metadata{"callback_url": "", "attempt": 2}), nil)
 				mockFlowRepo.EXPECT().Delete(ctx, flowID).Return(nil)
 				srv := authenticate.NewService(nil, authenticate.Config{}, mockFlowRepo, nil,
 					nil, nil, nil, nil, nil, nil)
@@ -655,6 +656,91 @@ func TestService_FinishFlow_WrongThenRightOTP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, sampleUser, got.User)
+}
+
+// jsonFlowRepository keeps flow metadata as JSON bytes, the same way the
+// Postgres repository stores it. Numbers in metadata come back from Get as
+// float64, matching a real database round trip.
+type jsonFlowRepository struct {
+	flows map[uuid.UUID]jsonStoredFlow
+}
+
+type jsonStoredFlow struct {
+	flow        authenticate.Flow
+	rawMetadata []byte
+}
+
+func (r *jsonFlowRepository) Set(_ context.Context, flow *authenticate.Flow) error {
+	raw, err := json.Marshal(flow.Metadata)
+	if err != nil {
+		return err
+	}
+	r.flows[flow.ID] = jsonStoredFlow{flow: *flow, rawMetadata: raw}
+	return nil
+}
+
+func (r *jsonFlowRepository) Get(_ context.Context, id uuid.UUID) (*authenticate.Flow, error) {
+	stored, ok := r.flows[id]
+	if !ok {
+		return nil, authenticate.ErrFlowInvalid
+	}
+	flow := stored.flow
+	var md pkgMetadata.Metadata
+	if err := json.Unmarshal(stored.rawMetadata, &md); err != nil {
+		return nil, err
+	}
+	flow.Metadata = md
+	return &flow, nil
+}
+
+func (r *jsonFlowRepository) Delete(_ context.Context, id uuid.UUID) error {
+	delete(r.flows, id)
+	return nil
+}
+
+func (r *jsonFlowRepository) DeleteExpiredFlows(_ context.Context) error {
+	return nil
+}
+
+func TestService_FinishFlow_OTPAttemptCapAfterJSONRoundTrip(t *testing.T) {
+	flowID := uuid.New()
+	timeNow := time.Now()
+	otpHash, err := bcrypt.GenerateFromPassword([]byte("111111"), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	flowRepo := &jsonFlowRepository{flows: map[uuid.UUID]jsonStoredFlow{}}
+	require.NoError(t, flowRepo.Set(ctx, mailOTPFlow(flowID, timeNow, string(otpHash), pkgMetadata.Metadata{"callback_url": ""})))
+
+	srv := authenticate.NewService(nil, authenticate.Config{}, flowRepo, nil,
+		nil, nil, nil, nil, nil, nil)
+	srv.Now = func() time.Time {
+		return timeNow
+	}
+
+	wrongCode := authenticate.RegistrationFinishRequest{
+		Method: authenticate.MailOTPAuthMethod.String(),
+		State:  flowID.String(),
+		Code:   "222222",
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		got, err := srv.FinishFlow(ctx, wrongCode)
+		assert.ErrorIs(t, err, authenticate.ErrInvalidMailOTP)
+		assert.Nil(t, got)
+
+		flow, err := flowRepo.Get(ctx, flowID)
+		require.NoError(t, err)
+		assert.Equal(t, float64(attempt), flow.Metadata["attempt"])
+	}
+
+	// the third wrong code reaches the cap and destroys the flow
+	got, err := srv.FinishFlow(ctx, wrongCode)
+	assert.ErrorIs(t, err, authenticate.ErrInvalidMailOTP)
+	assert.Nil(t, got)
+
+	_, err = flowRepo.Get(ctx, flowID)
+	assert.ErrorIs(t, err, authenticate.ErrFlowInvalid)
 }
 
 func TestService_GetPrincipal_JWTGrantSkipsNonGrantToken(t *testing.T) {


### PR DESCRIPTION
## Summary
Flow metadata is stored as JSON, and JSON decoding returns numbers as float64. The mail OTP wrong-code attempt counter now handles both int and float64 when read from flow metadata, and the flow is destroyed when the counter reaches the attempt cap.

## Changes
- `core/authenticate/service.go`: add an `otpAttempts` helper that reads the attempt counter with a type switch over `int` and `float64`; count the current wrong code before the cap check, so the third wrong code destroys the flow.
- `core/authenticate/service_test.go`: add a `jsonFlowRepository` fake that stores flow metadata as JSON bytes like the Postgres repository, plus a test walking the counter to the cap; seed the mock-based destroy case at the boundary.

## Test Plan
- [x] Manual testing completed
- [x] Build and type checking passes
- [x] `go test -race -count 2 ./core/authenticate/` passes
- [x] `golangci-lint run` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)