### PR TITLE
test(reconcile): guard canonicalJSON number precision with a 2^53 pair

### DIFF
--- a/internal/reconcile/metaschema_test.go
+++ b/internal/reconcile/metaschema_test.go
@@ -129,9 +129,13 @@ func TestCanonicalJSON(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("keeps a real difference in a large integer", func(t *testing.T) {
-		a, err := canonicalJSON(`{"maximum":10000000000000001}`)
+		// 2^53+1 and 2^53 both round to 2^53 under a float64 decode, so this pair
+		// fails without the UseNumber decode and passes with it. A larger pair like
+		// 1e16+1 vs 1e16+2 would round to distinct floats and pass either way, so it
+		// would not guard the fix.
+		a, err := canonicalJSON(`{"maximum":9007199254740993}`)
 		assert.NoError(t, err)
-		b, err := canonicalJSON(`{"maximum":10000000000000002}`)
+		b, err := canonicalJSON(`{"maximum":9007199254740992}`)
 		assert.NoError(t, err)
 		assert.NotEqual(t, a, b)
 	})


### PR DESCRIPTION
## Summary

Fixes the `TestCanonicalJSON` large-integer case so it actually guards the `UseNumber` decode in `canonicalJSON`.

## The problem

The test compared `10000000000000001` and `10000000000000002`. Under the old `float64` decode those round to `10000000000000000` and `10000000000000002`, which already differ, so the test passed even without the fix. Reverting `decodeJSON` to `json.Unmarshal` left the test green, so it caught nothing.

## The fix

Use the `2^53` pair instead: `9007199254740993` and `9007199254740992` both round to `9007199254740992` under `float64`, so they compare equal on the old code. The test now fails without `UseNumber` and passes with it.

## Test Plan

- [x] With `UseNumber` (current code) the test passes.
- [x] Dropping `dec.UseNumber()` makes it fail (both inputs canonicalize to `9007199254740992`).
- [x] Restoring `UseNumber` passes again.
- [x] `go build ./...` and `gofmt` clean.
