### PR TITLE
fix(server): set ReadHeaderTimeout and IdleTimeout on all HTTP servers

### DIFF
--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -58,6 +58,12 @@ app:
   metrics_port: 9000
   # how long each server waits for in-flight requests to finish during shutdown
   shutdown_grace_period: 10s
+  # how long each server waits for a client to send its request headers
+  read_header_timeout: 10s
+  # how long each server keeps an idle keep-alive connection open.
+  # keep it larger than the keep-alive timeout of any fronting proxy,
+  # so the proxy never sends a request on a connection the server is closing
+  idle_timeout: 180s
   # enable pprof endpoints for cpu/mem/mutex profiling
   profiler: false
   host: "127.0.0.1"

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -60,6 +60,16 @@ type Config struct {
 	// requests to finish during shutdown before cutting them off
 	ShutdownGracePeriod time.Duration `yaml:"shutdown_grace_period" mapstructure:"shutdown_grace_period" default:"10s"`
 
+	// ReadHeaderTimeout is how long each server waits for a client to send
+	// its request headers before closing the connection
+	ReadHeaderTimeout time.Duration `yaml:"read_header_timeout" mapstructure:"read_header_timeout" default:"10s"`
+
+	// IdleTimeout is how long each server keeps an idle keep-alive
+	// connection open before closing it. It must be larger than the
+	// keep-alive timeout of any fronting proxy, so the proxy never sends
+	// a request on a connection the server is already closing
+	IdleTimeout time.Duration `yaml:"idle_timeout" mapstructure:"idle_timeout" default:"180s"`
+
 	// Profiler enables /debug/pprof under metrics port
 	Profiler bool `yaml:"profiler" mapstructure:"profiler" default:"false"`
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -99,8 +99,10 @@ func ServeUI(ctx context.Context, logger *slog.Logger, uiConfig UIConfig, apiSer
 	mux.Handle("/", http.StripPrefix("/", spaHandler))
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", uiConfig.Port),
-		Handler: mux,
+		Addr:              fmt.Sprintf(":%d", uiConfig.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: apiServerConfig.ReadHeaderTimeout,
+		IdleTimeout:       apiServerConfig.IdleTimeout,
 	}
 
 	logger.Info("ui server starting", "http-port", uiConfig.Port)
@@ -230,10 +232,14 @@ func ServeConnect(ctx context.Context, logger *slog.Logger, cfg Config, deps api
 	protocols.SetUnencryptedHTTP2(true)
 	protocols.SetHTTP2(true)
 
+	// No WriteTimeout on purpose: the connect server streams long export
+	// responses (e.g. ExportAuditRecords) that a write deadline would cut off.
 	server := &http.Server{
-		Addr:      fmt.Sprintf(":%d", cfg.Connect.Port),
-		Handler:   handler,
-		Protocols: protocols,
+		Addr:              fmt.Sprintf(":%d", cfg.Connect.Port),
+		Handler:           handler,
+		Protocols:         protocols,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		IdleTimeout:       cfg.IdleTimeout,
 	}
 
 	// counts shutdown goroutines still draining their servers
@@ -249,8 +255,10 @@ func ServeConnect(ctx context.Context, logger *slog.Logger, cfg Config, deps api
 			metricsMux.Handle("/debug/pprof/", http.DefaultServeMux)
 		}
 		metricsServer := &http.Server{
-			Addr:    fmt.Sprintf(":%d", cfg.MetricsPort),
-			Handler: metricsMux,
+			Addr:              fmt.Sprintf(":%d", cfg.MetricsPort),
+			Handler:           metricsMux,
+			ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+			IdleTimeout:       cfg.IdleTimeout,
 		}
 		metricsFailed := make(chan struct{})
 		go func() {


### PR DESCRIPTION
Fixes #1819.

All three `http.Server` instances in `pkg/server/server.go` (connect, metrics, UI) were built with only `Addr` and `Handler`. Nothing limited how long a client could withhold request headers or keep an idle connection open.

- The `idle_timeout` default exceeds common proxy keep-alive timeouts (ALB 60s, nginx 75s). Deployments behind a proxy with a longer keep-alive should raise it, so the proxy never sends a request on a connection the server is already closing.
- No `WriteTimeout` on purpose: the connect server streams long export responses (e.g. `ExportAuditRecords`) that a write deadline would cut off.
- No `ReadTimeout` either; it would need a value that accounts for large request bodies, and the header timeout already covers the slow-client case this issue is about.

## Testing

- `go build ./pkg/server/...` and `go test ./pkg/server/` pass.
- Verified with a throwaway config test that `Load` fills both defaults (`10s` / `180s`) when the fields are absent from the config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)