### PR TITLE
fix(sdk): reword the delete organization blocker messages

### DIFF
--- a/web/sdk/client/utils/delete-blockers.test.ts
+++ b/web/sdk/client/utils/delete-blockers.test.ts
@@ -1,0 +1,78 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+import {
+  GENERIC_DELETE_BLOCKED_MESSAGE,
+  deleteBlockedDescription,
+  instructionLines
+} from './delete-blockers';
+
+const wording = { organizationLabel: 'workspace', basePlanTitle: 'Standard Plan' };
+
+describe('instructionLines', () => {
+  it('writes one full sentence per kind of blocker', () => {
+    const lines = instructionLines(
+      [
+        { type: 'ACTIVE_SUBSCRIPTION' },
+        { type: 'UNPAID_INVOICE' },
+        { type: 'NEGATIVE_TOKEN_BALANCE' }
+      ],
+      wording
+    );
+    expect(lines).toEqual([
+      'Downgrade your current subscription and switch to the Standard Plan before deleting this workspace.',
+      'Please pay your outstanding invoice before deleting this workspace.',
+      'Please purchase enough tokens to clear your outstanding token balance before deleting this workspace.'
+    ]);
+  });
+
+  it('counts blockers of the same kind', () => {
+    const lines = instructionLines(
+      [{ type: 'UNPAID_INVOICE' }, { type: 'UNPAID_INVOICE' }],
+      wording
+    );
+    expect(lines).toEqual([
+      'Please pay your 2 outstanding invoices before deleting this workspace.'
+    ]);
+  });
+
+  it('falls back to plain words when the host app set no terminology', () => {
+    const lines = instructionLines([{ type: 'ACTIVE_SUBSCRIPTION' }]);
+    expect(lines).toEqual([
+      'Downgrade your current subscription and switch to the standard plan before deleting this organization.'
+    ]);
+  });
+
+  it('shows the generic message once for unknown kinds', () => {
+    const lines = instructionLines(
+      [{ type: 'SOMETHING_NEW' }, { type: 'SOMETHING_ELSE' }],
+      wording
+    );
+    expect(lines).toEqual([GENERIC_DELETE_BLOCKED_MESSAGE]);
+  });
+});
+
+describe('deleteBlockedDescription', () => {
+  it('reads the blockers out of the precondition failure detail', () => {
+    const err = new ConnectError('blocked', Code.FailedPrecondition);
+    err.details.push({
+      type: 'google.rpc.PreconditionFailure',
+      value: new Uint8Array(),
+      debug: {
+        violations: [
+          { type: 'ACTIVE_SUBSCRIPTION', subject: 'sub-1' },
+          { type: 'NEGATIVE_TOKEN_BALANCE', subject: 'acct-1' }
+        ]
+      }
+    });
+    expect(deleteBlockedDescription(err, wording)).toBe(
+      'Downgrade your current subscription and switch to the Standard Plan before deleting this workspace. ' +
+        'Please purchase enough tokens to clear your outstanding token balance before deleting this workspace.'
+    );
+  });
+
+  it('returns the generic message when the error carries no blockers', () => {
+    const err = new ConnectError('blocked', Code.FailedPrecondition);
+    expect(deleteBlockedDescription(err, wording)).toBe(
+      GENERIC_DELETE_BLOCKED_MESSAGE
+    );
+  });
+});

--- a/web/sdk/client/utils/delete-blockers.ts
+++ b/web/sdk/client/utils/delete-blockers.ts
@@ -1,13 +1,9 @@
 import { ConnectError } from '@connectrpc/connect';
 
-// Words the instructions are built from. The host app decides what an
-// organization is called (for example "workspace") and what its base plan
-// is called (for example "Standard Plan"), so both come from the caller.
+// Words that come from the host app: what it calls an organization
+// and what it calls its base plan.
 export interface BlockerWording {
-  // The organization noun in lower case, as used mid-sentence.
   organizationLabel: string;
-  // The display title of the plan a paid subscription must be moved to.
-  // Falls back to a plain "standard plan" when the host app set none.
   basePlanTitle?: string;
 }
 
@@ -15,12 +11,7 @@ const DEFAULT_WORDING: BlockerWording = {
   organizationLabel: 'organization'
 };
 
-// The server reports why an organization cannot be deleted as a list of
-// blockers, each with a machine-readable type. These are the types the
-// server knows today, mapped to one full sentence the user can act on.
-// The wording must stay in line with the server behavior: a paid
-// subscription must be downgraded, unpaid invoices must be paid, and a
-// token debt is cleared by buying tokens.
+// One sentence per blocker type the server can return.
 const BLOCKER_INSTRUCTIONS: Record<
   string,
   (count: number, wording: BlockerWording) => string
@@ -37,15 +28,11 @@ const BLOCKER_INSTRUCTIONS: Record<
     `Please purchase enough tokens to clear your outstanding token balance before deleting this ${organizationLabel}.`
 };
 
-// Shown when the server reports a blocker kind this version does not know,
-// or when the error could not be read at all.
+// Used for blocker types this version does not know.
 export const GENERIC_DELETE_BLOCKED_MESSAGE =
   'Something is blocking the delete right now. Please try again later or contact support.';
 
-// instructionLines turns a list of blockers into one sentence per kind of
-// blocker. Blockers of the same kind are counted so the sentence can say
-// "your 2 outstanding invoices". A kind without a known instruction becomes
-// the generic message, once.
+// Returns one sentence per blocker type. Same-type blockers are counted.
 export function instructionLines(
   blockers: { type: string }[],
   wording: BlockerWording = DEFAULT_WORDING
@@ -70,12 +57,10 @@ export function instructionLines(
   return lines;
 }
 
-// deleteBlockedDescription reads the blockers out of a failed_precondition
-// error from DeleteOrganization and returns the instructions as one string.
-// The server attaches them as a google.rpc.PreconditionFailure detail; over
-// the Connect JSON protocol that detail arrives with a ready-made JSON copy
-// in its debug field. When the error carries nothing readable, the generic
-// message is returned, so the raw server text is never shown.
+// Reads the blockers from a failed_precondition error and returns the
+// sentences as one string. The server sends them as a
+// google.rpc.PreconditionFailure detail, which Connect exposes in the
+// detail's debug field.
 export function deleteBlockedDescription(
   err: ConnectError,
   wording: BlockerWording = DEFAULT_WORDING

--- a/web/sdk/client/utils/delete-blockers.ts
+++ b/web/sdk/client/utils/delete-blockers.ts
@@ -1,20 +1,40 @@
 import { ConnectError } from '@connectrpc/connect';
 
+// Words the instructions are built from. The host app decides what an
+// organization is called (for example "workspace") and what its base plan
+// is called (for example "Standard Plan"), so both come from the caller.
+export interface BlockerWording {
+  // The organization noun in lower case, as used mid-sentence.
+  organizationLabel: string;
+  // The display title of the plan a paid subscription must be moved to.
+  // Falls back to a plain "standard plan" when the host app set none.
+  basePlanTitle?: string;
+}
+
+const DEFAULT_WORDING: BlockerWording = {
+  organizationLabel: 'organization'
+};
+
 // The server reports why an organization cannot be deleted as a list of
 // blockers, each with a machine-readable type. These are the types the
-// server knows today, mapped to a short instruction the user can act on.
+// server knows today, mapped to one full sentence the user can act on.
 // The wording must stay in line with the server behavior: a paid
 // subscription must be downgraded, unpaid invoices must be paid, and a
-// token debt is settled through support.
-const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
-  ACTIVE_SUBSCRIPTION: () =>
-    'Please downgrade the subscription to the standard plan',
-  UNPAID_INVOICE: count =>
+// token debt is cleared by buying tokens.
+const BLOCKER_INSTRUCTIONS: Record<
+  string,
+  (count: number, wording: BlockerWording) => string
+> = {
+  ACTIVE_SUBSCRIPTION: (_, { organizationLabel, basePlanTitle }) =>
+    `Downgrade your current subscription and switch to the ${
+      basePlanTitle || 'standard plan'
+    } before deleting this ${organizationLabel}.`,
+  UNPAID_INVOICE: (count, { organizationLabel }) =>
     count > 1
-      ? `Please pay the ${count} open invoices from the billing page`
-      : 'Please pay the open invoice from the billing page',
-  NEGATIVE_TOKEN_BALANCE: () =>
-    'Your token balance is negative. Please add tokens from the Tokens page to bring it back up, or pay the invoice when it arrives, and then you can delete'
+      ? `Please pay your ${count} outstanding invoices before deleting this ${organizationLabel}.`
+      : `Please pay your outstanding invoice before deleting this ${organizationLabel}.`,
+  NEGATIVE_TOKEN_BALANCE: (_, { organizationLabel }) =>
+    `Please purchase enough tokens to clear your outstanding token balance before deleting this ${organizationLabel}.`
 };
 
 // Shown when the server reports a blocker kind this version does not know,
@@ -22,11 +42,14 @@ const BLOCKER_INSTRUCTIONS: Record<string, (count: number) => string> = {
 export const GENERIC_DELETE_BLOCKED_MESSAGE =
   'Something is blocking the delete right now. Please try again later or contact support.';
 
-// instructionLines turns a list of blockers into one instruction per kind
-// of blocker. Blockers of the same kind are counted so the instruction can
-// say "the 2 open invoices". A kind without a known instruction becomes the
-// generic message, once.
-export function instructionLines(blockers: { type: string }[]): string[] {
+// instructionLines turns a list of blockers into one sentence per kind of
+// blocker. Blockers of the same kind are counted so the sentence can say
+// "your 2 outstanding invoices". A kind without a known instruction becomes
+// the generic message, once.
+export function instructionLines(
+  blockers: { type: string }[],
+  wording: BlockerWording = DEFAULT_WORDING
+): string[] {
   const counts = new Map<string, number>();
   for (const blocker of blockers) {
     counts.set(blocker.type, (counts.get(blocker.type) ?? 0) + 1);
@@ -36,7 +59,7 @@ export function instructionLines(blockers: { type: string }[]): string[] {
   for (const [type, count] of counts) {
     const instruction = BLOCKER_INSTRUCTIONS[type];
     if (instruction) {
-      lines.push(instruction(count));
+      lines.push(instruction(count, wording));
     } else {
       hasUnknown = true;
     }
@@ -53,7 +76,10 @@ export function instructionLines(blockers: { type: string }[]): string[] {
 // the Connect JSON protocol that detail arrives with a ready-made JSON copy
 // in its debug field. When the error carries nothing readable, the generic
 // message is returned, so the raw server text is never shown.
-export function deleteBlockedDescription(err: ConnectError): string {
+export function deleteBlockedDescription(
+  err: ConnectError,
+  wording: BlockerWording = DEFAULT_WORDING
+): string {
   for (const detail of err.details) {
     if (!('type' in detail) || detail.type !== 'google.rpc.PreconditionFailure') {
       continue;
@@ -73,9 +99,9 @@ export function deleteBlockedDescription(err: ConnectError): string {
           violation !== null &&
           typeof (violation as { type?: unknown }).type === 'string'
       );
-    const lines = instructionLines(blockers);
+    const lines = instructionLines(blockers, wording);
     if (lines.length > 0) {
-      return lines.join('. ');
+      return lines.join(' ');
     }
   }
   return GENERIC_DELETE_BLOCKED_MESSAGE;

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -42,7 +42,7 @@ export const DeleteOrganizationDialog = ({
   onDeleteSuccess
 }: DeleteOrganizationDialogProps) => {
   const t = useTerminology();
-  const { activeOrganization: organization } = useFrontier();
+  const { activeOrganization: organization, basePlan } = useFrontier();
   const orgLabel = t.organization({ case: 'capital' });
   const orgLabelLower = t.organization({ case: 'lower' });
   const [isAcknowledged, setIsAcknowledged] = useState(false);
@@ -91,7 +91,15 @@ export const DeleteOrganizationDialog = ({
         PermissionDenied: () => toastManager.add({ title: "You don't have permission to perform this action", type: 'error' }),
         // the server names what blocks the delete; show the matching
         // instructions instead of the raw server text
-        FailedPrecondition: (err) => toastManager.add({ title: `Cannot delete this ${orgLabelLower} yet`, description: deleteBlockedDescription(err), type: 'error' }),
+        FailedPrecondition: (err) =>
+          toastManager.add({
+            title: `Cannot delete this ${orgLabelLower} yet`,
+            description: deleteBlockedDescription(err, {
+              organizationLabel: orgLabelLower,
+              basePlanTitle: basePlan?.title
+            }),
+            type: 'error'
+          }),
         NotFound: () => toastManager.add({ title: 'Not found', description: `This ${orgLabelLower} no longer exists.`, type: 'error' }),
         Default: () => toastManager.add({ title: 'Something went wrong', description: 'Please try again later or contact support.', type: 'error' }),
       });

--- a/web/sdk/client/views/general/components/delete-organization-dialog.tsx
+++ b/web/sdk/client/views/general/components/delete-organization-dialog.tsx
@@ -89,8 +89,6 @@ export const DeleteOrganizationDialog = ({
     } catch (error) {
       handleConnectError(error, {
         PermissionDenied: () => toastManager.add({ title: "You don't have permission to perform this action", type: 'error' }),
-        // the server names what blocks the delete; show the matching
-        // instructions instead of the raw server text
         FailedPrecondition: (err) =>
           toastManager.add({
             title: `Cannot delete this ${orgLabelLower} yet`,

--- a/web/sdk/client/views/general/general-view.tsx
+++ b/web/sdk/client/views/general/general-view.tsx
@@ -60,7 +60,8 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
   const {
     activeOrganization: organization,
     isActiveOrganizationLoading,
-    setActiveOrganization
+    setActiveOrganization,
+    basePlan
   } = useFrontier();
   const queryClient = useQueryClient();
   const transport = useTransport();
@@ -116,8 +117,12 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
   );
   const isDeleteBlocked = !!deleteCheck && !deleteCheck.canDelete;
   const blockerLines = useMemo(
-    () => instructionLines(deleteCheck?.blockers ?? []),
-    [deleteCheck]
+    () =>
+      instructionLines(deleteCheck?.blockers ?? [], {
+        organizationLabel: t.organization({ case: 'lower' }),
+        basePlanTitle: basePlan?.title
+      }),
+    [deleteCheck, t, basePlan]
   );
 
   // Update organization form
@@ -326,7 +331,7 @@ export function GeneralView({ onDeleteSuccess, urlPrefix }: GeneralViewProps = {
                     <Tooltip.Content>
                       <Flex direction="column" gap={2}>
                         {blockerLines.map(line => (
-                          <span key={line}>{line}</span>
+                          <Text key={line}>{line}</Text>
                         ))}
                       </Flex>
                     </Tooltip.Content>


### PR DESCRIPTION
Rewords the messages shown when an organization cannot be deleted, so each blocker is one full sentence:

- `Downgrade your current subscription and switch to the Standard Plan before deleting this workspace.`
- `Please pay your outstanding invoice before deleting this workspace.`
- `Please purchase enough tokens to clear your outstanding token balance before deleting this workspace.`

The organization noun and plan name come from the host app's terminology and `billing.basePlan.title`. Adds a jest test for the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
