### PR TITLE
fix(bootstrap): harden AppendSchema against list errors and missing metadata description

### DIFF
--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -188,20 +188,29 @@ func (s Service) AppendSchema(ctx context.Context, customServiceDefinition schem
 		return fmt.Errorf("AppendSchema: listing existing permissions: %w", err)
 	}
 	for _, existingPermission := range existingPermissions {
-		description := ""
-		if existingPermission.Metadata != nil {
-			if v, ok := existingPermission.Metadata["description"]; !ok {
-				description = v.(string)
-			}
-		}
 		existingServiceDefinition.Permissions = append(existingServiceDefinition.Permissions, schema.ResourcePermission{
 			Name:        existingPermission.Name,
 			Namespace:   existingPermission.NamespaceID,
-			Description: description,
+			Description: permissionDescription(existingPermission),
 		})
 	}
 
 	return s.applySchema(ctx, schema.MergeServiceDefinitions(customServiceDefinition, existingServiceDefinition))
+}
+
+// permissionDescription reads the human description out of a permission's
+// metadata. It returns "" when the metadata is missing, has no description, or
+// stores a non-string value, and never panics on a missing key.
+func permissionDescription(p permission.Permission) string {
+	if p.Metadata == nil {
+		return ""
+	}
+	v, ok := p.Metadata["description"]
+	if !ok {
+		return ""
+	}
+	desc, _ := v.(string)
+	return desc
 }
 
 // applySchema builds and apply schema over az engine and db

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/core/role"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/pkg/metadata"
 )
 
 var (
@@ -179,37 +180,37 @@ func (s Service) BuiltinPermissions(ctx context.Context) (map[string]struct{}, e
 }
 
 func (s Service) AppendSchema(ctx context.Context, customServiceDefinition schema.ServiceDefinition) error {
-	// get existing permissions and append to the new definition
-	// this is required to avoid overriding existing permissions in authzed engine
-	var existingServiceDefinition schema.ServiceDefinition
-
+	// re-apply the base schema merged with the permissions already in the
+	// database, so a re-apply never drops the existing ones.
 	existingPermissions, err := s.permissionService.List(ctx, permission.Filter{})
 	if err != nil {
 		return fmt.Errorf("AppendSchema: listing existing permissions: %w", err)
 	}
-	for _, existingPermission := range existingPermissions {
-		existingServiceDefinition.Permissions = append(existingServiceDefinition.Permissions, schema.ResourcePermission{
-			Name:        existingPermission.Name,
-			Namespace:   existingPermission.NamespaceID,
-			Description: permissionDescription(existingPermission),
-		})
-	}
+	existingServiceDefinition := existingPermissionsAsServiceDefinition(existingPermissions)
 
 	return s.applySchema(ctx, schema.MergeServiceDefinitions(customServiceDefinition, existingServiceDefinition))
 }
 
+// existingPermissionsAsServiceDefinition maps the permissions already in the
+// database into a service definition, so merging it into a re-applied schema
+// keeps them.
+func existingPermissionsAsServiceDefinition(perms []permission.Permission) schema.ServiceDefinition {
+	var def schema.ServiceDefinition
+	for _, p := range perms {
+		def.Permissions = append(def.Permissions, schema.ResourcePermission{
+			Name:        p.Name,
+			Namespace:   p.NamespaceID,
+			Description: permissionDescription(p.Metadata),
+		})
+	}
+	return def
+}
+
 // permissionDescription reads the human description out of a permission's
-// metadata. It returns "" when the metadata is missing, has no description, or
-// stores a non-string value, and never panics on a missing key.
-func permissionDescription(p permission.Permission) string {
-	if p.Metadata == nil {
-		return ""
-	}
-	v, ok := p.Metadata["description"]
-	if !ok {
-		return ""
-	}
-	desc, _ := v.(string)
+// metadata. Indexing a nil map and asserting a missing or non-string value are
+// both safe, so this returns "" in those cases and never panics.
+func permissionDescription(m metadata.Metadata) string {
+	desc, _ := m["description"].(string)
 	return desc
 }
 

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -185,7 +185,7 @@ func (s Service) AppendSchema(ctx context.Context, customServiceDefinition schem
 
 	existingPermissions, err := s.permissionService.List(ctx, permission.Filter{})
 	if err != nil {
-		return nil
+		return fmt.Errorf("AppendSchema: listing existing permissions: %w", err)
 	}
 	for _, existingPermission := range existingPermissions {
 		description := ""

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/core/role"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
+	"github.com/raystack/frontier/pkg/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -324,4 +325,26 @@ func Test_AppendSchema(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "db timeout")
 	})
+}
+
+func Test_permissionDescription(t *testing.T) {
+	cases := []struct {
+		name string
+		meta metadata.Metadata
+		want string
+	}{
+		{"nil metadata", nil, ""},
+		// a present key must be read, not ignored
+		{"string description", metadata.Metadata{"description": "read access"}, "read access"},
+		// a missing key must not panic; it used to assert nil to string
+		{"missing description key", metadata.Metadata{"other": "x"}, ""},
+		// a non-string value must not panic either
+		{"non-string description", metadata.Metadata{"description": 42}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := permissionDescription(permission.Permission{Metadata: tc.meta})
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/raystack/frontier/core/permission"
 	"github.com/raystack/frontier/core/relation"
 	"github.com/raystack/frontier/core/role"
 	"github.com/raystack/frontier/internal/bootstrap/schema"
@@ -53,6 +54,24 @@ func (m *mockRelationService) Create(ctx context.Context, rel relation.Relation)
 func (m *mockRelationService) Delete(ctx context.Context, rel relation.Relation) error {
 	args := m.Called(ctx, rel)
 	return args.Error(0)
+}
+
+// mockPermissionService implements bootstrap.PermissionService
+type mockPermissionService struct {
+	mock.Mock
+}
+
+func (m *mockPermissionService) List(ctx context.Context, flt permission.Filter) ([]permission.Permission, error) {
+	args := m.Called(ctx, flt)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]permission.Permission), args.Error(1)
+}
+
+func (m *mockPermissionService) Upsert(ctx context.Context, action permission.Permission) (permission.Permission, error) {
+	args := m.Called(ctx, action)
+	return args.Get(0).(permission.Permission), args.Error(1)
 }
 
 func Test_migratePATRelations(t *testing.T) {
@@ -288,5 +307,21 @@ func Test_migrateRole(t *testing.T) {
 		assert.Error(t, err)
 		roleSvc.AssertNotCalled(t, "Upsert")
 		roleSvc.AssertNotCalled(t, "Update")
+	})
+}
+
+func Test_AppendSchema(t *testing.T) {
+	t.Run("returns the error when listing existing permissions fails", func(t *testing.T) {
+		// A failed list must not be swallowed: boot would then apply an empty
+		// schema and drop every custom permission already in the database.
+		permSvc := new(mockPermissionService)
+		permSvc.On("List", mock.Anything, permission.Filter{}).
+			Return(nil, errors.New("db timeout"))
+
+		svc := Service{permissionService: permSvc}
+		err := svc.AppendSchema(context.Background(), schema.ServiceDefinition{})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "db timeout")
 	})
 }

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -313,8 +313,8 @@ func Test_migrateRole(t *testing.T) {
 
 func Test_AppendSchema(t *testing.T) {
 	t.Run("returns the error when listing existing permissions fails", func(t *testing.T) {
-		// A failed list must not be swallowed: boot would then apply an empty
-		// schema and drop every custom permission already in the database.
+		// The old code returned nil here, so a failed list skipped the schema
+		// re-apply but still reported boot success. Boot must surface the error.
 		permSvc := new(mockPermissionService)
 		permSvc.On("List", mock.Anything, permission.Filter{}).
 			Return(nil, errors.New("db timeout"))
@@ -325,6 +325,20 @@ func Test_AppendSchema(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "db timeout")
 	})
+}
+
+func Test_existingPermissionsAsServiceDefinition(t *testing.T) {
+	perms := []permission.Permission{
+		{Name: "get", NamespaceID: "compute/order", Metadata: metadata.Metadata{"description": "read an order"}},
+		{Name: "delete", NamespaceID: "compute/order"},
+	}
+
+	def := existingPermissionsAsServiceDefinition(perms)
+
+	assert.Equal(t, []schema.ResourcePermission{
+		{Name: "get", Namespace: "compute/order", Description: "read an order"},
+		{Name: "delete", Namespace: "compute/order", Description: ""},
+	}, def.Permissions)
 }
 
 func Test_permissionDescription(t *testing.T) {
@@ -343,7 +357,7 @@ func Test_permissionDescription(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := permissionDescription(permission.Permission{Metadata: tc.meta})
+			got := permissionDescription(tc.meta)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## What

Fixes two long-standing bugs in `bootstrap.AppendSchema`. Both are already on `main` and are independent of the boot loader removal work.

### 1. A failed permission list was swallowed

```go
existingPermissions, err := s.permissionService.List(ctx, permission.Filter{})
if err != nil {
    return nil // <- returns success without applying the schema
}
```

When the list call failed, `AppendSchema` returned `nil` before `applySchema` ran. So a transient list error at boot skipped the schema re-apply but still reported success. Nothing was applied and nothing was dropped, but boot looked healthy while silently doing no schema work. On a first boot, where the base schema has not been applied yet, that leaves the server with no schema at all. The fix returns the wrapped error so boot stops instead of reporting a false success.

### 2. The metadata description read had inverted logic and could panic

```go
if v, ok := existingPermission.Metadata["description"]; !ok {
    description = v.(string) // <- runs only when the key is absent, then asserts nil to string
}
```

The `!ok` branch runs only when the `description` key is missing. In that case `v` is a nil `any`, so `v.(string)` panics. When the key is present, the value was ignored and the description was dropped. The logic is now pulled into a small `permissionDescription` helper that reads the value when present, returns `""` when it is missing or not a string, and never panics.

## Why now

These are pre-existing bugs, but #1767 removes the boot-time config schema loader and makes `AppendSchema` the only path that applies the schema at boot. That raises how much these two edge cases matter, so it is worth fixing them on their own.

## Tests

- `Test_AppendSchema` proves a list error is returned, not swallowed.
- `Test_permissionDescription` covers nil metadata, a present string, a missing key, and a non-string value (the last two used to panic).
- `Test_existingPermissionsAsServiceDefinition` covers the mapping from existing permissions into the schema, so a wrong field or dropped description is caught.

`go build ./...`, `go vet ./...`, `go test ./internal/bootstrap/...` pass. gofmt and golangci-lint clean.
