### PR TITLE
fix(sdk): scope PAT detail to active org and show a unified not-found page

### DIFF
--- a/web/sdk/client/views/pat/pat-details-view.tsx
+++ b/web/sdk/client/views/pat/pat-details-view.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { ReactNode, useCallback, useEffect, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo } from 'react';
 import {
   DotsHorizontalIcon,
+  LockClosedIcon,
   Pencil1Icon,
   UpdateIcon
 } from '@radix-ui/react-icons';
@@ -11,13 +12,13 @@ import {
   Breadcrumb,
   Button,
   Dialog,
+  EmptyState,
   Flex,
   IconButton,
   Image,
   Menu,
   Skeleton,
   Text,
-  toastManager,
   Tooltip
 } from '@raystack/apsara';
 import deleteIcon from '../../assets/delete.svg';
@@ -108,19 +109,12 @@ export function PATDetailsView({
     create(GetCurrentUserPATRequestSchema, { id: patId }),
     {
       enabled: Boolean(patId),
+      // A bad or unknown id is a definite answer, not a transient failure, so
+      // don't retry: surface the "not found" state immediately.
+      retry: false,
       select: d => d?.pat
     }
   );
-
-  useEffect(() => {
-    if (patError) {
-      toastManager.add({
-        title: 'Something went wrong',
-        description: patError.message,
-        type: 'error'
-      });
-    }
-  }, [patError]);
 
   const { data: orgRolesData, isLoading: isOrgRolesLoading } = useQuery(
     FrontierServiceQueries.listRolesForPAT,
@@ -237,6 +231,49 @@ export function PATDetailsView({
   };
 
   const patTitle = pat?.title || '';
+
+  // getCurrentUserPAT only scopes by the logged-in user, not the org, so a token
+  // from another org the user belongs to can still load here. Treat that, a
+  // missing token, and an invalid id the same way: one generic "not found" that
+  // reveals nothing and blocks opening, editing, regenerating or revoking.
+  const isForeignPat = Boolean(orgId) && pat != null && pat.orgId !== orgId;
+  const showTokenNotFound = Boolean(patError) || isForeignPat;
+
+  if (showTokenNotFound) {
+    return (
+      <ViewContainer>
+        <ViewHeader
+          title=""
+          breadcrumb={
+            <Breadcrumb size="small">
+              <Breadcrumb.Item
+                onClick={() => onNavigateToPats?.()}
+                data-test-id="frontier-sdk-pat-not-found-breadcrumb"
+              >
+                Personal access token
+              </Breadcrumb.Item>
+            </Breadcrumb>
+          }
+        />
+        <EmptyState
+          icon={<LockClosedIcon />}
+          heading="Token not found"
+          subHeading="This personal access token doesn't exist."
+          primaryAction={
+            <Button
+              variant="outline"
+              color="neutral"
+              size="small"
+              onClick={() => onNavigateToPats?.()}
+              data-test-id="frontier-sdk-pat-not-found-back-btn"
+            >
+              Back to personal access tokens
+            </Button>
+          }
+        />
+      </ViewContainer>
+    );
+  }
 
   return (
     <ViewContainer>

--- a/web/sdk/client/views/pat/pat-details-view.tsx
+++ b/web/sdk/client/views/pat/pat-details-view.tsx
@@ -241,10 +241,6 @@ export function PATDetailsView({
 
   const patTitle = pat?.title || '';
 
-  // getCurrentUserPAT only scopes by the logged-in user, not the org, so a token
-  // from another org the user belongs to can still load here. A missing token,
-  // an invalid id, and a foreign token are all shown as a generic "not found"
-  // that reveals nothing. Any other failure is a real error, not a not-found.
   const patErrorCode =
     patError instanceof ConnectError ? patError.code : undefined;
   const isNotFoundError =

--- a/web/sdk/client/views/pat/pat-details-view.tsx
+++ b/web/sdk/client/views/pat/pat-details-view.tsx
@@ -3,6 +3,7 @@
 import { ReactNode, useCallback, useMemo } from 'react';
 import {
   DotsHorizontalIcon,
+  ExclamationTriangleIcon,
   LockClosedIcon,
   Pencil1Icon,
   UpdateIcon
@@ -23,6 +24,7 @@ import {
 } from '@raystack/apsara';
 import deleteIcon from '../../assets/delete.svg';
 import { useQuery } from '@connectrpc/connect-query';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { create } from '@bufbuild/protobuf';
 import {
   FrontierServiceQueries,
@@ -109,9 +111,16 @@ export function PATDetailsView({
     create(GetCurrentUserPATRequestSchema, { id: patId }),
     {
       enabled: Boolean(patId),
-      // A bad or unknown id is a definite answer, not a transient failure, so
-      // don't retry: surface the "not found" state immediately.
-      retry: false,
+      // A missing token or an invalid id is a definite answer, so don't retry
+      // those and surface the result immediately. Other failures may be
+      // transient, so allow a couple of retries before showing an error.
+      retry: (failureCount, error) => {
+        const code = error instanceof ConnectError ? error.code : undefined;
+        if (code === Code.NotFound || code === Code.InvalidArgument) {
+          return false;
+        }
+        return failureCount < 2;
+      },
       select: d => d?.pat
     }
   );
@@ -233,13 +242,18 @@ export function PATDetailsView({
   const patTitle = pat?.title || '';
 
   // getCurrentUserPAT only scopes by the logged-in user, not the org, so a token
-  // from another org the user belongs to can still load here. Treat that, a
-  // missing token, and an invalid id the same way: one generic "not found" that
-  // reveals nothing and blocks opening, editing, regenerating or revoking.
+  // from another org the user belongs to can still load here. A missing token,
+  // an invalid id, and a foreign token are all shown as a generic "not found"
+  // that reveals nothing. Any other failure is a real error, not a not-found.
+  const patErrorCode =
+    patError instanceof ConnectError ? patError.code : undefined;
+  const isNotFoundError =
+    patErrorCode === Code.NotFound || patErrorCode === Code.InvalidArgument;
   const isForeignPat = Boolean(orgId) && pat != null && pat.orgId !== orgId;
-  const showTokenNotFound = Boolean(patError) || isForeignPat;
+  const showTokenNotFound = isForeignPat || isNotFoundError;
+  const hasUnexpectedError = patError != null && !isNotFoundError;
 
-  if (showTokenNotFound) {
+  if (showTokenNotFound || hasUnexpectedError) {
     return (
       <ViewContainer>
         <ViewHeader
@@ -255,22 +269,41 @@ export function PATDetailsView({
             </Breadcrumb>
           }
         />
-        <EmptyState
-          icon={<LockClosedIcon />}
-          heading="Token not found"
-          subHeading="This personal access token doesn't exist."
-          primaryAction={
-            <Button
-              variant="outline"
-              color="neutral"
-              size="small"
-              onClick={() => onNavigateToPats?.()}
-              data-test-id="frontier-sdk-pat-not-found-back-btn"
-            >
-              Back to personal access tokens
-            </Button>
-          }
-        />
+        {showTokenNotFound ? (
+          <EmptyState
+            icon={<LockClosedIcon />}
+            heading="Token not found"
+            subHeading="This personal access token doesn't exist."
+            primaryAction={
+              <Button
+                variant="outline"
+                color="neutral"
+                size="small"
+                onClick={() => onNavigateToPats?.()}
+                data-test-id="frontier-sdk-pat-not-found-back-btn"
+              >
+                Back to personal access tokens
+              </Button>
+            }
+          />
+        ) : (
+          <EmptyState
+            icon={<ExclamationTriangleIcon />}
+            heading="Something went wrong"
+            subHeading="We couldn't load this personal access token. Please try again."
+            primaryAction={
+              <Button
+                variant="outline"
+                color="neutral"
+                size="small"
+                onClick={() => refetchPat()}
+                data-test-id="frontier-sdk-pat-error-retry-btn"
+              >
+                Try again
+              </Button>
+            }
+          />
+        )}
       </ViewContainer>
     );
   }


### PR DESCRIPTION
## Problem

The current-user PAT management flows (get, update, delete, regenerate) scope the token lookup by the logged-in user, not by the org. A user who belongs to more than one org could open, edit, regenerate, or delete a token that belongs to another org just by changing the org in the URL. The token also rendered under any org the user is a member of.

The PAT detail view is where all of this happens. It fetches the token by id and hosts the Update, Regenerate, and Revoke actions.

## Fix

A client-side guard in the PAT detail view. The PAT response already carries its `org_id`, so we compare it with the active org from the route.

- If the token belongs to a different org, or the id is unknown or malformed (NotFound / InvalidArgument), show a generic "Token not found" state with no actions. The same message covers all of these, so it reveals nothing about tokens in other orgs.
- Any other failure (network, server error, and so on) shows a separate "Something went wrong" state with a Try again button. We do not claim the token is missing when the real problem is transient.

Retry is tuned to match. A NotFound or invalid id is a definite answer and is not retried, so the not-found state shows right away. Other failures may be transient, so they are retried a couple of times before the error state appears. Before this, the query used the default retry of 3, which retried even a 404 three times.

No proto or server change is needed. The list view already scopes its search by org.

## Testing

Ran a local sandbox with one user in two orgs, each with a PAT, and checked:

- Token opened in its own org: details render as before.
- Token opened under a different org: "Token not found", no actions.
- Unknown or malformed token id: same "Token not found", shown right away with no retries.
- Server made unreachable: "Something went wrong" with a Try again button, and Try again recovers once the server is back.

## Notes

This is a UI guard. A direct RPC call is still not org-scoped on the server, which is a separate, deeper change.
