### PR TITLE
feat(consent): add the user_consents table with immutability triggers

### DIFF
--- a/internal/store/postgres/migrations/20260830100000_create_user_consents.down.sql
+++ b/internal/store/postgres/migrations/20260830100000_create_user_consents.down.sql
@@ -1,0 +1,12 @@
+DROP TRIGGER IF EXISTS trg_user_consents_prevent_delete ON user_consents;
+DROP TRIGGER IF EXISTS trg_user_consents_prevent_update ON user_consents;
+
+DROP FUNCTION IF EXISTS prevent_user_consent_deletes();
+DROP FUNCTION IF EXISTS prevent_user_consent_updates();
+
+DROP INDEX IF EXISTS uq_user_consents_signup;
+
+-- The BEFORE DELETE trigger fires per row and does not block DROP TABLE.
+DROP TABLE IF EXISTS user_consents;
+
+-- uuid_generate_v7() belongs to 20250901054744_create_audits_table and is left in place.

--- a/internal/store/postgres/migrations/20260830100000_create_user_consents.up.sql
+++ b/internal/store/postgres/migrations/20260830100000_create_user_consents.up.sql
@@ -1,0 +1,63 @@
+-- One consent record per consent, listing the documents it covers.
+-- See docs/rfcs/0002-explicit-consent-at-signup.md, "Storage".
+--
+-- There is deliberately no foreign key to users(id). UserRepository.Delete does a hard
+-- DELETE, so ON DELETE CASCADE would drop these records along with the account and
+-- ON DELETE RESTRICT would block account deletion outright. The records have to outlive
+-- the user, which is also why user_email is denormalized onto the row.
+CREATE TABLE user_consents (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    user_id       UUID        NOT NULL, -- no FK to users(id): see above.
+    user_email    TEXT        NOT NULL, -- denormalized so the record survives the user row.
+    documents     JSONB       NOT NULL, -- [{id, title, version, url}, ...], copied from config at write time.
+    source        TEXT        NOT NULL DEFAULT 'signup',
+    auth_strategy TEXT,                 -- the flow's own strategy_name: oidc, mailotp or passkey.
+    ip_address    TEXT,                 -- TEXT and nullable, not INET: it comes from a request header.
+    consented_at  TIMESTAMPTZ NOT NULL, -- when the user accepted, not when the row was written.
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT documents_not_empty CHECK (
+        jsonb_typeof(documents) = 'array' AND jsonb_array_length(documents) > 0
+    )
+);
+
+-- At most one signup consent per user. Nothing repairs a record, so a second signup write
+-- is a bug; this makes it fail rather than leave two rows disagreeing.
+CREATE UNIQUE INDEX uq_user_consents_signup
+    ON user_consents(user_id) WHERE source = 'signup';
+
+-- Immutability, following 20250904105226_add_audit_records_immutability.up.sql. That
+-- migration guards UPDATE only; DELETE is guarded here as well, because a deleted record
+-- leaves a user who looks like they never consented. DROP TABLE is unaffected by a row
+-- level trigger, so the down migration still works.
+CREATE OR REPLACE FUNCTION prevent_user_consent_updates()
+  RETURNS TRIGGER AS $$
+BEGIN
+      RAISE EXCEPTION 'user_consents cannot be updated to maintain consent integrity'
+          USING ERRCODE = '45000',  -- User-defined error (Postgres convention: user-defined error codes are in the 45000-45999 range)
+              DETAIL = 'Consent records are immutable once created';
+END;
+  $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_user_consents_prevent_update
+    BEFORE UPDATE ON user_consents
+    FOR EACH ROW EXECUTE FUNCTION prevent_user_consent_updates();
+
+COMMENT ON TRIGGER trg_user_consents_prevent_update ON user_consents IS
+    'Enforces immutability of consent records by preventing any UPDATE operation.';
+
+CREATE OR REPLACE FUNCTION prevent_user_consent_deletes()
+  RETURNS TRIGGER AS $$
+BEGIN
+      RAISE EXCEPTION 'user_consents cannot be deleted to maintain consent integrity'
+          USING ERRCODE = '45000',  -- User-defined error (Postgres convention: user-defined error codes are in the 45000-45999 range)
+              DETAIL = 'Consent records must outlive the user they describe';
+END;
+  $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_user_consents_prevent_delete
+    BEFORE DELETE ON user_consents
+    FOR EACH ROW EXECUTE FUNCTION prevent_user_consent_deletes();
+
+COMMENT ON TRIGGER trg_user_consents_prevent_delete ON user_consents IS
+    'Enforces immutability of consent records by preventing any DELETE operation.';


### PR DESCRIPTION
Part of [RFC 0002: Explicit consent at signup](https://github.com/raystack/frontier/blob/main/docs/rfcs/0002-explicit-consent-at-signup.md). Based on #1908.

## Summary

Adds the `user_consents` table from the RFC's Storage section. Schema only — there is no repository and no write path here. The repository lands with its caller in the transactional-write PR, so it arrives with something that exercises it rather than as dead code. `audit_records` shipped the same way: the table migration in #1118, the repository in #1124.

A consent record says which documents a user accepted, in what version, when, and from where. It has to be readable years later, it has to survive the user row, and nothing may edit it after the fact — those three requirements are what the rest of this description is about.

## Changes

- `20260830100000_create_user_consents.up.sql` — the table, the `documents_not_empty` CHECK, the partial unique index `uq_user_consents_signup`, and `BEFORE UPDATE` / `BEFORE DELETE` triggers raising `45000`.
- `20260830100000_create_user_consents.down.sql` — drops the triggers, the functions, the index and the table.

`documents` is a JSONB array holding one object per accepted document, copied from config at write time with the same four fields config holds (`id`, `title`, `version`, `url`). The CHECK enforces that it is an array and non-empty, so a consent that covers nothing cannot be stored.

`consented_at` is when the user accepted, taken from the flow, not when the row was written. `created_at` is the write time. They differ by an OIDC round trip, and conflating them would put the post-redirect moment on the record.

## Technical Details

**Four choices that read as mistakes without the RFC.** Each is also commented in the migration, since the schema outlives this PR description.

*No foreign key to `users`.* `UserRepository.Delete` does a hard `DELETE`, so `ON DELETE CASCADE` would drop consent records along with the account and `ON DELETE RESTRICT` would block account deletion outright. Neither is acceptable: the records have to outlive the user. That is also why `user_email` is denormalized onto the row — after the user is gone, the email is the only thing left identifying whose consent it was.

*`ip_address` is `TEXT` and nullable, not `INET`.* The value comes from a request header. A proxy that sends a malformed value, or a deployment that sends none, must not fail a signup over it — `INET` would reject the row and take the account creation down with it. The RFC's Limitations section is explicit that the IP is only as good as the header it comes from.

*Versions and URLs are copies, not references.* A record stays readable after the document leaves config, and stays correct after the version bumps. It also means a `consent_documents` table can be added later with no backfill, since every record already carries its own snapshot. The tradeoff is that a record ties to a version string rather than to the document text — a per-document hash would close that and can be added later.

*The partial unique index* gives a user at most one signup consent. Nothing in the design repairs or rewrites a record, so a second signup write is a bug rather than a legitimate update. The index makes that bug fail loudly instead of leaving two rows that disagree about what the user accepted. It is partial on `source = 'signup'` so a later re-consent, written with a different `source`, is not blocked by it.

**Also deliberate:** there is no `metadata` column. Nothing would write it today, and a re-consent that needs one can add it in its own migration — an unused JSONB column invites unstructured writes that no reader expects.

**Immutability, and why `DELETE` is guarded too.** The triggers follow `20250904105226_add_audit_records_immutability.up.sql`: a `plpgsql` function per operation that does nothing but `RAISE EXCEPTION` with `ERRCODE = '45000'`, a `BEFORE ... FOR EACH ROW` trigger, and a `COMMENT ON TRIGGER` recording intent. That precedent guards `UPDATE` only. `DELETE` is guarded here as well, because the failure modes are not symmetric: a modified record is visibly wrong, whereas a deleted one leaves a user who simply looks like they never consented, which is indistinguishable from a user who never did. The triggers fire per row and so do not block `DROP TABLE`, which is what keeps the down migration working.

**One migration pair, not two.** The `audit_records` precedent is two pairs only because the immutability trigger was an afterthought that arrived days later with the repository. Here the table and its triggers are one design landing at one time, and splitting them would create an intermediate version in which `user_consents` is mutable — a state no deployment should ever be in. `20260218100000_create_user_pats.up.sql` is the closer precedent: table, indexes, function and trigger in a single migration.

`uuid_generate_v7()` is the existing function from `20250901054744_create_audits_table.up.sql`, which runs first. The down migration deliberately leaves it in place rather than dropping something it does not own.

## Test Plan

Verified against Postgres 16 with the repo's own migrate path (`migrations.MigrationFs` through `golang-migrate`), the same code `frontier server migrate` runs.

- [x] `migrate up` from an empty database — clean, lands on `20260830100000`, not dirty.
- [x] `UPDATE` on a stored row → `ERROR: 45000: user_consents cannot be updated to maintain consent integrity`.
- [x] `DELETE` on a stored row → `ERROR: 45000: user_consents cannot be deleted to maintain consent integrity`.
- [x] Second `source = 'signup'` row for the same `user_id` → `23505` on `uq_user_consents_signup`. A row for the same user with a different `source` inserts, confirming the index is partial.
- [x] `documents` as `'[]'` and as a JSON object → both rejected by `documents_not_empty` (`23514`).
- [x] Null `ip_address` and null `auth_strategy` insert fine; the RFC's `documents @> ...` containment query returns the expected row.
- [x] `migrate down` one step with rows present — table, triggers and functions gone, `uuid_generate_v7()` untouched. Confirms the `BEFORE DELETE` trigger does not block `DROP TABLE`.
- [x] Full up / down / up cycle, and a full `Down()` to version 0 followed by a fresh `up`.
- [x] `make lint` — 0 issues.
- [x] `make test` — passes, including `internal/store/postgres`, which boots a Dockerized Postgres and applies every migration.

## SQL Safety

Not applicable — this PR adds two `.sql` migration files and touches no `*_repository.go` and no `goqu.*`. There is no query construction here at all; the repository that will query this table lands in a later PR, where the checklist applies.
