### PR TITLE
fix(billing): omit empty product description for Stripe

### DIFF
--- a/billing/product/service.go
+++ b/billing/product/service.go
@@ -81,13 +81,12 @@ func (s *Service) Create(ctx context.Context, product Product) (Product, error) 
 	}
 	product.Name = strings.ToLower(product.Name)
 
-	_, err := s.stripeClient.Products.New(&stripe.ProductParams{
+	providerParams := &stripe.ProductParams{
 		Params: stripe.Params{
 			Context: ctx,
 		},
-		ID:          &product.ProviderID,
-		Name:        &product.Title,
-		Description: &product.Description,
+		ID:   &product.ProviderID,
+		Name: &product.Title,
 		Metadata: map[string]string{
 			"name":          product.Name,
 			"credit_amount": fmt.Sprintf("%d", product.Config.CreditAmount),
@@ -95,7 +94,13 @@ func (s *Service) Create(ctx context.Context, product Product) (Product, error) 
 			"product_id":    product.ID,
 			"managed_by":    "frontier",
 		},
-	})
+	}
+
+	if product.Description != "" {
+		providerParams.Description = &product.Description
+	}
+
+	_, err := s.stripeClient.Products.New(providerParams)
 	if err != nil {
 		return Product{}, fmt.Errorf("failed to create product at billing provider: %w", billingerrors.TranslateStripeError(err))
 	}

--- a/billing/product/service_test.go
+++ b/billing/product/service_test.go
@@ -41,6 +41,51 @@ func TestService_Create(t *testing.T) {
 		setup   func() *product.Service
 	}{
 		{
+			name: "should create product with empty description",
+			args: args{
+				product: product.Product{
+					ID:          "1",
+					Name:        "product1",
+					Description: "",
+				},
+			},
+			want: product.Product{
+				ID:          "1",
+				Name:        "product1",
+				Description: "",
+			},
+			wantErr: false,
+			setup: func() *product.Service {
+				stripeClient, mockStripeBackend, mockProductRepo, mockPriceRepo, mockFeatureRepo := mockService(t)
+				mockProductRepo.EXPECT().Create(ctx, product.Product{
+					ID:          "1",
+					Name:        "product1",
+					Description: "",
+					Behavior:    product.BasicBehavior,
+				}).Return(product.Product{
+					ID:          "1",
+					Name:        "product1",
+					Description: "",
+				}, nil)
+				mockStripeBackend.EXPECT().Call("POST", "/v1/products", "key_123", &stripe.ProductParams{
+					Params: stripe.Params{
+						Context: ctx,
+					},
+					ID:          new(""),
+					Name:        new(""),
+					Description: nil,
+					Metadata: map[string]string{
+						"behavior":      "basic",
+						"credit_amount": "0",
+						"managed_by":    "frontier",
+						"name":          "product1",
+						"product_id":    "1",
+					},
+				}, &stripe.Product{}).Return(nil)
+				return product.NewService(stripeClient, mockProductRepo, mockPriceRepo, mockFeatureRepo)
+			},
+		},
+		{
 			name: "should create product in repo and billing provider with no price and features",
 			args: args{
 				product: product.Product{


### PR DESCRIPTION
## Summary

Fix product creation failing when the product description is empty.

## Changes

- Omit the Stripe `description` parameter when the product description is empty.
- Preserve the existing behavior when a description is provided.
- Add a regression test covering empty product descriptions.

## Test Plan

- `go test ./billing/product`
- Reproduced the issue end-to-end using a Stripe test account.
- Verified that creating a product with an empty description now succeeds.

Closes #1853