### PR TITLE
fix(sdk): skip the header for PAT detail error and not-found states

### DIFF
--- a/web/sdk/client/views/pat/pat-details-view.tsx
+++ b/web/sdk/client/views/pat/pat-details-view.tsx
@@ -252,19 +252,6 @@ export function PATDetailsView({
   if (showTokenNotFound || hasUnexpectedError) {
     return (
       <ViewContainer>
-        <ViewHeader
-          title=""
-          breadcrumb={
-            <Breadcrumb size="small">
-              <Breadcrumb.Item
-                onClick={() => onNavigateToPats?.()}
-                data-test-id="frontier-sdk-pat-not-found-breadcrumb"
-              >
-                Personal access token
-              </Breadcrumb.Item>
-            </Breadcrumb>
-          }
-        />
         {showTokenNotFound ? (
           <EmptyState
             icon={<LockClosedIcon />}


### PR DESCRIPTION
## What

Follow-up to #1895. In the PAT detail view, the error and not-found states rendered the `ViewHeader` (breadcrumb row). This removes it so those states show only the `EmptyState`, which matches how the PAT list view hides its header for its empty state.

## Why

Review feedback on #1895: "ViewHeader should be skipped for error states." That PR was merged before the change landed, so this carries it forward.

## Testing

Loaded a cross-org / invalid token URL in the local client-demo: the not-found state now shows just the empty state (heading, message, and action button) with no breadcrumb header. A valid in-org token still renders the normal detail view with its header.
