### PR TITLE
feat(sdk): guard the delete organization flow

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.71.2(react@19.2.4))
       '@raystack/proton':
-        specifier: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839
-        version: 0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-194685ed0280d282261bc16f708266465dd1deb1
+        version: 0.1.0-194685ed0280d282261bc16f708266465dd1deb1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -1587,16 +1587,16 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e':
-    resolution: {integrity: sha512-82QvGoJjcp5zGt/QIkdSJEn2iX8vn/g2H4jm8O3QH3YIZuZp0bXFXo+ddD5S49tSUtWiegi7qWJargHgBceLPg==}
+  '@raystack/proton@0.1.0-194685ed0280d282261bc16f708266465dd1deb1':
+    resolution: {integrity: sha512-e1u+Tky38WpufUe9JO4KzIdJ49BbQDOFMayL5UiS/KPnvWR0xVgFleECbQ/xGqiwisTERYMXqjUbKvfpfyctgw==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
       '@tanstack/react-query':
         optional: true
 
-  '@raystack/proton@0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839':
-    resolution: {integrity: sha512-YCzbMMyYaf5naOZdHYe01x5Ln0FFmABWwHDD3Oi6ANtQIZn1UmNsl8s3zcuhJ7dgQfGT87rFDeRBLm1ihxL2QQ==}
+  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e':
+    resolution: {integrity: sha512-82QvGoJjcp5zGt/QIkdSJEn2iX8vn/g2H4jm8O3QH3YIZuZp0bXFXo+ddD5S49tSUtWiegi7qWJargHgBceLPg==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -2224,6 +2224,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2584,6 +2585,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
@@ -6309,6 +6311,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -8073,7 +8076,7 @@ snapshots:
       - '@date-fns/tz'
       - date-fns
 
-  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-194685ed0280d282261bc16f708266465dd1deb1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)
@@ -8087,7 +8090,7 @@ snapshots:
       - react
       - react-dom
 
-  '@raystack/proton@0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-859ba765e6cfd44736ddcf42664b742fe7fd916e(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.71.2(react@19.2.4))
       '@raystack/proton':
-        specifier: 0.1.0-194685ed0280d282261bc16f708266465dd1deb1
-        version: 0.1.0-194685ed0280d282261bc16f708266465dd1deb1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.1.0-092b26eddcae87e16504380cf8333f22eb56591b
+        version: 0.1.0-092b26eddcae87e16504380cf8333f22eb56591b(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.21(react@19.2.4)
@@ -1587,8 +1587,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@raystack/proton@0.1.0-194685ed0280d282261bc16f708266465dd1deb1':
-    resolution: {integrity: sha512-e1u+Tky38WpufUe9JO4KzIdJ49BbQDOFMayL5UiS/KPnvWR0xVgFleECbQ/xGqiwisTERYMXqjUbKvfpfyctgw==}
+  '@raystack/proton@0.1.0-092b26eddcae87e16504380cf8333f22eb56591b':
+    resolution: {integrity: sha512-xBq3JcCAkcITCtQWkMms1VH+4VvYwqNupWbBgTrXHIn2bCXizX/noxm3TDH8ZFFRACEj5GkdFMscjKPVaGVHPQ==}
     peerDependencies:
       '@tanstack/react-query': ^5.0.0
     peerDependenciesMeta:
@@ -8076,7 +8076,7 @@ snapshots:
       - '@date-fns/tz'
       - date-fns
 
-  '@raystack/proton@0.1.0-194685ed0280d282261bc16f708266465dd1deb1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@raystack/proton@0.1.0-092b26eddcae87e16504380cf8333f22eb56591b(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)

--- a/web/sdk/client/hooks/useTokens.ts
+++ b/web/sdk/client/hooks/useTokens.ts
@@ -11,7 +11,13 @@ interface UseTokensReturn {
   fetchTokenBalance: () => Promise<any>;
 }
 
-export const useTokens = (): UseTokensReturn => {
+export interface UseTokensOptions {
+  // when false the balance is not fetched; callers that only need the
+  // balance in a rarely-opened surface (like a dialog) gate it on that
+  enabled?: boolean;
+}
+
+export const useTokens = (options: UseTokensOptions = {}): UseTokensReturn => {
   const { billingAccount } = useFrontier();
 
   const {
@@ -25,7 +31,7 @@ export const useTokens = (): UseTokensReturn => {
       id: billingAccount?.id ?? ''
     }),
     {
-      enabled: !!billingAccount?.id,
+      enabled: !!billingAccount?.id && (options.enabled ?? true),
       retry: false
     }
   );

--- a/web/sdk/client/hooks/useTokens.ts
+++ b/web/sdk/client/hooks/useTokens.ts
@@ -8,12 +8,15 @@ import { toastManager } from '@raystack/apsara';
 interface UseTokensReturn {
   tokenBalance: bigint;
   isTokensLoading: boolean;
+  // unlike isTokensLoading, this is also true while an already cached
+  // balance is being refetched
+  isTokensFetching: boolean;
   fetchTokenBalance: () => Promise<any>;
 }
 
 export interface UseTokensOptions {
-  // when false the balance is not fetched; callers that only need the
-  // balance in a rarely-opened surface (like a dialog) gate it on that
+  // Set this to false to skip fetching the balance. The delete dialog uses
+  // it so the balance is only fetched while the dialog is open.
   enabled?: boolean;
 }
 
@@ -23,6 +26,7 @@ export const useTokens = (options: UseTokensOptions = {}): UseTokensReturn => {
   const {
     data,
     isLoading: isTokensLoading,
+    isFetching: isTokensFetching,
     error,
     refetch
   } = useQuery(
@@ -55,6 +59,7 @@ export const useTokens = (options: UseTokensOptions = {}): UseTokensReturn => {
   return {
     tokenBalance,
     isTokensLoading,
+    isTokensFetching,
     fetchTokenBalance: refetch
   };
 };

--- a/web/sdk/client/utils/delete-blockers.ts
+++ b/web/sdk/client/utils/delete-blockers.ts
@@ -14,7 +14,7 @@ const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
       ? `Please pay the ${count} open invoices from the billing page`
       : 'Please pay the open invoice from the billing page',
   NEGATIVE_TOKEN_BALANCE: () =>
-    'The token balance needs to be settled. Our support team will reach out to you'
+    'Your token balance is negative. Please add tokens from the Tokens page to bring it back up, or pay the invoice when it arrives, and then you can delete'
 };
 
 // Shown when the server reports a blocker kind this version does not know,

--- a/web/sdk/client/utils/delete-blockers.ts
+++ b/web/sdk/client/utils/delete-blockers.ts
@@ -1,0 +1,82 @@
+import { ConnectError } from '@connectrpc/connect';
+
+// The server reports why an organization cannot be deleted as a list of
+// blockers, each with a machine-readable type. These are the types the
+// server knows today, mapped to a short instruction the user can act on.
+// The wording must stay in line with the server behavior: a paid
+// subscription must be downgraded, unpaid invoices must be paid, and a
+// token debt is settled through support.
+const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
+  ACTIVE_SUBSCRIPTION: () =>
+    'Please downgrade the subscription to the standard plan',
+  UNPAID_INVOICE: count =>
+    count > 1
+      ? `Please pay the ${count} open invoices from the billing page`
+      : 'Please pay the open invoice from the billing page',
+  NEGATIVE_TOKEN_BALANCE: () =>
+    'Please contact support to settle the token balance'
+};
+
+// Shown when the server reports a blocker kind this version does not know,
+// or when the error could not be read at all.
+export const GENERIC_DELETE_BLOCKED_MESSAGE =
+  'Something is blocking the delete right now. Please try again later or contact support.';
+
+// instructionLines turns a list of blockers into one instruction per kind
+// of blocker. Blockers of the same kind are counted so the instruction can
+// say "the 2 open invoices". A kind without a known instruction becomes the
+// generic message, once.
+export function instructionLines(blockers: { type: string }[]): string[] {
+  const counts = new Map<string, number>();
+  for (const blocker of blockers) {
+    counts.set(blocker.type, (counts.get(blocker.type) ?? 0) + 1);
+  }
+  const lines: string[] = [];
+  let hasUnknown = false;
+  for (const [type, count] of counts) {
+    const instruction = BLOCKER_INSTRUCTIONS[type];
+    if (instruction) {
+      lines.push(instruction(count));
+    } else {
+      hasUnknown = true;
+    }
+  }
+  if (hasUnknown) {
+    lines.push(GENERIC_DELETE_BLOCKED_MESSAGE);
+  }
+  return lines;
+}
+
+// deleteBlockedDescription reads the blockers out of a failed_precondition
+// error from DeleteOrganization and returns the instructions as one string.
+// The server attaches them as a google.rpc.PreconditionFailure detail; over
+// the Connect JSON protocol that detail arrives with a ready-made JSON copy
+// in its debug field. When the error carries nothing readable, the generic
+// message is returned, so the raw server text is never shown.
+export function deleteBlockedDescription(err: ConnectError): string {
+  for (const detail of err.details) {
+    if (!('type' in detail) || detail.type !== 'google.rpc.PreconditionFailure') {
+      continue;
+    }
+    const debug = (detail as { debug?: unknown }).debug;
+    if (typeof debug !== 'object' || debug === null) {
+      continue;
+    }
+    const violations = (debug as { violations?: unknown }).violations;
+    if (!Array.isArray(violations)) {
+      continue;
+    }
+    const blockers = violations
+      .filter(
+        (violation): violation is { type: string } =>
+          typeof violation === 'object' &&
+          violation !== null &&
+          typeof (violation as { type?: unknown }).type === 'string'
+      );
+    const lines = instructionLines(blockers);
+    if (lines.length > 0) {
+      return lines.join('. ');
+    }
+  }
+  return GENERIC_DELETE_BLOCKED_MESSAGE;
+}

--- a/web/sdk/client/utils/delete-blockers.ts
+++ b/web/sdk/client/utils/delete-blockers.ts
@@ -14,7 +14,7 @@ const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
       ? `Please pay the ${count} open invoices from the billing page`
       : 'Please pay the open invoice from the billing page',
   NEGATIVE_TOKEN_BALANCE: () =>
-    'Please contact support to settle the token balance'
+    'The token balance needs to be settled. Our support team will reach out to you'
 };
 
 // Shown when the server reports a blocker kind this version does not know,

--- a/web/sdk/client/utils/invoice-queries.ts
+++ b/web/sdk/client/utils/invoice-queries.ts
@@ -1,0 +1,23 @@
+import { create } from '@bufbuild/protobuf';
+import { RQLFilterSchema } from '@raystack/proton/frontier';
+import { INVOICE_STATES } from './constants';
+
+// The one definition of "an invoice the customer still has to pay": open
+// state with a non-zero amount. The server refuses an organization delete
+// while any exist, and the billing page's payment-issue banner keys off the
+// same set — both build their queries from these filters so the two can not
+// drift apart.
+export function openInvoiceFilters() {
+  return [
+    create(RQLFilterSchema, {
+      name: 'state',
+      operator: 'eq',
+      value: { case: 'stringValue', value: INVOICE_STATES.OPEN }
+    }),
+    create(RQLFilterSchema, {
+      name: 'amount',
+      operator: 'gt',
+      value: { case: 'numberValue', value: 0 }
+    })
+  ];
+}

--- a/web/sdk/client/utils/invoice-queries.ts
+++ b/web/sdk/client/utils/invoice-queries.ts
@@ -2,11 +2,9 @@ import { create } from '@bufbuild/protobuf';
 import { RQLFilterSchema } from '@raystack/proton/frontier';
 import { INVOICE_STATES } from './constants';
 
-// The one definition of "an invoice the customer still has to pay": open
-// state with a non-zero amount. The server refuses an organization delete
-// while any exist, and the billing page's payment-issue banner keys off the
-// same set — both build their queries from these filters so the two can not
-// drift apart.
+// An invoice the customer still has to pay: open state with a non-zero
+// amount. This is defined once here so every caller means the same thing
+// by it.
 export function openInvoiceFilters() {
   return [
     create(RQLFilterSchema, {

--- a/web/sdk/client/views/billing/components/payment-issue.tsx
+++ b/web/sdk/client/views/billing/components/payment-issue.tsx
@@ -6,11 +6,11 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import {
   Subscription,
   RQLRequestSchema,
-  RQLFilterSchema,
   RQLSortSchema
 } from '@raystack/proton/frontier';
 import { create } from '@bufbuild/protobuf';
 import { INVOICE_STATES, SUBSCRIPTION_STATES } from '../../../utils/constants';
+import { openInvoiceFilters } from '../../../utils/invoice-queries';
 import { DEFAULT_PAGE_SIZE } from '../../../utils/connect-pagination';
 import { useOrganizationInvoices } from '../../../hooks/useOrganizationInvoices';
 import styles from '../billing-view.module.css';
@@ -18,18 +18,7 @@ import styles from '../billing-view.module.css';
 // Open invoices with a non-zero amount, newest first — the invoice that needs
 // payment when a subscription is past due.
 const OPEN_INVOICES_QUERY = create(RQLRequestSchema, {
-  filters: [
-    create(RQLFilterSchema, {
-      name: 'state',
-      operator: 'eq',
-      value: { case: 'stringValue', value: INVOICE_STATES.OPEN }
-    }),
-    create(RQLFilterSchema, {
-      name: 'amount',
-      operator: 'gt',
-      value: { case: 'numberValue', value: 0 }
-    })
-  ],
+  filters: openInvoiceFilters(),
   sort: [create(RQLSortSchema, { name: 'created_at', order: 'desc' })],
   offset: 0,
   limit: DEFAULT_PAGE_SIZE

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -45,9 +45,10 @@ export const DeleteOrganizationDialog = ({
   const orgLabel = t.organization({ case: 'capital' });
   const orgLabelLower = t.organization({ case: 'lower' });
   const [isAcknowledged, setIsAcknowledged] = useState(false);
-  // fetched only while the dialog is open; the confirm button waits for the
-  // answer so the forfeit warning cannot be skipped by a slow response
-  const { tokenBalance, isTokensLoading } = useTokens({ enabled: open });
+  // The balance is fetched only while the dialog is open. The confirm
+  // button below stays disabled until the fetch finishes, so the user
+  // cannot confirm before the token warning had a chance to appear.
+  const { tokenBalance, isTokensFetching } = useTokens({ enabled: open });
 
   const { mutateAsync: deleteOrganization } = useMutation(
     FrontierServiceQueries.deleteOrganization
@@ -163,7 +164,7 @@ export const DeleteOrganizationDialog = ({
                 !deleteTitle ||
                 !isAcknowledged ||
                 isSubmitting ||
-                isTokensLoading
+                isTokensFetching
               }
               data-test-id="frontier-sdk-delete-organization-btn"
               loading={isSubmitting}

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -113,10 +113,9 @@ export const DeleteOrganizationDialog = ({
               </Text>
               {tokenBalance > 0 ? (
                 <Text size="small" variant="danger">
-                  You have {tokenBalance.toString()} tokens remaining. Deleting
-                  the {orgLabelLower} forfeits them. Please contact support
-                  about these tokens: any amount that was purchased can be
-                  transferred to your bank account.
+                  This {orgLabelLower} still has unused tokens, and deleting
+                  it forfeits them. If any of them were purchased, our
+                  support team will reach out to you to settle them.
                 </Text>
               ) : null}
               <Field

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -110,8 +110,8 @@ export const DeleteOrganizationDialog = ({
               {tokenBalance > 0 ? (
                 <Text size="small" variant="danger">
                   You have {tokenBalance.toString()} tokens remaining. Deleting
-                  the {orgLabelLower} forfeits them. Contact support about
-                  these tokens: any amount that was purchased can be
+                  the {orgLabelLower} forfeits them. Please contact support
+                  about these tokens: any amount that was purchased can be
                   transferred to your bank account.
                 </Text>
               ) : null}

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -21,6 +21,7 @@ import {
 import { useFrontier } from '../../../contexts/FrontierContext';
 import { useTerminology } from '../../../hooks/useTerminology';
 import { useTokens } from '../../../hooks/useTokens';
+import { deleteBlockedDescription } from '../../../utils/delete-blockers';
 import { handleConnectError } from '~/utils/error';
 
 const deleteOrgSchema = yup
@@ -88,9 +89,11 @@ export const DeleteOrganizationDialog = ({
     } catch (error) {
       handleConnectError(error, {
         PermissionDenied: () => toastManager.add({ title: "You don't have permission to perform this action", type: 'error' }),
-        FailedPrecondition: (err) => toastManager.add({ title: `Cannot delete this ${orgLabelLower} yet`, description: err.message, type: 'error' }),
-        NotFound: (err) => toastManager.add({ title: 'Not found', description: err.message, type: 'error' }),
-        Default: (err) => toastManager.add({ title: 'Something went wrong', description: err.message, type: 'error' }),
+        // the server names what blocks the delete; show the matching
+        // instructions instead of the raw server text
+        FailedPrecondition: (err) => toastManager.add({ title: `Cannot delete this ${orgLabelLower} yet`, description: deleteBlockedDescription(err), type: 'error' }),
+        NotFound: () => toastManager.add({ title: 'Not found', description: `This ${orgLabelLower} no longer exists.`, type: 'error' }),
+        Default: () => toastManager.add({ title: 'Something went wrong', description: 'Please try again later or contact support.', type: 'error' }),
       });
     }
   }

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -20,6 +20,7 @@ import {
 } from '@raystack/apsara';
 import { useFrontier } from '../../../contexts/FrontierContext';
 import { useTerminology } from '../../../hooks/useTerminology';
+import { useTokens } from '../../../hooks/useTokens';
 import { handleConnectError } from '~/utils/error';
 
 const deleteOrgSchema = yup
@@ -44,6 +45,7 @@ export const DeleteOrganizationDialog = ({
   const orgLabel = t.organization({ case: 'capital' });
   const orgLabelLower = t.organization({ case: 'lower' });
   const [isAcknowledged, setIsAcknowledged] = useState(false);
+  const { tokenBalance } = useTokens();
 
   const { mutateAsync: deleteOrganization } = useMutation(
     FrontierServiceQueries.deleteOrganization
@@ -83,6 +85,7 @@ export const DeleteOrganizationDialog = ({
     } catch (error) {
       handleConnectError(error, {
         PermissionDenied: () => toastManager.add({ title: "You don't have permission to perform this action", type: 'error' }),
+        FailedPrecondition: (err) => toastManager.add({ title: `Cannot delete this ${orgLabelLower} yet`, description: err.rawMessage, type: 'error' }),
         NotFound: (err) => toastManager.add({ title: 'Not found', description: err.message, type: 'error' }),
         Default: (err) => toastManager.add({ title: 'Something went wrong', description: err.message, type: 'error' }),
       });
@@ -102,6 +105,13 @@ export const DeleteOrganizationDialog = ({
                 This action can not be undone. This will permanently
                 delete all the projects and resources in {organization?.title}.
               </Text>
+              {tokenBalance > 0 ? (
+                <Text size="small" variant="danger">
+                  You have {tokenBalance.toString()} tokens remaining. Deleting
+                  the {orgLabelLower} forfeits them. Contact support to get the
+                  amount transferred to your bank account.
+                </Text>
+              ) : null}
               <Field
                 label={`Please type name of the ${orgLabel} to confirm.`}
                 error={
@@ -146,7 +156,7 @@ export const DeleteOrganizationDialog = ({
               variant="solid"
               color="danger"
               type="submit"
-              disabled={!deleteTitle || !isAcknowledged}
+              disabled={!deleteTitle || !isAcknowledged || isSubmitting}
               data-test-id="frontier-sdk-delete-organization-btn"
               loading={isSubmitting}
               loaderText="Deleting..."

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -45,7 +45,9 @@ export const DeleteOrganizationDialog = ({
   const orgLabel = t.organization({ case: 'capital' });
   const orgLabelLower = t.organization({ case: 'lower' });
   const [isAcknowledged, setIsAcknowledged] = useState(false);
-  const { tokenBalance } = useTokens();
+  // fetched only while the dialog is open; the confirm button waits for the
+  // answer so the forfeit warning cannot be skipped by a slow response
+  const { tokenBalance, isTokensLoading } = useTokens({ enabled: open });
 
   const { mutateAsync: deleteOrganization } = useMutation(
     FrontierServiceQueries.deleteOrganization
@@ -85,7 +87,7 @@ export const DeleteOrganizationDialog = ({
     } catch (error) {
       handleConnectError(error, {
         PermissionDenied: () => toastManager.add({ title: "You don't have permission to perform this action", type: 'error' }),
-        FailedPrecondition: (err) => toastManager.add({ title: `Cannot delete this ${orgLabelLower} yet`, description: err.rawMessage, type: 'error' }),
+        FailedPrecondition: (err) => toastManager.add({ title: `Cannot delete this ${orgLabelLower} yet`, description: err.message, type: 'error' }),
         NotFound: (err) => toastManager.add({ title: 'Not found', description: err.message, type: 'error' }),
         Default: (err) => toastManager.add({ title: 'Something went wrong', description: err.message, type: 'error' }),
       });
@@ -108,8 +110,9 @@ export const DeleteOrganizationDialog = ({
               {tokenBalance > 0 ? (
                 <Text size="small" variant="danger">
                   You have {tokenBalance.toString()} tokens remaining. Deleting
-                  the {orgLabelLower} forfeits them. Contact support to get the
-                  amount transferred to your bank account.
+                  the {orgLabelLower} forfeits them. Contact support about
+                  these tokens: any amount that was purchased can be
+                  transferred to your bank account.
                 </Text>
               ) : null}
               <Field
@@ -156,7 +159,12 @@ export const DeleteOrganizationDialog = ({
               variant="solid"
               color="danger"
               type="submit"
-              disabled={!deleteTitle || !isAcknowledged || isSubmitting}
+              disabled={
+                !deleteTitle ||
+                !isAcknowledged ||
+                isSubmitting ||
+                isTokensLoading
+              }
               data-test-id="frontier-sdk-delete-organization-btn"
               loading={isSubmitting}
               loaderText="Deleting..."

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -112,10 +112,10 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
 
   const isLoading = !organization?.id || isActiveOrganizationLoading || isPermissionsFetching;
 
-  // the server's own answer to "would a delete go through right now" — the
-  // same blockers a real delete would refuse with. While it loads the button
-  // stays disabled rather than briefly allowing a delete the server would
-  // refuse; a failed check fails open since the server refuses independently
+  // Ask the server whether a delete would go through right now. While the
+  // answer is loading, the delete button stays disabled. If this check
+  // itself fails, the button stays enabled: the server still refuses a
+  // blocked delete when the user actually clicks.
   const { data: deleteCheck, isLoading: isDeleteCheckLoading } = useQuery(
     FrontierServiceQueries.checkOrganizationDelete,
     create(CheckOrganizationDeleteRequestSchema, {

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -30,6 +30,7 @@ import {
 import { useFrontier } from '../../contexts/FrontierContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useTerminology } from '../../hooks/useTerminology';
+import { instructionLines } from '../../utils/delete-blockers';
 import { PERMISSIONS, shouldShowComponent } from '../../../utils';
 import { AuthTooltipMessage } from '../../utils';
 import { ViewContainer } from '../../components/view-container';
@@ -48,19 +49,6 @@ const generalSchema = yup
   .required();
 
 type FormData = yup.InferType<typeof generalSchema>;
-
-// One short instruction per kind of delete blocker the server can report.
-// An unknown kind falls back to the server's own message.
-const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
-  ACTIVE_SUBSCRIPTION: () =>
-    'Please downgrade the subscription to the standard plan',
-  UNPAID_INVOICE: count =>
-    count > 1
-      ? `Please pay the ${count} open invoices from the billing page`
-      : 'Please pay the open invoice from the billing page',
-  NEGATIVE_TOKEN_BALANCE: () =>
-    'Please contact support to settle the token balance'
-};
 
 export interface GeneralViewProps {
   onDeleteSuccess?: () => void;
@@ -127,19 +115,10 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
     }
   );
   const isDeleteBlocked = !!deleteCheck && !deleteCheck.canDelete;
-  const blockerLines = useMemo(() => {
-    const blockers = deleteCheck?.blockers ?? [];
-    const counts = new Map<string, number>();
-    for (const blocker of blockers) {
-      counts.set(blocker.type, (counts.get(blocker.type) ?? 0) + 1);
-    }
-    return [...counts.entries()].map(
-      ([type, count]) =>
-        BLOCKER_INSTRUCTIONS[type]?.(count) ??
-        blockers.find(blocker => blocker.type === type)?.message ??
-        type
-    );
-  }, [deleteCheck]);
+  const blockerLines = useMemo(
+    () => instructionLines(deleteCheck?.blockers ?? []),
+    [deleteCheck]
+  );
 
   // Update organization form
   const { mutateAsync: updateOrganization } = useMutation(

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -8,13 +8,14 @@ import { create } from '@bufbuild/protobuf';
 import {
   createConnectQueryKey,
   useMutation,
+  useQuery,
   useTransport
 } from '@connectrpc/connect-query';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   FrontierServiceQueries,
   UpdateOrganizationRequestSchema,
-  RQLRequestSchema
+  CheckOrganizationDeleteRequestSchema
 } from '@raystack/proton/frontier';
 import {
   Button,
@@ -29,8 +30,6 @@ import {
 import { useFrontier } from '../../contexts/FrontierContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useTerminology } from '../../hooks/useTerminology';
-import { useOrganizationInvoices } from '../../hooks/useOrganizationInvoices';
-import { openInvoiceFilters } from '../../utils/invoice-queries';
 import { PERMISSIONS, shouldShowComponent } from '../../../utils';
 import { AuthTooltipMessage } from '../../utils';
 import { ViewContainer } from '../../components/view-container';
@@ -50,14 +49,18 @@ const generalSchema = yup
 
 type FormData = yup.InferType<typeof generalSchema>;
 
-// The server refuses the delete while an unpaid invoice exists, so the
-// delete button greys out and explains why. Only existence matters here,
-// hence one row and no sort.
-const HAS_UNPAID_INVOICES_QUERY = create(RQLRequestSchema, {
-  filters: openInvoiceFilters(),
-  offset: 0,
-  limit: 1
-});
+// One short instruction per kind of delete blocker the server can report.
+// An unknown kind falls back to the server's own message.
+const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
+  ACTIVE_SUBSCRIPTION: () =>
+    'Downgrade the subscription to the standard plan',
+  UNPAID_INVOICE: count =>
+    count > 1
+      ? `Pay the ${count} open invoices from the billing page`
+      : 'Pay the open invoice from the billing page',
+  NEGATIVE_TOKEN_BALANCE: () =>
+    'Contact support to settle the token balance'
+};
 
 export interface GeneralViewProps {
   onDeleteSuccess?: () => void;
@@ -109,14 +112,34 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
 
   const isLoading = !organization?.id || isActiveOrganizationLoading || isPermissionsFetching;
 
-  const { invoices, isLoading: isInvoicesLoading } = useOrganizationInvoices({
-    query: HAS_UNPAID_INVOICES_QUERY,
-    enabled: canDeleteWorkspace && !!organization?.id
-  });
-  // the query already filters to unpaid invoices; while the answer is still
-  // loading the button stays disabled rather than briefly allowing a delete
-  // the server would refuse
-  const hasUnpaidInvoices = invoices.length > 0;
+  // the server's own answer to "would a delete go through right now" — the
+  // same blockers a real delete would refuse with. While it loads the button
+  // stays disabled rather than briefly allowing a delete the server would
+  // refuse; a failed check fails open since the server refuses independently
+  const { data: deleteCheck, isLoading: isDeleteCheckLoading } = useQuery(
+    FrontierServiceQueries.checkOrganizationDelete,
+    create(CheckOrganizationDeleteRequestSchema, {
+      id: organization?.id ?? ''
+    }),
+    {
+      enabled: canDeleteWorkspace && !!organization?.id,
+      retry: false
+    }
+  );
+  const isDeleteBlocked = !!deleteCheck && !deleteCheck.canDelete;
+  const blockerLines = useMemo(() => {
+    const blockers = deleteCheck?.blockers ?? [];
+    const counts = new Map<string, number>();
+    for (const blocker of blockers) {
+      counts.set(blocker.type, (counts.get(blocker.type) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(
+      ([type, count]) =>
+        BLOCKER_INSTRUCTIONS[type]?.(count) ??
+        blockers.find(blocker => blocker.type === type)?.message ??
+        type
+    );
+  }, [deleteCheck]);
 
   // Update organization form
   const { mutateAsync: updateOrganization } = useMutation(
@@ -301,7 +324,7 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
                 </Text>
                 <Tooltip>
                   <Tooltip.Trigger
-                    disabled={canDeleteWorkspace && !hasUnpaidInvoices}
+                    disabled={canDeleteWorkspace && !isDeleteBlocked}
                     render={<span className={styles.fitContent} />}
                   >
                     <Button
@@ -310,8 +333,8 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
                       onClick={() => setShowDeleteDialog(true)}
                       disabled={
                         !canDeleteWorkspace ||
-                        hasUnpaidInvoices ||
-                        isInvoicesLoading
+                        isDeleteBlocked ||
+                        isDeleteCheckLoading
                       }
                       data-test-id="frontier-sdk-delete-organization-btn"
                     >
@@ -320,10 +343,13 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
                   </Tooltip.Trigger>
                   {!canDeleteWorkspace ? (
                     <Tooltip.Content>{AuthTooltipMessage}</Tooltip.Content>
-                  ) : hasUnpaidInvoices ? (
+                  ) : isDeleteBlocked ? (
                     <Tooltip.Content>
-                      There are unpaid invoices. Pay them from the billing page
-                      before deleting the {orgLabelLower}.
+                      <Flex direction="column" gap={2}>
+                        {blockerLines.map(line => (
+                          <span key={line}>{line}</span>
+                        ))}
+                      </Flex>
                     </Tooltip.Content>
                   ) : null}
                 </Tooltip>

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -14,9 +14,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
   FrontierServiceQueries,
   UpdateOrganizationRequestSchema,
-  RQLRequestSchema,
-  RQLFilterSchema,
-  RQLSortSchema
+  RQLRequestSchema
 } from '@raystack/proton/frontier';
 import {
   Button,
@@ -32,8 +30,7 @@ import { useFrontier } from '../../contexts/FrontierContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useTerminology } from '../../hooks/useTerminology';
 import { useOrganizationInvoices } from '../../hooks/useOrganizationInvoices';
-import { INVOICE_STATES } from '../../utils/constants';
-import { DEFAULT_PAGE_SIZE } from '../../utils/connect-pagination';
+import { openInvoiceFilters } from '../../utils/invoice-queries';
 import { PERMISSIONS, shouldShowComponent } from '../../../utils';
 import { AuthTooltipMessage } from '../../utils';
 import { ViewContainer } from '../../components/view-container';
@@ -53,24 +50,13 @@ const generalSchema = yup
 
 type FormData = yup.InferType<typeof generalSchema>;
 
-// Open invoices with a non-zero amount. The server refuses the delete while
-// any exist, so the delete button greys out and explains why.
-const OPEN_INVOICES_QUERY = create(RQLRequestSchema, {
-  filters: [
-    create(RQLFilterSchema, {
-      name: 'state',
-      operator: 'eq',
-      value: { case: 'stringValue', value: INVOICE_STATES.OPEN }
-    }),
-    create(RQLFilterSchema, {
-      name: 'amount',
-      operator: 'gt',
-      value: { case: 'numberValue', value: 0 }
-    })
-  ],
-  sort: [create(RQLSortSchema, { name: 'created_at', order: 'desc' })],
+// The server refuses the delete while an unpaid invoice exists, so the
+// delete button greys out and explains why. Only existence matters here,
+// hence one row and no sort.
+const HAS_UNPAID_INVOICES_QUERY = create(RQLRequestSchema, {
+  filters: openInvoiceFilters(),
   offset: 0,
-  limit: DEFAULT_PAGE_SIZE
+  limit: 1
 });
 
 export interface GeneralViewProps {
@@ -123,13 +109,14 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
 
   const isLoading = !organization?.id || isActiveOrganizationLoading || isPermissionsFetching;
 
-  const { invoices } = useOrganizationInvoices({
-    query: OPEN_INVOICES_QUERY,
+  const { invoices, isLoading: isInvoicesLoading } = useOrganizationInvoices({
+    query: HAS_UNPAID_INVOICES_QUERY,
     enabled: canDeleteWorkspace && !!organization?.id
   });
-  const hasUnpaidInvoices = invoices.some(
-    inv => inv.state === INVOICE_STATES.OPEN
-  );
+  // the query already filters to unpaid invoices; while the answer is still
+  // loading the button stays disabled rather than briefly allowing a delete
+  // the server would refuse
+  const hasUnpaidInvoices = invoices.length > 0;
 
   // Update organization form
   const { mutateAsync: updateOrganization } = useMutation(
@@ -321,7 +308,11 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
                       variant="solid"
                       color="danger"
                       onClick={() => setShowDeleteDialog(true)}
-                      disabled={!canDeleteWorkspace || hasUnpaidInvoices}
+                      disabled={
+                        !canDeleteWorkspace ||
+                        hasUnpaidInvoices ||
+                        isInvoicesLoading
+                      }
                       data-test-id="frontier-sdk-delete-organization-btn"
                     >
                       Delete {orgLabelLower}

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -13,7 +13,10 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import {
   FrontierServiceQueries,
-  UpdateOrganizationRequestSchema
+  UpdateOrganizationRequestSchema,
+  RQLRequestSchema,
+  RQLFilterSchema,
+  RQLSortSchema
 } from '@raystack/proton/frontier';
 import {
   Button,
@@ -28,6 +31,9 @@ import {
 import { useFrontier } from '../../contexts/FrontierContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useTerminology } from '../../hooks/useTerminology';
+import { useOrganizationInvoices } from '../../hooks/useOrganizationInvoices';
+import { INVOICE_STATES } from '../../utils/constants';
+import { DEFAULT_PAGE_SIZE } from '../../utils/connect-pagination';
 import { PERMISSIONS, shouldShowComponent } from '../../../utils';
 import { AuthTooltipMessage } from '../../utils';
 import { ViewContainer } from '../../components/view-container';
@@ -46,6 +52,26 @@ const generalSchema = yup
   .required();
 
 type FormData = yup.InferType<typeof generalSchema>;
+
+// Open invoices with a non-zero amount. The server refuses the delete while
+// any exist, so the delete button greys out and explains why.
+const OPEN_INVOICES_QUERY = create(RQLRequestSchema, {
+  filters: [
+    create(RQLFilterSchema, {
+      name: 'state',
+      operator: 'eq',
+      value: { case: 'stringValue', value: INVOICE_STATES.OPEN }
+    }),
+    create(RQLFilterSchema, {
+      name: 'amount',
+      operator: 'gt',
+      value: { case: 'numberValue', value: 0 }
+    })
+  ],
+  sort: [create(RQLSortSchema, { name: 'created_at', order: 'desc' })],
+  offset: 0,
+  limit: DEFAULT_PAGE_SIZE
+});
 
 export interface GeneralViewProps {
   onDeleteSuccess?: () => void;
@@ -96,6 +122,14 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
   }, [permissions, resource]);
 
   const isLoading = !organization?.id || isActiveOrganizationLoading || isPermissionsFetching;
+
+  const { invoices } = useOrganizationInvoices({
+    query: OPEN_INVOICES_QUERY,
+    enabled: canDeleteWorkspace && !!organization?.id
+  });
+  const hasUnpaidInvoices = invoices.some(
+    inv => inv.state === INVOICE_STATES.OPEN
+  );
 
   // Update organization form
   const { mutateAsync: updateOrganization } = useMutation(
@@ -280,22 +314,27 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
                 </Text>
                 <Tooltip>
                   <Tooltip.Trigger
-                    disabled={canDeleteWorkspace}
+                    disabled={canDeleteWorkspace && !hasUnpaidInvoices}
                     render={<span className={styles.fitContent} />}
                   >
                     <Button
                       variant="solid"
                       color="danger"
                       onClick={() => setShowDeleteDialog(true)}
-                      disabled={!canDeleteWorkspace}
+                      disabled={!canDeleteWorkspace || hasUnpaidInvoices}
                       data-test-id="frontier-sdk-delete-organization-btn"
                     >
                       Delete {orgLabelLower}
                     </Button>
                   </Tooltip.Trigger>
-                  {!canDeleteWorkspace && (
+                  {!canDeleteWorkspace ? (
                     <Tooltip.Content>{AuthTooltipMessage}</Tooltip.Content>
-                  )}
+                  ) : hasUnpaidInvoices ? (
+                    <Tooltip.Content>
+                      There are unpaid invoices. Pay them from the billing page
+                      before deleting the {orgLabelLower}.
+                    </Tooltip.Content>
+                  ) : null}
                 </Tooltip>
               </>
             )}

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -53,13 +53,13 @@ type FormData = yup.InferType<typeof generalSchema>;
 // An unknown kind falls back to the server's own message.
 const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
   ACTIVE_SUBSCRIPTION: () =>
-    'Downgrade the subscription to the standard plan',
+    'Please downgrade the subscription to the standard plan',
   UNPAID_INVOICE: count =>
     count > 1
-      ? `Pay the ${count} open invoices from the billing page`
-      : 'Pay the open invoice from the billing page',
+      ? `Please pay the ${count} open invoices from the billing page`
+      : 'Please pay the open invoice from the billing page',
   NEGATIVE_TOKEN_BALANCE: () =>
-    'Contact support to settle the token balance'
+    'Please contact support to settle the token balance'
 };
 
 export interface GeneralViewProps {

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -101,7 +101,7 @@
     "@connectrpc/connect-query": "2.1.1",
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
-    "@raystack/proton": "0.1.0-f0b06e61f1985a9052f32744976a2b73d8c56839",
+    "@raystack/proton": "0.1.0-194685ed0280d282261bc16f708266465dd1deb1",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -101,7 +101,7 @@
     "@connectrpc/connect-query": "2.1.1",
     "@connectrpc/connect-web": "2.1.1",
     "@hookform/resolvers": "^3.10.0",
-    "@raystack/proton": "0.1.0-194685ed0280d282261bc16f708266465dd1deb1",
+    "@raystack/proton": "0.1.0-092b26eddcae87e16504380cf8333f22eb56591b",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.168.3",
     "axios": "^1.9.0",


### PR DESCRIPTION
Part of https://github.com/raystack/frontier/issues/1837 — the client half of the delete pre-flight. The server stack (#1865–#1894) is merged; this PR now contains all the SDK changes in one place.

Guards in the client SDK's General settings view:

- **The delete button asks the server whether a delete would go through.** It calls the new `CheckOrganizationDelete` RPC (shipped in #1894, `@raystack/proton` bumped to the proton main commit that carries it). The button greys out for every blocker the real delete would refuse with — a paid subscription to downgrade, unpaid invoices, a token debt — and the hover tooltip shows one short instruction per kind of blocker ("Downgrade the subscription to the standard plan", "Pay the 2 open invoices from the billing page", "Contact support to settle the token balance"). A blocker kind this version does not know shows one generic line instead — deliberately not the server’s own message, which carries entity ids the UI must not surface. While the check loads the button stays disabled; a failed check fails open, since the server refuses a blocked delete independently.
- **The delete dialog warns about remaining tokens.** The balance is fetched only while the dialog is open, and the confirm button waits for the answer so a slow response cannot skip the warning. The dialog says the organization still has unused tokens, that deleting forfeits them, and that the support team will reach out to settle any that were purchased. It deliberately shows no amounts and promises nothing for complimentary tokens. Confirming the dialog is the user's consent — the server does not block on tokens.
- **Idempotent confirm.** The dialog's delete button disables while the request is in flight, so repeated clicks cannot fire the delete twice. A `failed_precondition` response still surfaces the server's reasons in the error toast for anyone who reaches the server anyway.
- The open-invoice filters used by the billing page's payment-issue banner now live in one shared helper (`client/utils/invoice-queries.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


