### PR TITLE
docs(reconcile): declare disabled users out of scope for the PlatformUser kind

### DIFF
--- a/docs/content/docs/reconcile.mdx
+++ b/docs/content/docs/reconcile.mdx
@@ -85,6 +85,11 @@ Because the file is the full list, `spec: []` removes every platform user. The b
 service account is the exception: it is never removed. Keep `app.admin.bootstrap` configured,
 since that account is the recovery path if a file ever empties the list.
 
+Disabled principals are out of scope. A disabled user does not appear in the platform-user
+listing the reconciler reads, so it cannot see or manage their platform access: a disabled
+admin is not exported, and an empty file does not remove their grant. Do not list a disabled
+principal in the file. Re-enable the user first if you need to reconcile their access.
+
 ## The Permission kind
 
 A permission is an identity: a `service/resource` namespace plus a verb. There is nothing

--- a/docs/content/docs/reconcile.mdx
+++ b/docs/content/docs/reconcile.mdx
@@ -85,10 +85,11 @@ Because the file is the full list, `spec: []` removes every platform user. The b
 service account is the exception: it is never removed. Keep `app.admin.bootstrap` configured,
 since that account is the recovery path if a file ever empties the list.
 
-Disabled principals are out of scope. A disabled user does not appear in the platform-user
+Disabled users are out of scope. A disabled user does not appear in the platform-user
 listing the reconciler reads, so it cannot see or manage their platform access: a disabled
 admin is not exported, and an empty file does not remove their grant. Do not list a disabled
-principal in the file. Re-enable the user first if you need to reconcile their access.
+user in the file. Re-enable them first if you need to reconcile their access. This only
+concerns users. Service users cannot be disabled today, so they are always listed.
 
 ## The Permission kind
 

--- a/internal/reconcile/platformuser_reconciler.go
+++ b/internal/reconcile/platformuser_reconciler.go
@@ -120,6 +120,12 @@ func (r *PlatformUserReconciler) Export(ctx context.Context) (any, error) {
 	return specs, nil
 }
 
+// fetchCurrent lists the platform principals the reconciler manages. Disabled
+// principals are out of scope: ListPlatformUsers resolves users through a store
+// query that filters out disabled accounts, so a disabled admin never appears
+// here. It is therefore neither exported nor removed by an empty file, and a file
+// that lists a disabled principal cannot converge. Re-enable the user to manage
+// their platform access.
 func (r *PlatformUserReconciler) fetchCurrent(ctx context.Context) ([]platformPrincipal, error) {
 	resp, err := r.client.ListPlatformUsers(ctx, authReq(&frontierv1beta1.ListPlatformUsersRequest{}, r.header))
 	if err != nil {

--- a/internal/reconcile/platformuser_reconciler.go
+++ b/internal/reconcile/platformuser_reconciler.go
@@ -121,11 +121,11 @@ func (r *PlatformUserReconciler) Export(ctx context.Context) (any, error) {
 }
 
 // fetchCurrent lists the platform principals the reconciler manages. Disabled
-// principals are out of scope: ListPlatformUsers resolves users through a store
+// users are out of scope: ListPlatformUsers resolves users through a store
 // query that filters out disabled accounts, so a disabled admin never appears
 // here. It is therefore neither exported nor removed by an empty file, and a file
-// that lists a disabled principal cannot converge. Re-enable the user to manage
-// their platform access.
+// that lists a disabled user cannot converge. Re-enable the user to manage their
+// platform access. Service users cannot be disabled today, so they are always listed.
 func (r *PlatformUserReconciler) fetchCurrent(ctx context.Context) ([]platformPrincipal, error) {
 	resp, err := r.client.ListPlatformUsers(ctx, authReq(&frontierv1beta1.ListPlatformUsersRequest{}, r.header))
 	if err != nil {


### PR DESCRIPTION
## What

A disabled user does not appear in the platform-user listing the reconciler reads (the store query filters out disabled accounts), so the reconciler cannot see or manage their platform access. This documents that disabled principals are out of scope, both in the reconcile docs and as a comment on `fetchCurrent`.

No behavior change.

## Why

This makes the existing behavior explicit so operators do not list a disabled principal and expect it to reconcile. A disabled admin is not exported and an empty file does not remove their grant. Re-enable the user first to manage their access.

## Stack

Stacked on `fix/reconcile-billingproduct-r2`.
