### PR TITLE
fix(reconcile): reject unknown top-level fields in desired-state documents

### DIFF
--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -64,6 +64,11 @@ var kindDependencies = map[string][]string{
 // Write `spec: []` to mean that on purpose.
 func parseDocuments(registry map[string]Reconciler, data []byte) ([]parsedDocument, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
+	// Reject unknown top-level keys (a stray "metadata:", a typo'd "apiVarsion")
+	// instead of ignoring them, the same way entry decoding does. The document's
+	// own spec content is decoded separately, so this only guards the outer
+	// apiVersion/kind/spec envelope.
+	dec.KnownFields(true)
 	var docs []parsedDocument
 	for {
 		var doc document

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -123,6 +123,18 @@ func TestRun_SpecHandling(t *testing.T) {
 		assert.ErrorContains(t, err, "field spce not found")
 		assert.Zero(t, rec.called)
 	})
+
+	t.Run("an unknown field in a later document is rejected", func(t *testing.T) {
+		rec := &fakeReconciler{}
+		reg := map[string]Reconciler{KindPlatformUser: rec}
+
+		// The stray key sits in the second document. The check must fire on every
+		// document, not only the first, which is the whole point of checking the file.
+		file := []byte("kind: PlatformUser\nspec: []\n---\nkind: PlatformUser\nspec: []\nspce: oops\n")
+		_, err := Run(context.Background(), reg, file, false)
+		assert.ErrorContains(t, err, "field spce not found")
+		assert.Zero(t, rec.called)
+	})
 }
 
 func TestExport_Errors(t *testing.T) {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -112,6 +112,17 @@ func TestRun_SpecHandling(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, rec.called)
 	})
+
+	t.Run("a document with an unknown top-level field is rejected", func(t *testing.T) {
+		rec := &fakeReconciler{}
+		reg := map[string]Reconciler{KindPlatformUser: rec}
+
+		// A stray top-level key (here a typo of "spec") must fail the file rather
+		// than being ignored, the same way entry decoding rejects unknown fields.
+		_, err := Run(context.Background(), reg, []byte("kind: PlatformUser\nspec: []\nspce: oops\n"), false)
+		assert.ErrorContains(t, err, "field spce not found")
+		assert.Zero(t, rec.called)
+	})
 }
 
 func TestExport_Errors(t *testing.T) {


### PR DESCRIPTION
## What

The reconcile document decoder ignored unknown top-level keys. A stray key (a typo of `spec`, a misplaced `metadata`, a misspelled `apiVersion` that silently falls back to v1) was dropped instead of failing the file.

This adds `KnownFields(true)` to the document decoder, so an unknown top-level key fails the whole file up front, the same way entry decoding already rejects unknown fields. The spec's own content is decoded separately, so only the outer `apiVersion`/`kind`/`spec` envelope is guarded.

## Why

RFC 0001 Rule 3 ("validate before apply") says the whole file is checked first, including that unknown fields are rejected. The document level did not enforce this, so a typo could pass validation and hide a mistake.

## Testing

- New unit test: a document with an unknown top-level field is rejected before any reconciler runs.
- Full `internal/reconcile` package passes.

## Stack

Base of a four-PR stack fixing reconcile-kind findings from the RFC 0001 audit:

1. `fix/reconcile-framework-known-fields` (this PR)
2. `fix/reconcile-permission-spicedb-grammar`
3. `fix/reconcile-billingproduct-r2`
4. `docs/reconcile-platformuser-disabled-out-of-scope`

## Note on casing

Top-level keys are now case-sensitive. `apiversion:` or `KIND:` fail instead of silently defaulting. That is the intended typo-catch, and export always writes the correct casing, so exported files are unaffected.
