### PR TITLE
feat(sdk): show a consent tooltip and add a disableIntent prop

### DIFF
--- a/web/sdk/client/components/auth-oidc-button/auth-oidc-button.tsx
+++ b/web/sdk/client/components/auth-oidc-button/auth-oidc-button.tsx
@@ -2,6 +2,7 @@ import { Button } from '@raystack/apsara';
 import { ComponentProps } from 'react';
 import GoogleLogo from '~/client/assets/logos/google-logo.svg';
 import { capitalize } from '~/utils';
+import { DisabledTooltip } from '../disabled-tooltip';
 import styles from './auth-oidc-button.module.css';
 
 const oidcLogoMap = new Map([['google', GoogleLogo]]);
@@ -11,32 +12,36 @@ export type AuthOIDCButtonProps = Omit<
   'variant' | 'color' | 'className' | 'leadingIcon'
 > & {
   provider: string;
+  disabledMessage?: string;
 };
 
 export const AuthOIDCButton = ({
   onClick,
   provider,
   disabled,
+  disabledMessage,
   children = `Continue with ${capitalize(provider)}`,
   ...props
 }: AuthOIDCButtonProps) => (
-  <Button
-    variant="outline"
-    color="neutral"
-    className={styles.button}
-    onClick={onClick}
-    disabled={disabled}
-    data-test-id="frontier-sdk-oidc-logo-btn"
-    {...props}
-    leadingIcon={
-      oidcLogoMap.has(provider) ? (
-        <img
-          src={oidcLogoMap.get(provider) as unknown as string}
-          alt={provider + '-logo'}
-        />
-      ) : null
-    }
-  >
-    {children}
-  </Button>
+  <DisabledTooltip disabled={disabled} message={disabledMessage}>
+    <Button
+      variant="outline"
+      color="neutral"
+      className={styles.button}
+      onClick={onClick}
+      disabled={disabled}
+      data-test-id="frontier-sdk-oidc-logo-btn"
+      {...props}
+      leadingIcon={
+        oidcLogoMap.has(provider) ? (
+          <img
+            src={oidcLogoMap.get(provider) as unknown as string}
+            alt={provider + '-logo'}
+          />
+        ) : null
+      }
+    >
+      {children}
+    </Button>
+  </DisabledTooltip>
 );

--- a/web/sdk/client/components/disabled-tooltip/disabled-tooltip.module.css
+++ b/web/sdk/client/components/disabled-tooltip/disabled-tooltip.module.css
@@ -1,0 +1,4 @@
+.trigger {
+  display: flex;
+  width: 100%;
+}

--- a/web/sdk/client/components/disabled-tooltip/disabled-tooltip.tsx
+++ b/web/sdk/client/components/disabled-tooltip/disabled-tooltip.tsx
@@ -15,19 +15,21 @@ export const DisabledTooltip = ({
 }: DisabledTooltipProps) => {
   const active = disabled && !!message;
 
+  if (!active) return children;
+
   return (
     <Tooltip>
-      <Tooltip.Trigger
-        disabled={!active}
-        render={<span className={styles.trigger} />}
-      >
+      <Tooltip.Trigger render={<span className={styles.trigger} />}>
         {children}
       </Tooltip.Trigger>
-      {active && (
-        <Tooltip.Content side="top" align="end">
-          {message}
-        </Tooltip.Content>
-      )}
+      <Tooltip.Content
+        side="right"
+        align="start"
+        sideOffset={-40}
+        alignOffset={-10}
+      >
+        {message}
+      </Tooltip.Content>
     </Tooltip>
   );
 };

--- a/web/sdk/client/components/disabled-tooltip/disabled-tooltip.tsx
+++ b/web/sdk/client/components/disabled-tooltip/disabled-tooltip.tsx
@@ -1,0 +1,33 @@
+import { Tooltip } from '@raystack/apsara';
+import { ReactNode } from 'react';
+import styles from './disabled-tooltip.module.css';
+
+export type DisabledTooltipProps = {
+  disabled?: boolean;
+  message?: string;
+  children: ReactNode;
+};
+
+export const DisabledTooltip = ({
+  disabled = false,
+  message,
+  children
+}: DisabledTooltipProps) => {
+  const active = disabled && !!message;
+
+  return (
+    <Tooltip>
+      <Tooltip.Trigger
+        disabled={!active}
+        render={<span className={styles.trigger} />}
+      >
+        {children}
+      </Tooltip.Trigger>
+      {active && (
+        <Tooltip.Content side="top" align="end">
+          {message}
+        </Tooltip.Content>
+      )}
+    </Tooltip>
+  );
+};

--- a/web/sdk/client/components/disabled-tooltip/index.ts
+++ b/web/sdk/client/components/disabled-tooltip/index.ts
@@ -1,0 +1,2 @@
+export { DisabledTooltip } from './disabled-tooltip';
+export type { DisabledTooltipProps } from './disabled-tooltip';

--- a/web/sdk/client/views/auth/magic-link/magic-link-view.tsx
+++ b/web/sdk/client/views/auth/magic-link/magic-link-view.tsx
@@ -132,7 +132,6 @@ export const MagicLinkView = ({
           {...register('email')}
           size="large"
           placeholder="name@example.com"
-          disabled={disabled}
         />
       </Field>
       <DisabledTooltip disabled={disabled} message={disabledMessage}>

--- a/web/sdk/client/views/auth/magic-link/magic-link-view.tsx
+++ b/web/sdk/client/views/auth/magic-link/magic-link-view.tsx
@@ -12,6 +12,7 @@ import {
   type AuthContainerProps
 } from '~/client/components/auth-container';
 import { AuthHeader } from '~/client/components/auth-header';
+import { DisabledTooltip } from '~/client/components/disabled-tooltip';
 import { describeAuthError } from '~/client/utils/auth-error';
 import { MAIL_OTP_STRATEGY } from '~/client/utils/constants';
 import styles from './magic-link-view.module.css';
@@ -25,6 +26,7 @@ export type MagicLinkViewProps = ComponentPropsWithRef<'div'> &
     intent?: FlowIntent;
     acceptedDocumentIds?: string[];
     disabled?: boolean;
+    disabledMessage?: string;
     onActivate?: () => void;
   };
 
@@ -51,6 +53,7 @@ export const MagicLinkView = ({
   intent = FlowIntent.UNSPECIFIED,
   acceptedDocumentIds,
   disabled = false,
+  disabledMessage,
   onActivate,
   ...props
 }: MagicLinkViewProps) => {
@@ -102,19 +105,21 @@ export const MagicLinkView = ({
   const email = watch('email', '');
 
   const formContent = !visible ? (
-    <Button
-      variant="outline"
-      color="neutral"
-      className={styles.button}
-      onClick={() => {
-        setVisible(true);
-        onActivate?.();
-      }}
-      disabled={disabled}
-      data-test-id="frontier-sdk-mail-otp-login-btn"
-    >
-      Continue with Email
-    </Button>
+    <DisabledTooltip disabled={disabled} message={disabledMessage}>
+      <Button
+        variant="outline"
+        color="neutral"
+        className={styles.button}
+        onClick={() => {
+          setVisible(true);
+          onActivate?.();
+        }}
+        disabled={disabled}
+        data-test-id="frontier-sdk-mail-otp-login-btn"
+      >
+        Continue with Email
+      </Button>
+    </DisabledTooltip>
   ) : (
     <form
       noValidate
@@ -130,16 +135,18 @@ export const MagicLinkView = ({
           disabled={disabled}
         />
       </Field>
-      <Button
-        className={styles.button}
-        disabled={!email || disabled}
-        type="submit"
-        loading={isPending}
-        loaderText="Loading..."
-        data-test-id="frontier-sdk-mail-otp-login-submit-btn"
-      >
-        Continue with Email
-      </Button>
+      <DisabledTooltip disabled={disabled} message={disabledMessage}>
+        <Button
+          className={styles.button}
+          disabled={!email || disabled}
+          type="submit"
+          loading={isPending}
+          loaderText="Loading..."
+          data-test-id="frontier-sdk-mail-otp-login-submit-btn"
+        >
+          Continue with Email
+        </Button>
+      </DisabledTooltip>
     </form>
   );
 

--- a/web/sdk/client/views/auth/sign-in/sign-in-view.tsx
+++ b/web/sdk/client/views/auth/sign-in/sign-in-view.tsx
@@ -24,6 +24,8 @@ export type SignInViewProps = ComponentPropsWithRef<'div'> &
     title?: string;
     excludes?: string[];
     footer?: boolean;
+    /** Send no flow intent, so the server falls back to create-or-get. */
+    disableIntent?: boolean;
     error?: AuthRejection;
   };
 
@@ -32,6 +34,7 @@ export const SignInView = ({
   title = 'Login to Raystack',
   excludes = [],
   footer = true,
+  disableIntent = false,
   error,
   ...props
 }: SignInViewProps) => {
@@ -52,6 +55,8 @@ export const SignInView = ({
     FrontierServiceQueries.authenticate
   );
 
+  const intent = disableIntent ? FlowIntent.UNSPECIFIED : FlowIntent.LOGIN;
+
   const clearError = useCallback(() => setAuthError(null), []);
 
   const clickHandler = useCallback(
@@ -61,7 +66,7 @@ export const SignInView = ({
         const response = await authenticate({
           strategyName: name,
           callbackUrl: config.callbackUrl,
-          flowIntent: FlowIntent.LOGIN
+          flowIntent: intent
         });
         if (response.endpoint) {
           window.location.href = response.endpoint;
@@ -73,7 +78,7 @@ export const SignInView = ({
         });
       }
     },
-    [authenticate, config, clearError]
+    [authenticate, config, intent, clearError]
   );
 
   const isUnknownError =
@@ -91,7 +96,7 @@ export const SignInView = ({
             <MagicLinkView
               key={s.name}
               inline
-              intent={FlowIntent.LOGIN}
+              intent={intent}
               onActivate={clearError}
             />
           ) : (

--- a/web/sdk/client/views/auth/sign-up/sign-up-view.tsx
+++ b/web/sdk/client/views/auth/sign-up/sign-up-view.tsx
@@ -35,6 +35,8 @@ export type SignUpViewProps = ComponentPropsWithRef<'div'> &
     title?: string;
     excludes?: string[];
     consentLabel?: ConsentLabel;
+    /** Send no flow intent, so the server falls back to create-or-get. */
+    disableIntent?: boolean;
     error?: AuthRejection;
   };
 
@@ -43,6 +45,7 @@ export const SignUpView = ({
   title = 'Create your account',
   excludes = [],
   consentLabel,
+  disableIntent = false,
   error,
   ...props
 }: SignUpViewProps) => {
@@ -85,6 +88,8 @@ export const SignUpView = ({
   const blocked =
     consentPending || consentFailed || (documents.length > 0 && !consented);
 
+  const intent = disableIntent ? FlowIntent.UNSPECIFIED : FlowIntent.SIGNUP;
+
   const clearError = useCallback(() => setAuthError(null), []);
 
   const clickHandler = useCallback(
@@ -94,7 +99,7 @@ export const SignUpView = ({
         const response = await authenticate({
           strategyName: name,
           callbackUrl: config.callbackUrl,
-          flowIntent: FlowIntent.SIGNUP,
+          flowIntent: intent,
           acceptedDocumentIds
         });
         if (response.endpoint) {
@@ -107,7 +112,7 @@ export const SignUpView = ({
         });
       }
     },
-    [authenticate, config, acceptedDocumentIds, clearError]
+    [authenticate, config, intent, acceptedDocumentIds, clearError]
   );
 
   const isUnknownError =
@@ -129,7 +134,7 @@ export const SignUpView = ({
             <MagicLinkView
               key={s.name}
               inline
-              intent={FlowIntent.SIGNUP}
+              intent={intent}
               acceptedDocumentIds={acceptedDocumentIds}
               disabled={blocked}
               disabledMessage={CONSENT_REQUIRED_TOOLTIP}

--- a/web/sdk/client/views/auth/sign-up/sign-up-view.tsx
+++ b/web/sdk/client/views/auth/sign-up/sign-up-view.tsx
@@ -27,6 +27,7 @@ import styles from './sign-up-view.module.css';
 
 const CONSENT_UNAVAILABLE_MESSAGE =
   'The documents required to sign up could not be loaded. Please refresh the page.';
+const CONSENT_REQUIRED_TOOLTIP = 'You must agree to continue';
 
 export type SignUpViewProps = ComponentPropsWithRef<'div'> &
   AuthContainerProps & {
@@ -131,6 +132,7 @@ export const SignUpView = ({
               intent={FlowIntent.SIGNUP}
               acceptedDocumentIds={acceptedDocumentIds}
               disabled={blocked}
+              disabledMessage={CONSENT_REQUIRED_TOOLTIP}
               onActivate={clearError}
             />
           ) : (
@@ -144,6 +146,7 @@ export const SignUpView = ({
                 onClick={() => clickHandler(s.name)}
                 provider={s.name}
                 disabled={blocked}
+                disabledMessage={CONSENT_REQUIRED_TOOLTIP}
                 data-test-id="frontier-sdk-signup-page-oidc-btn"
               />
             </Field>

--- a/web/sdk/client/views/auth/sign-up/sign-up-view.tsx
+++ b/web/sdk/client/views/auth/sign-up/sign-up-view.tsx
@@ -37,6 +37,8 @@ export type SignUpViewProps = ComponentPropsWithRef<'div'> &
     consentLabel?: ConsentLabel;
     /** Send no flow intent, so the server falls back to create-or-get. */
     disableIntent?: boolean;
+    /** Tooltip shown on the disabled sign-up buttons until consent is given. */
+    disabledContentMessage?: string;
     error?: AuthRejection;
   };
 
@@ -46,6 +48,7 @@ export const SignUpView = ({
   excludes = [],
   consentLabel,
   disableIntent = false,
+  disabledContentMessage = CONSENT_REQUIRED_TOOLTIP,
   error,
   ...props
 }: SignUpViewProps) => {
@@ -137,7 +140,7 @@ export const SignUpView = ({
               intent={intent}
               acceptedDocumentIds={acceptedDocumentIds}
               disabled={blocked}
-              disabledMessage={CONSENT_REQUIRED_TOOLTIP}
+              disabledMessage={disabledContentMessage}
               onActivate={clearError}
             />
           ) : (
@@ -151,7 +154,7 @@ export const SignUpView = ({
                 onClick={() => clickHandler(s.name)}
                 provider={s.name}
                 disabled={blocked}
-                disabledMessage={CONSENT_REQUIRED_TOOLTIP}
+                disabledMessage={disabledContentMessage}
                 data-test-id="frontier-sdk-signup-page-oidc-btn"
               />
             </Field>


### PR DESCRIPTION
## Summary

- While the consent checkbox is unchecked, hovering a disabled OIDC button or either "Continue with Email" button in the sign-up view shows a "You must agree to continue" tooltip, via a new shared `DisabledTooltip` component.
- The tooltip wrapper returns its child untouched unless the control is disabled with a message, and anchors at the top-end of the button.
- The magic-link email input stays enabled while consent is pending, so an address can be typed before agreeing; only the submit button is blocked.
- `SignInView` and `SignUpView` gain a `disableIntent` prop. When set, they send no flow intent so the server keeps its create-or-get behaviour instead of gating on account existence, the opt-out described in RFC 0002. Consent handling is unchanged since it is enforced under every intent.
- `SignUpView` gains a `disabledContentMessage` prop that overrides the tooltip copy on the disabled sign-up buttons.