### PR TITLE
test(e2e): move billing setup off deprecated UpdateBillingAccountLimits

### DIFF
--- a/test/e2e/regression/billing_test.go
+++ b/test/e2e/regression/billing_test.go
@@ -1200,11 +1200,11 @@ func (s *BillingRegressionTestSuite) TestUsageAPI() {
 		beforeBalance := getBalanceResp.Msg.GetBalance().GetAmount()
 
 		// set limit to -20
-		//nolint:staticcheck
-		_, err = s.testBench.AdminClient.UpdateBillingAccountLimits(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.UpdateBillingAccountLimitsRequest{
+		_, err = s.testBench.AdminClient.UpdateBillingAccountDetails(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.UpdateBillingAccountDetailsRequest{
 			OrgId:     createOrgResp.Msg.GetOrganization().GetId(),
 			Id:        createBillingResp.Msg.GetBillingAccount().GetId(),
 			CreditMin: -20,
+			DueInDays: 0,
 		}))
 		s.Assert().NoError(err)
 
@@ -1262,11 +1262,11 @@ func (s *BillingRegressionTestSuite) TestUsageAPI() {
 		s.Assert().NoError(err)
 
 		// reset limit
-		//nolint:staticcheck
-		_, err = s.testBench.AdminClient.UpdateBillingAccountLimits(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.UpdateBillingAccountLimitsRequest{
+		_, err = s.testBench.AdminClient.UpdateBillingAccountDetails(ctxOrgAdminAuth, connect.NewRequest(&frontierv1beta1.UpdateBillingAccountDetailsRequest{
 			OrgId:     createOrgResp.Msg.GetOrganization().GetId(),
 			Id:        createBillingResp.Msg.GetBillingAccount().GetId(),
 			CreditMin: 0,
+			DueInDays: 0,
 		}))
 		s.Assert().NoError(err)
 	})


### PR DESCRIPTION
## Summary
Move the billing e2e setup off the deprecated UpdateBillingAccountLimits RPC. Part of #1782.

## Changes
- Replace both UpdateBillingAccountLimits calls in test/e2e/regression/billing_test.go with UpdateBillingAccountDetails
- Remove the two //nolint:staticcheck markers

## Technical Details
UpdateBillingAccountDetails sets the same credit_min and also writes due_in_days. The calls pass DueInDays: 0, matching the existing call in TestInvoiceAPI. No callers of the deprecated RPC remain outside generated code.

## Test Plan
- [x] `go test -run 'TestEndToEndBillingRegressionTestSuite/TestUsageAPI' ./test/e2e/regression/` — all 11 steps pass, including step 10 (overdraft) which exercises both changed calls
- [x] Build and type checking passes