### PR TITLE
refactor: remove unused new relic instrumentation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,20 +15,13 @@ import (
 
 type Frontier struct {
 	// configuration version
-	Version  int             `yaml:"version" mapstructure:"version"`
-	Log      logger.Config   `yaml:"log" mapstructure:"log"`
-	NewRelic NewRelic        `yaml:"new_relic" mapstructure:"new_relic"`
-	App      server.Config   `yaml:"app" mapstructure:"app"`
-	DB       db.Config       `yaml:"db" mapstructure:"db"`
-	UI       server.UIConfig `yaml:"ui" mapstructure:"ui"`
-	SpiceDB  spicedb.Config  `yaml:"spicedb" mapstructure:"spicedb"`
-	Billing  billing.Config  `yaml:"billing" mapstructure:"billing"`
-}
-
-type NewRelic struct {
-	AppName string `yaml:"app_name" mapstructure:"app_name"`
-	License string `yaml:"license" mapstructure:"license"`
-	Enabled bool   `yaml:"enabled" mapstructure:"enabled"`
+	Version int             `yaml:"version" mapstructure:"version"`
+	Log     logger.Config   `yaml:"log" mapstructure:"log"`
+	App     server.Config   `yaml:"app" mapstructure:"app"`
+	DB      db.Config       `yaml:"db" mapstructure:"db"`
+	UI      server.UIConfig `yaml:"ui" mapstructure:"ui"`
+	SpiceDB spicedb.Config  `yaml:"spicedb" mapstructure:"spicedb"`
+	Billing billing.Config  `yaml:"billing" mapstructure:"billing"`
 }
 
 func Load(serverConfigFileFromFlag string) (*Frontier, error) {

--- a/config/sample.config.yaml
+++ b/config/sample.config.yaml
@@ -10,14 +10,6 @@ log:
   # e.g. ["app.user.created", "app.permission.checked"]
   ignored_audit_events: []
 
-new_relic:
-  # enable new relic for tracing and metrics
-  enabled: false
-  # name of the application in new relic
-  app_name: "Frontier"
-  # license key for new relic
-  license: "NEWRELIC_LICENSE_KEY"
-
 # Admin UI configuration
 ui:
   # port to serve the UI

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mocktools/go-smtp-mock/v2 v2.1.0
-	github.com/newrelic/go-agent v3.20.2+incompatible
 	github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/ory/dockertest/v3 v3.10.0

--- a/go.sum
+++ b/go.sum
@@ -1721,8 +1721,6 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/newrelic/go-agent v3.20.2+incompatible h1:kO1pT79OwgW3KqJzEDUWgg8eam41FKjewMs8mqSRLJk=
-github.com/newrelic/go-agent v3.20.2+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79 h1:Dmx8g2747UTVPzSkmohk84S3g/uWqd6+f4SSLPhLcfA=
 github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79/go.mod h1:E26fwEtRNigBfFfHDWsklmo0T7Ixbg0XXgck+Hq4O9k=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/internal/store/postgres/organization_repository.go
+++ b/internal/store/postgres/organization_repository.go
@@ -84,8 +84,6 @@ func (r OrganizationRepository) GetByIDs(ctx context.Context, ids []string) ([]o
 	}
 
 	var orgs []Organization
-	// TODO(kushsharma): clean up this unnecessary newrelic blot over each query
-	// abstract it over database using a facade
 	if err = r.dbc.WithTimeout(ctx, TABLE_ORGANIZATIONS, "GetByIDs", func(ctx context.Context) error {
 		return r.dbc.SelectContext(ctx, &orgs, query, params...)
 	}); err != nil {

--- a/internal/store/spicedb/relation_repository.go
+++ b/internal/store/spicedb/relation_repository.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"sync/atomic"
 
 	authzedpb "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	newrelic "github.com/newrelic/go-agent" //nolint:staticcheck
 	"github.com/raystack/frontier/core/relation"
 )
 
@@ -48,8 +46,6 @@ const (
 	ConsistencyLevelMinimizeLatency ConsistencyLevel = "minimize_latency"
 )
 
-const nrProductName = "spicedb"
-
 func NewRelationRepository(spiceDB *SpiceDB, consistency ConsistencyLevel, tracing bool) *RelationRepository {
 	return &RelationRepository{
 		spiceDB:     spiceDB,
@@ -82,21 +78,6 @@ func (r *RelationRepository) Add(ctx context.Context, rel relation.Relation) err
 		},
 	}
 
-	nrCtx := newrelic.FromContext(ctx)
-	if nrCtx != nil {
-		nr := newrelic.DatastoreSegment{
-			Product: nrProductName,
-			QueryParameters: map[string]any{
-				"relation":          rel.Subject.SubRelationName,
-				"subject_namespace": rel.Subject.Namespace,
-				"object_namespace":  rel.Object.Namespace,
-			},
-			Operation: "Upsert_Relation",
-			StartTime: nrCtx.StartSegmentNow(),
-		}
-		defer nr.End() // nolint
-	}
-
 	resp, err := r.spiceDB.client.WriteRelationships(ctx, request)
 	if err != nil {
 		return err
@@ -122,17 +103,6 @@ func (r *RelationRepository) Check(ctx context.Context, rel relation.Relation) (
 		},
 		Permission:  rel.RelationName,
 		WithTracing: r.tracing,
-	}
-
-	nrCtx := newrelic.FromContext(ctx)
-	if nrCtx != nil {
-		nr := newrelic.DatastoreSegment{
-			Product:    nrProductName,
-			Collection: fmt.Sprintf("object:%s::subject:%s", request.GetResource().GetObjectType(), request.GetSubject().GetObject().GetObjectType()),
-			Operation:  "Check",
-			StartTime:  nrCtx.StartSegmentNow(),
-		}
-		defer nr.End() // nolint
 	}
 
 	response, err := r.spiceDB.client.CheckPermission(ctx, request)
@@ -167,20 +137,6 @@ func (r *RelationRepository) Delete(ctx context.Context, rel relation.Relation) 
 		},
 	}
 
-	nrCtx := newrelic.FromContext(ctx)
-	if nrCtx != nil {
-		nr := newrelic.DatastoreSegment{
-			Product: nrProductName,
-			QueryParameters: map[string]any{
-				"relation":          rel.Subject.SubRelationName,
-				"subject_namespace": rel.Subject.Namespace,
-				"object_namespace":  rel.Object.Namespace,
-			},
-			Operation: "Delete_Relation",
-			StartTime: nrCtx.StartSegmentNow(),
-		}
-		defer nr.End() // nolint
-	}
 	resp, err := r.spiceDB.client.DeleteRelationships(ctx, request)
 	if err != nil {
 		return err

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/raystack/frontier/internal/metrics"
 
-	newrelic "github.com/newrelic/go-agent" //nolint:staticcheck
-
 	"github.com/jmoiron/sqlx"
 )
 
@@ -45,18 +43,6 @@ func New(cfg Config) (*Client, error) {
 }
 
 func (c Client) WithTimeout(ctx context.Context, collection, operation string, op func(ctx context.Context) error) (err error) {
-	nrCtx := newrelic.FromContext(ctx)
-	if nrCtx != nil {
-		nr := newrelic.DatastoreSegment{
-			Product:    newrelic.DatastorePostgres,
-			Collection: collection,
-			Operation:  operation,
-			StartTime:  nrCtx.StartSegmentNow(),
-		}
-		defer func() {
-			_ = nr.End()
-		}()
-	}
 	if metrics.DatabaseQueryLatency != nil {
 		promCollect := metrics.DatabaseQueryLatency(collection, operation)
 		defer promCollect()


### PR DESCRIPTION
## Summary

Removes the New Relic go-agent v2 dependency and all its call sites. This was dead code: the agent was never initialized — nothing reads the `new_relic` config and nothing starts a New Relic transaction — so `newrelic.FromContext` always returned nil and the segment blocks never ran. Query latency is already recorded by the Prometheus histograms in the same code paths.

Tracing will be added with OpenTelemetry instead; it is not wired up yet and is tracked separately in #1875.

Closes #1783. Part of #1782.

## Changes

- `pkg/db/db.go`: drop the datastore segment in `WithTimeout`
- `internal/store/spicedb/relation_repository.go`: drop the segments in `Add`, `Check`, and `Delete`
- `config/config.go`: drop the unused `new_relic` config block
- `config/sample.config.yaml`: drop the sample entry
- `go.mod` / `go.sum`: drop `github.com/newrelic/go-agent`

## Technical Details

Config files that still contain a `new_relic:` block keep loading; the loader ignores unknown keys.

## Test Plan

- [x] Manual testing completed
- [x] Build and type checking passes

`go build ./...`, `golangci-lint run` on the touched packages, and `go test ./pkg/db/... ./config/...` pass. Verified a config file containing the old `new_relic:` block still loads.

## SQL Safety (if your PR touches `*_repository.go` or `goqu.*`)
- [x] Values flow through `?` placeholders, `goqu.Ex{}`, or `goqu.Record{}` — never `fmt.Sprintf` or `+` building a query that gets executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)