### PR TITLE
feat(admin): list and remove pending invites from organization members

### DIFF
--- a/web/sdk/admin/hooks/useOrganizationRoles.ts
+++ b/web/sdk/admin/hooks/useOrganizationRoles.ts
@@ -8,13 +8,21 @@ import {
 } from "@raystack/proton/frontier";
 import { SCOPES } from "~/admin/utils/constants";
 
+interface UseOrganizationRolesOptions {
+  /** Skip both fetches while false. Defaults to true. */
+  enabled?: boolean;
+}
+
 /*
   Roles assignable within an org: the platform's defaults plus the org's custom
   ones. Both halves are needed — a role id can come from either.
   - react-query caches per key, so repeat callers share one fetch
   - pass undefined/empty to skip the org-scoped half
 */
-export const useOrganizationRoles = (orgId?: string) => {
+export const useOrganizationRoles = (
+  orgId?: string,
+  { enabled = true }: UseOrganizationRolesOptions = {},
+) => {
   const {
     data: defaultRoles = [],
     isLoading: isDefaultRolesLoading,
@@ -23,6 +31,7 @@ export const useOrganizationRoles = (orgId?: string) => {
     FrontierServiceQueries.listRoles,
     create(ListRolesRequestSchema, { scopes: [SCOPES.ORG] }),
     {
+      enabled,
       select: (data) => data?.roles || [],
     },
   );
@@ -38,7 +47,7 @@ export const useOrganizationRoles = (orgId?: string) => {
       scopes: [SCOPES.ORG],
     }),
     {
-      enabled: !!orgId,
+      enabled: enabled && !!orgId,
       select: (data) => data?.roles || [],
     },
   );

--- a/web/sdk/admin/views/organizations/details/index.tsx
+++ b/web/sdk/admin/views/organizations/details/index.tsx
@@ -8,8 +8,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { create } from "@bufbuild/protobuf";
 
 import { OrganizationDetailsLayout } from "./layout";
-import { ORG_NAMESPACE } from "./types";
 import { OrganizationContext } from "./contexts/organization-context";
+import { useOrganizationRoles } from "~/admin/hooks/useOrganizationRoles";
 import {
   FrontierServiceQueries,
   GetBillingAccountRequestSchema,
@@ -112,35 +112,11 @@ export const OrganizationDetailsView = ({
     );
   }
 
-  // Fetch default roles
-  const {
-    data: defaultRoles = [],
-    isLoading: isDefaultRolesLoading,
-    error: defaultRolesError,
-  } = useQuery(
-    FrontierServiceQueries.listRoles,
-    { scopes: [ORG_NAMESPACE] },
-    {
-      enabled: !!organizationId,
-      select: (data) => data?.roles || [],
-    },
+  // Fetch roles assignable in this org (platform defaults + org custom)
+  const { roles, isLoading: isRolesLoading } = useOrganizationRoles(
+    organizationId,
+    { enabled: !!organizationId },
   );
-
-  // Fetch organization-specific roles
-  const {
-    data: organizationRoles = [],
-    isLoading: isOrgRolesLoading,
-    error: orgRolesError,
-  } = useQuery(
-    FrontierServiceQueries.listOrganizationRoles,
-    { orgId: organizationId || "", scopes: [ORG_NAMESPACE] },
-    {
-      enabled: !!organizationId,
-      select: (data) => data?.roles || [],
-    },
-  );
-
-  const roles = [...defaultRoles, ...organizationRoles];
 
   // Fetch organization members
   const {
@@ -226,12 +202,6 @@ export const OrganizationDetailsView = ({
     if (kycError) {
       console.error("Failed to fetch KYC details:", kycError);
     }
-    if (defaultRolesError) {
-      console.error("Failed to fetch default roles:", defaultRolesError);
-    }
-    if (orgRolesError) {
-      console.error("Failed to fetch organization roles:", orgRolesError);
-    }
     if (orgMembersError) {
       console.error("Failed to fetch organization members:", orgMembersError);
     }
@@ -250,8 +220,6 @@ export const OrganizationDetailsView = ({
   }, [
     organizationError,
     kycError,
-    defaultRolesError,
-    orgRolesError,
     orgMembersError,
     billingAccountsError,
     billingAccountError,
@@ -259,10 +227,7 @@ export const OrganizationDetailsView = ({
   ]);
 
   const isLoading =
-    isOrganizationLoading ||
-    isDefaultRolesLoading ||
-    isOrgRolesLoading ||
-    isBillingAccountLoading;
+    isOrganizationLoading || isRolesLoading || isBillingAccountLoading;
   return (
     <OrganizationContext.Provider
       value={{

--- a/web/sdk/admin/views/organizations/details/members/index.tsx
+++ b/web/sdk/admin/views/organizations/details/members/index.tsx
@@ -1,13 +1,22 @@
-import { AlertDialog, DataTable, EmptyState, Flex } from "@raystack/apsara";
+import { AlertDialog, Button, DataTable, EmptyState, Flex } from "@raystack/apsara";
 import type { DataTableQuery, DataTableSort } from "@raystack/apsara";
 import { PageTitle } from "~/admin/components/PageTitle";
 import styles from "./members.module.css";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { getColumns } from "./columns";
-import type { SearchOrganizationUsersResponse_OrganizationUser } from "@raystack/proton/frontier";
-import { AdminServiceQueries } from "@raystack/proton/frontier";
+import type {
+  Invitation,
+  SearchOrganizationUsersResponse_OrganizationUser,
+} from "@raystack/proton/frontier";
+import {
+  AdminServiceQueries,
+  FrontierServiceQueries,
+  ListOrganizationInvitationsRequestSchema,
+} from "@raystack/proton/frontier";
+import { create } from "@bufbuild/protobuf";
 import {
   useInfiniteQuery,
+  useQuery,
   createConnectQueryKey,
   useTransport
 } from '@connectrpc/connect-query';
@@ -24,8 +33,12 @@ import {
 import { transformDataTableQueryToRQLRequest } from '~/utils/transform-query';
 import { useDebouncedValue } from '~hooks';
 import { useTerminology } from "~/admin/hooks/useTerminology";
+import { InvitedMembersDialog } from './invited-members-dialog';
 
 const updateRoleDialogHandle = AlertDialog.createHandle<UpdateRolePayload>();
+
+// Stable ref: a fresh [] each render would remount the invites table.
+const NO_INVITATIONS: Invitation[] = [];
 
 const DEFAULT_SORT: DataTableSort = { name: 'orgJoinedAt', order: 'desc' };
 const INITIAL_QUERY: DataTableQuery = {
@@ -103,6 +116,24 @@ export function OrganizationMembersView() {
     user: SearchOrganizationUsersResponse_OrganizationUser | null;
   }>({ isOpen: false, user: null });
 
+  const [isInvitesDialogOpen, setIsInvitesDialogOpen] = useState(false);
+
+  // Not in the dialog: the toolbar needs the count before it mounts.
+  const {
+    data: invitations = NO_INVITATIONS,
+    isLoading: isInvitationsLoading,
+    error: invitationsError,
+  } = useQuery(
+    FrontierServiceQueries.listOrganizationInvitations,
+    create(ListOrganizationInvitationsRequestSchema, {
+      orgId: organizationId,
+    }),
+    {
+      enabled: !!organizationId,
+      select: data => data?.invitations || NO_INVITATIONS,
+    },
+  );
+
   const title = `${t.member({ plural: true, case: "capital" })} | ${organization?.title} | ${t.organization({ plural: true, case: "capital" })}`;
 
   const [tableQuery, setTableQuery] = useState<DataTableQuery>(INITIAL_QUERY);
@@ -155,6 +186,16 @@ export function OrganizationMembersView() {
   const showZeroState =
     !isLoading && !isError && !hasActiveQuery && data.length === 0;
 
+  // DataTable.Toolbar's own rule: hidden in the zero state.
+  const showToolbar = data.length > 0 || Boolean(tableQuery.filters?.length);
+  /*
+   * - an org always has at least one member, so the toolbar-less branch below
+   *   is a safeguard, not a state to expect
+   * - the trigger is the count: a failed fetch leaves nothing to label, so it
+   *   stays hidden and only logs
+   */
+  const showInvitesBtn = invitations.length > 0;
+
   const onTableQueryChange = (newQuery: DataTableQuery) => {
     setTableQuery(newQuery);
   };
@@ -164,6 +205,15 @@ export function OrganizationMembersView() {
       await fetchNextPage();
     }
   };
+
+  useEffect(() => {
+    if (invitationsError) {
+      console.error(
+        "Failed to fetch organization invitations:",
+        invitationsError,
+      );
+    }
+  }, [invitationsError]);
 
   useEffect(() => {
     setSearchVisibility(true);
@@ -230,6 +280,15 @@ export function OrganizationMembersView() {
           onClose={closeRemoveMemberDialog}
         />
       ) : null}
+
+      {isInvitesDialogOpen ? (
+        <InvitedMembersDialog
+          organizationId={organizationId}
+          invitations={invitations}
+          isLoading={isInvitationsLoading}
+          onClose={() => setIsInvitesDialogOpen(false)}
+        />
+      ) : null}
       <Flex justify="center" className={styles["container"]}>
         <PageTitle title={title} />
         <DataTable
@@ -242,7 +301,32 @@ export function OrganizationMembersView() {
           onLoadMore={fetchMore}
           query={tableQuery}>
           <Flex direction="column" style={{ width: "100%" }}>
-            <DataTable.Toolbar />
+            {/* DataTable.Toolbar takes no children, so the row is rebuilt from
+                its parts to seat the invites trigger left of Display. */}
+            {(showToolbar || showInvitesBtn) && (
+              <Flex
+                justify={showToolbar ? "between" : "end"}
+                align="start"
+                gap={3}
+                className={styles["toolbar"]}>
+                {showToolbar && <DataTable.Filters />}
+                <Flex align="center" gap={3}>
+                  {showInvitesBtn && (
+                    <Button
+                      variant="text"
+                      color="neutral"
+                      size="small"
+                      onClick={() => setIsInvitesDialogOpen(true)}
+                      data-test-id="admin-org-members-invites">
+                      {/* Expired invites come back too, so "Pending" would
+                          overstate the count — Status labels each row. */}
+                      {`${invitations.length} Invite${invitations.length === 1 ? "" : "s"}`}
+                    </Button>
+                  )}
+                  {showToolbar && <DataTable.DisplayControls />}
+                </Flex>
+              </Flex>
+            )}
             <DataTable.Content
               emptyState={showZeroState ? <ZeroState /> : isError ? <ErrorState /> : <NoMembers />}
               classNames={{

--- a/web/sdk/admin/views/organizations/details/members/invited-members-columns.tsx
+++ b/web/sdk/admin/views/organizations/details/members/invited-members-columns.tsx
@@ -2,7 +2,6 @@ import {
   AlertDialog,
   IconButton,
   Menu,
-  Text,
   type DataTableColumnDef,
 } from "@raystack/apsara";
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
@@ -72,10 +71,7 @@ export const getInvitedMembersColumns = ({
     {
       accessorKey: "expiresAt",
       header: "Expiry",
-      cell: ({ row }) => {
-        const { text, isExpired } = formatInviteExpiry(row.original.expiresAt);
-        return <Text variant={isExpired ? "danger" : undefined}>{text}</Text>;
-      },
+      cell: ({ row }) => formatInviteExpiry(row.original.expiresAt).text,
       sortingFn: (a, b) =>
         seconds(a.original.expiresAt) - seconds(b.original.expiresAt),
       enableSorting: true,
@@ -104,7 +100,7 @@ export const getInvitedMembersColumns = ({
                 </IconButton>
               }
             />
-            <Menu.Content>
+            <Menu.Content align="end">
               <Menu.Item
                 leadingIcon={<DeleteIcon />}
                 className={styles["invites-remove-item"]}

--- a/web/sdk/admin/views/organizations/details/members/invited-members-columns.tsx
+++ b/web/sdk/admin/views/organizations/details/members/invited-members-columns.tsx
@@ -1,0 +1,127 @@
+import {
+  AlertDialog,
+  IconButton,
+  Menu,
+  Text,
+  type DataTableColumnDef,
+} from "@raystack/apsara";
+import { DotsHorizontalIcon } from "@radix-ui/react-icons";
+import type { Invitation } from "@raystack/proton/frontier";
+import { DeleteIcon } from "~/admin/assets/icons/DeleteIcon";
+import {
+  formatInviteExpiry,
+  formatTimestamp,
+  type TimeStamp,
+} from "~/admin/utils/connect-timestamp";
+import type { RemoveInvitePayload } from "./remove-invite-dialog";
+import styles from "./members.module.css";
+
+interface GetColumnsOptions {
+  /** Role id → title, from useOrganizationRoles. */
+  roleTitleById: Map<string, string>;
+  removeInviteHandle: ReturnType<
+    typeof AlertDialog.createHandle<RemoveInvitePayload>
+  >;
+}
+
+const seconds = (timestamp?: TimeStamp) => Number(timestamp?.seconds ?? 0);
+
+export const getInvitedMembersColumns = ({
+  roleTitleById,
+  removeInviteHandle,
+}: GetColumnsOptions): DataTableColumnDef<Invitation, unknown>[] => [
+    {
+      // Invitations carry no user record — user_id is the invited email.
+      accessorKey: "userId",
+      header: "Email",
+      classNames: {
+        header: styles["invites-email-column"],
+        cell: styles["invites-email-column"],
+      },
+      cell: ({ getValue }) => (getValue() as string) || "-",
+      enableSorting: true,
+    },
+    {
+      accessorKey: "roleIds",
+      header: "Role",
+      cell: ({ getValue }) => {
+        const titles = (getValue() as string[])
+          .map((id) => roleTitleById.get(id))
+          .filter(Boolean);
+        return titles.join(", ") || "-";
+      },
+    },
+    {
+      accessorKey: "expiresAt",
+      id: "status",
+      header: "Status",
+      cell: ({ row }) =>
+        formatInviteExpiry(row.original.expiresAt).isExpired
+          ? "Expired"
+          : "Pending",
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Invited on",
+      cell: ({ row }) => formatTimestamp(row.original.createdAt),
+      // Timestamps are objects, so the default comparator can't order them.
+      sortingFn: (a, b) =>
+        seconds(a.original.createdAt) - seconds(b.original.createdAt),
+      enableSorting: true,
+    },
+    {
+      accessorKey: "expiresAt",
+      header: "Expiry",
+      cell: ({ row }) => {
+        const { text, isExpired } = formatInviteExpiry(row.original.expiresAt);
+        return <Text variant={isExpired ? "danger" : undefined}>{text}</Text>;
+      },
+      sortingFn: (a, b) =>
+        seconds(a.original.expiresAt) - seconds(b.original.expiresAt),
+      enableSorting: true,
+    },
+    {
+      accessorKey: "id",
+      header: "",
+      // Its accessor is a string, so search would match invite ids without this.
+      enableGlobalFilter: false,
+      classNames: {
+        header: styles["invites-action-column"],
+        cell: styles["invites-action-column"],
+      },
+      cell: ({ row }) => {
+        // Offered on every row; only the confirmation copy differs.
+        const { isExpired } = formatInviteExpiry(row.original.expiresAt);
+
+        return (
+          <Menu>
+            <Menu.Trigger
+              render={
+                <IconButton
+                  size={3}
+                  data-test-id="admin-org-invites-action-menu">
+                  <DotsHorizontalIcon />
+                </IconButton>
+              }
+            />
+            <Menu.Content>
+              <Menu.Item
+                leadingIcon={<DeleteIcon />}
+                className={styles["invites-remove-item"]}
+                onClick={() =>
+                  removeInviteHandle.openWithPayload({
+                    inviteId: row.original.id,
+                    email: row.original.userId,
+                    isExpired,
+                  })
+                }
+                data-test-id="admin-org-invites-remove-action"
+              >
+                Remove
+              </Menu.Item>
+            </Menu.Content>
+          </Menu>
+        );
+      },
+    },
+  ];

--- a/web/sdk/admin/views/organizations/details/members/invited-members-dialog.tsx
+++ b/web/sdk/admin/views/organizations/details/members/invited-members-dialog.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState } from "react";
+import {
+  AlertDialog,
+  Button,
+  DataTable,
+  Dialog,
+  EmptyState,
+  Flex,
+  type DataTableSort,
+} from "@raystack/apsara";
+import type { Invitation } from "@raystack/proton/frontier";
+import { UsersIcon } from "~/admin/assets/icons/UsersIcon";
+import { useOrganizationRoles } from "~/admin/hooks/useOrganizationRoles";
+import { useTerminology } from "~/admin/hooks/useTerminology";
+import { InviteUsersDialog } from "../layout/invite-users-dialog";
+import { getInvitedMembersColumns } from "./invited-members-columns";
+import {
+  RemoveInviteDialog,
+  type RemoveInvitePayload,
+} from "./remove-invite-dialog";
+import styles from "./members.module.css";
+
+const removeInviteHandle = AlertDialog.createHandle<RemoveInvitePayload>();
+
+const DEFAULT_SORT: DataTableSort = { name: "createdAt", order: "desc" };
+
+interface InvitedMembersDialogProps {
+  organizationId: string;
+  invitations: Invitation[];
+  isLoading: boolean;
+  onClose: () => void;
+}
+
+const NoInvites = () => (
+  <EmptyState
+    classNames={{
+      container: styles["empty-state"],
+      subHeading: styles["empty-state-subheading"],
+    }}
+    heading="No invites found"
+    subHeading="Invitations that have been sent but not yet accepted will appear here."
+    icon={<UsersIcon />}
+  />
+);
+
+export const InvitedMembersDialog = ({
+  organizationId,
+  invitations,
+  isLoading,
+  onClose,
+}: InvitedMembersDialogProps) => {
+  const t = useTerminology();
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
+  const { titleById } = useOrganizationRoles(organizationId);
+
+  const columns = useMemo(
+    () =>
+      getInvitedMembersColumns({
+        roleTitleById: titleById,
+        removeInviteHandle,
+      }),
+    [titleById],
+  );
+
+  return (
+    <>
+      {isInviteDialogOpen ? (
+        <InviteUsersDialog onOpenChange={setIsInviteDialogOpen} />
+      ) : null}
+      <RemoveInviteDialog
+        handle={removeInviteHandle}
+        organizationId={organizationId}
+      />
+      <Dialog open onOpenChange={onClose}>
+        <Dialog.Content className={styles["invites-dialog-content"]}>
+          <Dialog.Header>
+            <Dialog.Title>Invited {t.member({ plural: true })}</Dialog.Title>
+            <Dialog.CloseButton data-test-id="admin-org-invites-close" />
+          </Dialog.Header>
+          <Dialog.Body className={styles["invites-dialog-body"]}>
+            {/* Client mode: the list API takes no query. */}
+            <DataTable
+              columns={columns}
+              data={invitations}
+              isLoading={isLoading}
+              mode="client"
+              defaultSort={DEFAULT_SORT}
+            >
+              <Flex
+                direction="column"
+                gap={5}
+                className={styles["invites-table-wrapper"]}
+              >
+                <Flex justify="between" align="center" gap={4}>
+                  {/* Sized via `width`; className lands on the inner input. */}
+                  <DataTable.Search
+                    placeholder="Search by email"
+                    showClearButton={true}
+                    width="33.33%"
+                  />
+                  <Button
+                    onClick={() => setIsInviteDialogOpen(true)}
+                    data-test-id="admin-org-invites-invite-member"
+                  >
+                    Invite {t.member({ case: "lower" })}
+                  </Button>
+                </Flex>
+                <DataTable.Content
+                  emptyState={<NoInvites />}
+                  classNames={{
+                    root: styles["invites-table-scroll"],
+                    table: styles["table"],
+                    header: styles["table-header"],
+                  }}
+                />
+              </Flex>
+            </DataTable>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog>
+    </>
+  );
+};

--- a/web/sdk/admin/views/organizations/details/members/members.module.css
+++ b/web/sdk/admin/views/organizations/details/members/members.module.css
@@ -16,7 +16,7 @@
 }
 
 .zero-state-container {
-  padding: var(--rs-space-17) var(--rs-space-10) var(--rs-space-10);
+    padding: var(--rs-space-17) var(--rs-space-10) var(--rs-space-10);
 }
 
 .table {
@@ -39,13 +39,65 @@
     width: var(--rs-space-12);
 }
 
-.table-action-column > * {
+/* Mirrors Apsara's own toolbar row, which we rebuild. */
+.toolbar {
+    align-self: stretch;
+    background: var(--rs-color-background-base-primary);
+    border-bottom: 0.5px solid var(--rs-color-border-base-primary);
+    padding: var(--rs-space-3) var(--rs-space-7) var(--rs-space-3) var(--rs-space-5);
+}
+
+/* Design's proportions of the 1440x1024 frame; long lists scroll the rows
+   while the header and search row stay put. */
+.invites-dialog-content {
+    width: 80vw;
+    height: 78vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.invites-dialog-body {
+    display: flex;
+    /* min-height:0 lets the scroll container shrink instead of overflowing. */
+    min-height: 0;
+    flex: 1;
+    padding: var(--rs-space-5);
+}
+
+.invites-table-wrapper {
+    width: 100%;
+    min-height: 0;
+    flex: 1;
+}
+
+.invites-table-scroll {
+    min-height: 0;
+    flex: 1;
+    overflow: auto;
+}
+
+.invites-action-column {
+    width: var(--rs-space-12);
+}
+
+/* Cell colours its own leading-icon wrapper, so the icon needs the override. */
+.invites-remove-item,
+.invites-remove-item svg {
+    color: var(--rs-color-foreground-danger-primary);
+}
+
+/* table-layout:fixed splits columns evenly; emails need more. */
+.invites-email-column {
+    width: calc(100% / 3);
+}
+
+.table-action-column>* {
     opacity: 0;
     transition: opacity 120ms ease-in-out;
 }
 
-.table-wrapper tr:hover .table-action-column > *,
-.table-action-column:focus-within > *,
-.table-action-column:has([data-popup-open]) > * {
+.table-wrapper tr:hover .table-action-column>*,
+.table-action-column:focus-within>*,
+.table-action-column:has([data-popup-open])>* {
     opacity: 1;
 }

--- a/web/sdk/admin/views/organizations/details/members/remove-invite-dialog.tsx
+++ b/web/sdk/admin/views/organizations/details/members/remove-invite-dialog.tsx
@@ -1,0 +1,152 @@
+import { create } from "@bufbuild/protobuf";
+import {
+  useMutation,
+  createConnectQueryKey,
+  useTransport,
+} from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  FrontierServiceQueries,
+  DeleteOrganizationInvitationRequestSchema,
+} from "@raystack/proton/frontier";
+import { AlertDialog, Button, toastManager } from "@raystack/apsara";
+import { handleConnectError } from "~/utils/error";
+
+export type RemoveInvitePayload = {
+  inviteId: string;
+  email: string;
+  isExpired: boolean;
+};
+
+const DESCRIPTION = {
+  pending: (email: string) =>
+    `The invitation for ${email} will be revoked and the link in their email will stop working.`,
+  expired: (email: string) =>
+    `The invitation sent to ${email} has already expired. Removing it only clears the entry from this list.`,
+};
+
+interface RemoveInviteDialogProps {
+  handle: ReturnType<typeof AlertDialog.createHandle<RemoveInvitePayload>>;
+  organizationId: string;
+}
+
+export const RemoveInviteDialog = ({
+  handle,
+  organizationId,
+}: RemoveInviteDialogProps) => {
+  return (
+    <AlertDialog handle={handle}>
+      {({ payload: rawPayload }) => {
+        const payload = rawPayload as RemoveInvitePayload | undefined;
+        return payload ? (
+          <RemoveInviteContent
+            payload={payload}
+            organizationId={organizationId}
+            onClose={() => handle.close()}
+          />
+        ) : null;
+      }}
+    </AlertDialog>
+  );
+};
+
+function RemoveInviteContent({
+  payload,
+  organizationId,
+  onClose,
+}: {
+  payload: RemoveInvitePayload;
+  organizationId: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const transport = useTransport();
+
+  const { mutateAsync: deleteInvitation, isPending } = useMutation(
+    FrontierServiceQueries.deleteOrganizationInvitation,
+  );
+
+  async function onRemove() {
+    try {
+      await deleteInvitation(
+        create(DeleteOrganizationInvitationRequestSchema, {
+          orgId: organizationId,
+          id: payload.inviteId,
+        }),
+      );
+    } catch (error) {
+      console.error(error);
+      handleConnectError(error, {
+        NotFound: () =>
+          toastManager.add({
+            title: "Invitation no longer exists",
+            type: "error",
+          }),
+        PermissionDenied: () =>
+          toastManager.add({
+            title: "You don't have permission to perform this action",
+            type: "error",
+          }),
+        Default: err =>
+          toastManager.add({
+            title: "Something went wrong",
+            description: err.rawMessage,
+            type: "error",
+          }),
+      });
+      return;
+    }
+
+    toastManager.add({ title: "Invitation removed", type: "success" });
+    onClose();
+
+    // Outside the try: a failing refetch mustn't read as a failed delete.
+    await queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: FrontierServiceQueries.listOrganizationInvitations,
+        transport,
+        input: { orgId: organizationId },
+        cardinality: "finite",
+      }),
+    });
+  }
+
+  return (
+    <AlertDialog.Content>
+      <AlertDialog.Header>
+        <AlertDialog.Title>Remove invitation</AlertDialog.Title>
+        <AlertDialog.Description>
+          {payload.isExpired
+            ? DESCRIPTION.expired(payload.email)
+            : DESCRIPTION.pending(payload.email)}
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Close
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              color="neutral"
+              disabled={isPending}
+              data-test-id="admin-remove-invite-cancel"
+            >
+              Cancel
+            </Button>
+          }
+        />
+        <Button
+          type="button"
+          variant="solid"
+          color="danger"
+          onClick={onRemove}
+          loading={isPending}
+          loaderText="Removing..."
+          data-test-id="admin-remove-invite-confirm"
+        >
+          Remove
+        </Button>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a way to view and manage an organization's pending invites from the Members page. An "N Invites" button sits next to Display in the members toolbar and opens a modal listing every invitation sent for that org, where an invite can be revoked.

## Changes
- Members toolbar: "N Invites" trigger, shown only when the org has invites
- "Invited members" modal listing email, role, status, invited on and expiry, with search
- Remove action per invite, behind a confirmation dialog
- "Invite member" button in the modal, reusing the existing invite dialog
- `useOrganizationRoles` (added in #1847) takes an `enabled` option and is reused by organization details

## Technical Details
- Toolbar is rebuilt from `DataTable.Filters` + `DataTable.DisplayControls`, since `DataTable.Toolbar` accepts no children and the design puts the trigger left of Display.
- Table runs in `mode="client"`: `ListOrganizationInvitations` takes no query params and returns every row, so there is no server-side search or pagination to hook into. Search is scoped to email; the action column is opted out so invite uuids aren't matched.
- Status and expiry are derived from `expires_at` at render, as the API returns lapsed invites too. The trigger reads "N Invites", not "N Pending", because the count covers every row and Status distinguishes them. Expiry uses the default foreground — Status already signals expired.
- Removal calls `DeleteOrganizationInvitation` and invalidates the list query, refreshing both the table and the count. Confirmation wording differs for live vs expired invites.
- Invitations are fetched on the members page, not in the modal, because the toolbar needs the count first. The trigger *is* the count, so a failed fetch stays hidden and logs.

## Test Plan
- [x] Manual testing completed
  - Count appears with invites, hidden without, and matches the modal's rows
  - Search filters by email; a pasted invite id matches nothing
  - Remove revokes the invite and updates both list and count, with expired wording for lapsed ones
  - Invite member opens the existing dialog and the new invite appears
- [x] Build and type checking passes
  - `tsc --noEmit` and `eslint` clean on the touched files, apart from 3 pre-existing unused-arg warnings
  - `pnpm build` succeeds in `web/sdk`

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
Not applicable — frontend only, no Go or query changes.
