### PR TITLE
fix(billing): deny entitlement for a feature with no products

### DIFF
--- a/billing/entitlement/check_no_products_test.go
+++ b/billing/entitlement/check_no_products_test.go
@@ -1,0 +1,35 @@
+package entitlement_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raystack/frontier/billing/product"
+	"github.com/raystack/frontier/billing/subscription"
+)
+
+// A feature detached from its last product has an empty ProductIDs. Check must
+// deny it: an empty ProductIDs filter would otherwise match every product in the
+// store and wrongly grant the feature to any active subscriber. The ProductService
+// List mock is intentionally left unset, so the test fails if Check ever calls it
+// (i.e. if the guard is removed).
+func TestService_Check_FeatureWithNoProducts(t *testing.T) {
+	ctx := context.Background()
+	s, mockSubscription, mockProduct, _, _ := mockService(t)
+
+	mockSubscription.EXPECT().List(ctx, subscription.Filter{CustomerID: "cust-1"}).
+		Return([]subscription.Subscription{
+			{PlanID: "plan-1", State: subscription.StateActive.String()},
+		}, nil)
+	mockProduct.EXPECT().GetFeatureByID(ctx, "feat-detached").
+		Return(product.Feature{ProductIDs: []string{}}, nil)
+
+	got, err := s.Check(ctx, "cust-1", "feat-detached")
+
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got {
+		t.Errorf("Check() = true, want false for a feature attached to no product")
+	}
+}

--- a/billing/entitlement/service.go
+++ b/billing/entitlement/service.go
@@ -63,6 +63,13 @@ func (s *Service) Check(ctx context.Context, customerID, featureID string) (bool
 		return false, err
 	}
 
+	// a feature attached to no product cannot belong to any plan, so it grants no
+	// entitlement. Guard explicitly: an empty ProductIDs filter would otherwise match
+	// every product in the store and wrongly grant the feature to any active subscriber.
+	if len(feature.ProductIDs) == 0 {
+		return false, nil
+	}
+
 	// get all the products this feature is in
 	products, err := s.productService.List(ctx, product.Filter{
 		ProductIDs: feature.ProductIDs,


### PR DESCRIPTION
## What

`CheckFeatureEntitlement` wrongly returns `true` for a feature that is attached to no product. `entitlement.Service.Check` does `productService.List(Filter{ProductIDs: feature.ProductIDs})`, and when `feature.ProductIDs` is empty the store treats the empty id filter as *no filter* (`billing_plan`… `billing_product_repository.go`: `if len(flt.ProductIDs) > 0`), so it returns **every** product. The plan-bound product is in that list, its `plan_ids` matches an active subscription, and `Check` grants the feature to any active subscriber.

## Why it matters

A feature ends up with empty `ProductIDs` whenever it is removed from its **last** product — the exact effect of `RemoveFeatureFromProduct` (called by `updateProductFeatures` when a product update drops a feature). So retiring a feature would silently leave every subscriber entitled to it. This is an over-grant (grants access it should deny), independent of the reconcile/Stripe path.

## Fix

Guard in `Check`: a feature attached to no product cannot belong to any plan, so return `false` before the list call.

```go
if len(feature.ProductIDs) == 0 {
    return false, nil
}
```

The fix lives in `Check`, not in the store's empty-filter behaviour, because other callers rely on "empty filter = all products".

## Test

Added `TestService_Check_FeatureWithNoProducts`: an active subscriber, a feature with empty `ProductIDs`. It asserts `Check` returns `false` and leaves the `ProductService.List` mock **unset**, so the test fails if `Check` ever calls `List` again (a regression guard). Verified it fails without the guard (the mock rejects the unexpected `List` call) and passes with it.

## How it was found

Surfaced while testing the BillingProduct reconcile feature-remove flow in a local sandbox: after detaching a feature, `GetPlan` correctly dropped it, but the entitlement check kept returning `true`.
