### PR TITLE
fix(sdk): drop the invoice count from the delete blocker message

### DIFF
--- a/web/sdk/client/utils/delete-blockers.test.ts
+++ b/web/sdk/client/utils/delete-blockers.test.ts
@@ -24,13 +24,13 @@ describe('instructionLines', () => {
     ]);
   });
 
-  it('counts blockers of the same kind', () => {
+  it('uses the plural when there is more than one invoice', () => {
     const lines = instructionLines(
       [{ type: 'UNPAID_INVOICE' }, { type: 'UNPAID_INVOICE' }],
       wording
     );
     expect(lines).toEqual([
-      'Please pay your 2 outstanding invoices before deleting this workspace.'
+      'Please pay your outstanding invoices before deleting this workspace.'
     ]);
   });
 

--- a/web/sdk/client/utils/delete-blockers.ts
+++ b/web/sdk/client/utils/delete-blockers.ts
@@ -22,7 +22,7 @@ const BLOCKER_INSTRUCTIONS: Record<
     } before deleting this ${organizationLabel}.`,
   UNPAID_INVOICE: (count, { organizationLabel }) =>
     count > 1
-      ? `Please pay your ${count} outstanding invoices before deleting this ${organizationLabel}.`
+      ? `Please pay your outstanding invoices before deleting this ${organizationLabel}.`
       : `Please pay your outstanding invoice before deleting this ${organizationLabel}.`,
   NEGATIVE_TOKEN_BALANCE: (_, { organizationLabel }) =>
     `Please purchase enough tokens to clear your outstanding token balance before deleting this ${organizationLabel}.`
@@ -32,7 +32,7 @@ const BLOCKER_INSTRUCTIONS: Record<
 export const GENERIC_DELETE_BLOCKED_MESSAGE =
   'Something is blocking the delete right now. Please try again later or contact support.';
 
-// Returns one sentence per blocker type. Same-type blockers are counted.
+// Returns one sentence per blocker type.
 export function instructionLines(
   blockers: { type: string }[],
   wording: BlockerWording = DEFAULT_WORDING


### PR DESCRIPTION
When more than one invoice is unpaid, the delete blocker message now reads:

`Please pay your outstanding invoices before deleting this workspace.`

It used to include the number, as in "your 3 outstanding invoices". The single-invoice sentence is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
