### PR TITLE
fix(billing): keep the synced invoice amount up to date

### DIFF
--- a/billing/invoice/service.go
+++ b/billing/invoice/service.go
@@ -363,6 +363,10 @@ func (s *Service) upsert(ctx context.Context, customerID string,
 			existingInvoice.HostedURL = stripeInvoice.HostedInvoiceURL
 			updateNeeded = true
 		}
+		if existingInvoice.Amount != stripeInvoice.Total {
+			existingInvoice.Amount = stripeInvoice.Total
+			updateNeeded = true
+		}
 
 		if updateNeeded {
 			if _, err := s.repository.UpdateByID(ctx, *existingInvoice); err != nil {

--- a/internal/store/postgres/billing_invoice_repository.go
+++ b/internal/store/postgres/billing_invoice_repository.go
@@ -297,6 +297,9 @@ func (r BillingInvoiceRepository) UpdateByID(ctx context.Context, toUpdate invoi
 	if toUpdate.HostedURL != "" {
 		updateRecord["hosted_url"] = toUpdate.HostedURL
 	}
+	// Do not guard this with `!= 0` like the fields above: an invoice can
+	// be credited down to zero, and that zero must be saved.
+	updateRecord["amount"] = toUpdate.Amount
 
 	query, params, err := dialect.Update(TABLE_BILLING_INVOICES).Set(updateRecord).Where(goqu.Ex{
 		"id": toUpdate.ID,


### PR DESCRIPTION
Found through review on #1881 (https://github.com/raystack/frontier/pull/1881#issuecomment-5438416443): the invoice sync's update path only ever wrote `state`, `effective_at`, and `hosted_url` on an existing local row. The amount was frozen at whatever the first sync saw.

Concrete failure: Stripe creates next month's invoice as an empty draft, our sync stores it with amount 0, Stripe fills it with usage to a real total — and the local copy says 0 forever. Everything reading local rows inherits the lie: billing pages show stale totals, and `CheckOrganizationDelete` skips the invoice (its non-zero filter sees 0), so the delete button promises a delete the server then refuses against live provider data.

The fix is the sync writing the total when it changes, plus the repository update actually including the `amount` column. Zero is a real total (a draft whose items were credited away), so it is written unconditionally rather than behind a not-set guard; both `UpdateByID` callers pass full invoice rows.

What this deliberately does not solve: an open invoice fully covered by the customer's credit balance still has a positive total with nothing due, so the delete check can grey the button until the provider marks it paid (minutes, self-clearing, and in the safe direction). Storing `amount_remaining` locally would close that too — filed separately as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

